### PR TITLE
Fix formatting of project link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,8 +521,7 @@ Using filesql in your project? We'd love to hear about it! Please [open an issue
 | Project | Description |
 |---------|-------------|
 | [nao1215/sqly](https://github.com/nao1215/sqly) | Interactive shell for executing SQL queries against CSV, TSV, LTSV, JSON, and Excel files. Perfect for ad-hoc data analysis from the command line. |
-| [kanmu/gocon2025-ctf
-](https://github.com/kanmu/gocon2025-ctf) | Go Conference 2025 CTF repository (in japanese) |
+| [kanmu/gocon2025-ctf](https://github.com/kanmu/gocon2025-ctf) | Go Conference 2025 CTF repository (in japanese) |
 
 ## 🤝 Contributing
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed broken Markdown table entries in README.md by correcting improperly wrapped GitHub URL lines, restoring proper link formatting in two table rows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->