### PR TITLE
Add DumpOptions for DumpDatabase()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2025-08-24
+
+### Added
+- **Enhanced security compliance**: Added gosec security linter to the build process
+  - Comprehensive security analysis for potential vulnerabilities
+  - File permission restrictions (0600 for files, 0750 for directories)
+  - Protection against SQL injection and file inclusion vulnerabilities
+- **Duplicate validation system**: Implemented robust duplicate detection mechanisms
+  - **Table name validation**: Prevents multiple files from creating tables with identical names
+  - **Column name validation**: Detects and rejects files with duplicate column headers
+  - **Cross-directory validation**: Ensures uniqueness across multiple input paths
+  - **Compression preference logic**: Automatically prefers uncompressed files over compressed versions
+- **Comprehensive test coverage expansion**: Significantly increased driver package coverage
+  - Driver package coverage increased from 73.5% to 83.9%
+  - Added extensive transaction testing, connection management, and error handling tests
+  - Enhanced export functionality testing and helper method validation
+  - Overall project coverage maintained at 80.4%
+
+### Changed
+- **Major driver.go refactoring**: Complete architectural reorganization for improved maintainability
+  - **Method decomposition**: Split complex methods into focused, single-responsibility functions
+    - `loadFileDirectly` → `loadSinglePath`, `validatePath`
+    - `loadSingleFile` → `parseFileToTable`, `loadTableIntoDatabase`
+    - `collectDirectoryFiles` → `readDirectoryEntries`, `shouldSkipFile`, `handleTableNameConflict`
+    - `loadMultiplePaths` → `collectAllFiles`, `collectFilesFromPath`, `collectSingleFile`
+  - **Database operations unification**: Centralized query execution and statement handling
+    - `executeQuery`: Unified interface for all database queries
+    - `executeStatement`: Consistent statement execution with proper context support
+    - `scanStringValues`: Standardized database response processing
+  - **CSV export enhancement**: Modular CSV generation pipeline
+    - `writeCSVFile`, `writeDataRows`, `convertRowToCSVRecord`: Clean separation of concerns
+    - Improved error handling and resource management
+  - **Enhanced documentation**: Comprehensive package and method documentation
+    - Detailed usage examples and feature descriptions
+    - Clear API documentation for all public interfaces
+- **Improved error handling consistency**: Standardized error formatting and path validation
+- **Cross-platform compatibility improvements**: Enhanced Windows/Unix path handling compatibility
+
+### Fixed
+- **Security vulnerabilities**: Addressed all gosec security findings
+  - **G104 (Unhandled Errors)**: Proper error handling in all file and database operations
+  - **G201/G202 (SQL Injection)**: Secure SQL query construction with parameterization
+  - **G301/G302/G306 (File Permissions)**: Restricted file and directory permissions for security
+  - **G304 (File Inclusion)**: Safe file path handling with proper validation
+- **Cross-platform path issues**: Fixed Windows filepath separator compatibility
+  - Normalized path comparisons using `filepath.Clean()` for consistent behavior
+  - Unified output path formatting in examples and tests
+  - Resolved GitHub Actions Windows test failures
+- **Code quality improvements**: 
+  - All linting issues resolved with stricter gosec configuration
+  - Proper code formatting with gofmt
+  - Performance optimizations (replaced `fmt.Sprintf` with `strconv.Itoa` where appropriate)
+
+### Technical Details
+- **Security hardening**: Comprehensive security audit and remediation
+- **Architecture improvement**: Clean code principles applied throughout driver implementation
+- **Testing enhancement**: Robust test suite covering edge cases and error scenarios
+- **Documentation quality**: Improved code documentation and usage examples
+- **Platform compatibility**: Verified compatibility across Linux, macOS, and Windows environments
+
 ## [0.0.2] - 2025-08-24
 
 ### Added
@@ -62,6 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.0.2...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/nao1215/filesql/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/nao1215/filesql/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/nao1215/filesql/releases/tag/v0.0.1

--- a/domain/model/common.go
+++ b/domain/model/common.go
@@ -47,3 +47,130 @@ func (r Record) Equal(r2 Record) bool {
 	}
 	return true
 }
+
+// OutputFormat represents the output file format
+type OutputFormat int
+
+const (
+	// OutputFormatCSV represents CSV output format
+	OutputFormatCSV OutputFormat = iota
+	// OutputFormatTSV represents TSV output format
+	OutputFormatTSV
+	// OutputFormatLTSV represents LTSV output format
+	OutputFormatLTSV
+)
+
+// String returns the string representation of OutputFormat
+func (f OutputFormat) String() string {
+	switch f {
+	case OutputFormatCSV:
+		return "csv"
+	case OutputFormatTSV:
+		return "tsv"
+	case OutputFormatLTSV:
+		return "ltsv"
+	default:
+		return "csv"
+	}
+}
+
+// Extension returns the file extension for the format
+func (f OutputFormat) Extension() string {
+	switch f {
+	case OutputFormatCSV:
+		return ".csv"
+	case OutputFormatTSV:
+		return ".tsv"
+	case OutputFormatLTSV:
+		return ".ltsv"
+	default:
+		return ".csv"
+	}
+}
+
+// CompressionType represents the compression type
+type CompressionType int
+
+const (
+	// CompressionNone represents no compression
+	CompressionNone CompressionType = iota
+	// CompressionGZ represents gzip compression
+	CompressionGZ
+	// CompressionBZ2 represents bzip2 compression
+	CompressionBZ2
+	// CompressionXZ represents xz compression
+	CompressionXZ
+	// CompressionZSTD represents zstd compression
+	CompressionZSTD
+)
+
+// String returns the string representation of CompressionType
+func (c CompressionType) String() string {
+	switch c {
+	case CompressionNone:
+		return "none"
+	case CompressionGZ:
+		return "gz"
+	case CompressionBZ2:
+		return "bz2"
+	case CompressionXZ:
+		return "xz"
+	case CompressionZSTD:
+		return "zstd"
+	default:
+		return "none"
+	}
+}
+
+// Extension returns the file extension for the compression type
+func (c CompressionType) Extension() string {
+	switch c {
+	case CompressionNone:
+		return ""
+	case CompressionGZ:
+		return ".gz"
+	case CompressionBZ2:
+		return ".bz2"
+	case CompressionXZ:
+		return ".xz"
+	case CompressionZSTD:
+		return ".zst"
+	default:
+		return ""
+	}
+}
+
+// DumpOptions represents options for dumping database
+type DumpOptions struct {
+	// Format specifies the output file format
+	Format OutputFormat
+	// Compression specifies the compression type
+	Compression CompressionType
+}
+
+// NewDumpOptions creates new DumpOptions with default values (CSV format, no compression)
+func NewDumpOptions() DumpOptions {
+	return DumpOptions{
+		Format:      OutputFormatCSV,
+		Compression: CompressionNone,
+	}
+}
+
+// WithFormat sets the output format
+func (o DumpOptions) WithFormat(format OutputFormat) DumpOptions {
+	o.Format = format
+	return o
+}
+
+// WithCompression sets the compression type
+func (o DumpOptions) WithCompression(compression CompressionType) DumpOptions {
+	o.Compression = compression
+	return o
+}
+
+// FileExtension returns the complete file extension including compression
+func (o DumpOptions) FileExtension() string {
+	baseExt := o.Format.Extension()
+	compExt := o.Compression.Extension()
+	return baseExt + compExt
+}

--- a/domain/model/common_test.go
+++ b/domain/model/common_test.go
@@ -151,3 +151,317 @@ func TestRecord_Equal(t *testing.T) {
 		})
 	}
 }
+
+func TestOutputFormat_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		format OutputFormat
+		want   string
+	}{
+		{
+			name:   "CSV format",
+			format: OutputFormatCSV,
+			want:   "csv",
+		},
+		{
+			name:   "TSV format",
+			format: OutputFormatTSV,
+			want:   "tsv",
+		},
+		{
+			name:   "LTSV format",
+			format: OutputFormatLTSV,
+			want:   "ltsv",
+		},
+		{
+			name:   "Unknown format defaults to csv",
+			format: OutputFormat(999),
+			want:   "csv",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.format.String(); got != tt.want {
+				t.Errorf("OutputFormat.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOutputFormat_Extension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		format OutputFormat
+		want   string
+	}{
+		{
+			name:   "CSV extension",
+			format: OutputFormatCSV,
+			want:   ".csv",
+		},
+		{
+			name:   "TSV extension",
+			format: OutputFormatTSV,
+			want:   ".tsv",
+		},
+		{
+			name:   "LTSV extension",
+			format: OutputFormatLTSV,
+			want:   ".ltsv",
+		},
+		{
+			name:   "Unknown format defaults to csv",
+			format: OutputFormat(999),
+			want:   ".csv",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.format.Extension(); got != tt.want {
+				t.Errorf("OutputFormat.Extension() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompressionType_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		compression CompressionType
+		want        string
+	}{
+		{
+			name:        "No compression",
+			compression: CompressionNone,
+			want:        "none",
+		},
+		{
+			name:        "GZ compression",
+			compression: CompressionGZ,
+			want:        "gz",
+		},
+		{
+			name:        "BZ2 compression",
+			compression: CompressionBZ2,
+			want:        "bz2",
+		},
+		{
+			name:        "XZ compression",
+			compression: CompressionXZ,
+			want:        "xz",
+		},
+		{
+			name:        "ZSTD compression",
+			compression: CompressionZSTD,
+			want:        "zstd",
+		},
+		{
+			name:        "Unknown compression defaults to none",
+			compression: CompressionType(999),
+			want:        "none",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.compression.String(); got != tt.want {
+				t.Errorf("CompressionType.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompressionType_Extension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		compression CompressionType
+		want        string
+	}{
+		{
+			name:        "No compression",
+			compression: CompressionNone,
+			want:        "",
+		},
+		{
+			name:        "GZ compression",
+			compression: CompressionGZ,
+			want:        ".gz",
+		},
+		{
+			name:        "BZ2 compression",
+			compression: CompressionBZ2,
+			want:        ".bz2",
+		},
+		{
+			name:        "XZ compression",
+			compression: CompressionXZ,
+			want:        ".xz",
+		},
+		{
+			name:        "ZSTD compression",
+			compression: CompressionZSTD,
+			want:        ".zst",
+		},
+		{
+			name:        "Unknown compression defaults to empty",
+			compression: CompressionType(999),
+			want:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.compression.Extension(); got != tt.want {
+				t.Errorf("CompressionType.Extension() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewDumpOptions(t *testing.T) {
+	t.Parallel()
+
+	options := NewDumpOptions()
+
+	if options.Format != OutputFormatCSV {
+		t.Errorf("NewDumpOptions().Format = %v, want %v", options.Format, OutputFormatCSV)
+	}
+
+	if options.Compression != CompressionNone {
+		t.Errorf("NewDumpOptions().Compression = %v, want %v", options.Compression, CompressionNone)
+	}
+}
+
+func TestDumpOptions_WithFormat(t *testing.T) {
+	t.Parallel()
+
+	options := NewDumpOptions()
+	newOptions := options.WithFormat(OutputFormatTSV)
+
+	// Original options should not be modified
+	if options.Format != OutputFormatCSV {
+		t.Errorf("Original options modified: Format = %v, want %v", options.Format, OutputFormatCSV)
+	}
+
+	// New options should have the updated format
+	if newOptions.Format != OutputFormatTSV {
+		t.Errorf("WithFormat().Format = %v, want %v", newOptions.Format, OutputFormatTSV)
+	}
+
+	// Other fields should remain unchanged
+	if newOptions.Compression != CompressionNone {
+		t.Errorf("WithFormat().Compression = %v, want %v", newOptions.Compression, CompressionNone)
+	}
+}
+
+func TestDumpOptions_WithCompression(t *testing.T) {
+	t.Parallel()
+
+	options := NewDumpOptions()
+	newOptions := options.WithCompression(CompressionGZ)
+
+	// Original options should not be modified
+	if options.Compression != CompressionNone {
+		t.Errorf("Original options modified: Compression = %v, want %v", options.Compression, CompressionNone)
+	}
+
+	// New options should have the updated compression
+	if newOptions.Compression != CompressionGZ {
+		t.Errorf("WithCompression().Compression = %v, want %v", newOptions.Compression, CompressionGZ)
+	}
+
+	// Other fields should remain unchanged
+	if newOptions.Format != OutputFormatCSV {
+		t.Errorf("WithCompression().Format = %v, want %v", newOptions.Format, OutputFormatCSV)
+	}
+}
+
+func TestDumpOptions_FileExtension(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		format      OutputFormat
+		compression CompressionType
+		want        string
+	}{
+		{
+			name:        "CSV with no compression",
+			format:      OutputFormatCSV,
+			compression: CompressionNone,
+			want:        ".csv",
+		},
+		{
+			name:        "CSV with gzip compression",
+			format:      OutputFormatCSV,
+			compression: CompressionGZ,
+			want:        ".csv.gz",
+		},
+		{
+			name:        "TSV with bzip2 compression",
+			format:      OutputFormatTSV,
+			compression: CompressionBZ2,
+			want:        ".tsv.bz2",
+		},
+		{
+			name:        "LTSV with xz compression",
+			format:      OutputFormatLTSV,
+			compression: CompressionXZ,
+			want:        ".ltsv.xz",
+		},
+		{
+			name:        "TSV with zstd compression",
+			format:      OutputFormatTSV,
+			compression: CompressionZSTD,
+			want:        ".tsv.zst",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			options := DumpOptions{
+				Format:      tt.format,
+				Compression: tt.compression,
+			}
+			if got := options.FileExtension(); got != tt.want {
+				t.Errorf("DumpOptions.FileExtension() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDumpOptions_ChainedMethods(t *testing.T) {
+	t.Parallel()
+
+	options := NewDumpOptions().
+		WithFormat(OutputFormatLTSV).
+		WithCompression(CompressionZSTD)
+
+	if options.Format != OutputFormatLTSV {
+		t.Errorf("Chained WithFormat().Format = %v, want %v", options.Format, OutputFormatLTSV)
+	}
+
+	if options.Compression != CompressionZSTD {
+		t.Errorf("Chained WithCompression().Compression = %v, want %v", options.Compression, CompressionZSTD)
+	}
+
+	expectedExt := ".ltsv.zst"
+	if got := options.FileExtension(); got != expectedExt {
+		t.Errorf("Chained options FileExtension() = %v, want %v", got, expectedExt)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Export options: choose CSV/TSV/LTSV and compression (none, gzip, xz, zstd) with automatic file extensions; per-run DumpOptions supported in DumpDatabase and top-level aliases for easy use.

- **Changes**
  - Safer, consistent cross-platform output paths and sanitized table filenames; export API extended to accept options.

- **Bug Fixes**
  - Security hardening (safer queries, file handling), Windows path normalization, CI test stability.

- **Documentation / Tests**
  - Updated changelog, new examples and extensive unit/benchmark coverage for export/options and sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->