### PR TITLE
fix: keep int64-overflowing integers as TEXT to preserve exact value

### DIFF
--- a/column_overflow_test.go
+++ b/column_overflow_test.go
@@ -1,0 +1,89 @@
+package filesql
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsFloatRejectsInt64Overflow guards the core of nao1215/sqly#218: an
+// integer literal whose magnitude exceeds int64 must not be classified as a
+// float, because converting it to float64 loses precision and renders it in
+// scientific notation. Such values fall through to TEXT instead.
+func TestIsFloatRejectsInt64Overflow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"in-range integer is float-parseable", "123", true},
+		{"max int64 is float-parseable", "9223372036854775807", true},
+		{"overflow integer is not treated as float", "11040320260000000000", false},
+		{"huge integer is not treated as float", "99999999999999999999999999", false},
+		{"negative overflow integer is not treated as float", "-11040320260000000000", false},
+		{"decimal stays float", "3.14", true},
+		{"scientific notation literal stays float", "1.104032026e+19", true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isFloat(tt.value))
+		})
+	}
+}
+
+// TestClassifyValueInt64Overflow verifies that int64-overflowing integers are
+// classified as TEXT, while in-range integers and genuine floats keep their
+// numeric types.
+func TestClassifyValueInt64Overflow(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, columnTypeText, classifyValue("11040320260000000000"))
+	require.Equal(t, columnTypeText, classifyValue("-11040320260000000000"))
+	require.Equal(t, columnTypeInteger, classifyValue("9223372036854775807"))
+	require.Equal(t, columnTypeReal, classifyValue("1.104032026e+19"))
+}
+
+// TestInferColumnTypeInt64Overflow verifies that a column entirely made of
+// int64-overflowing integers is inferred as TEXT.
+func TestInferColumnTypeInt64Overflow(t *testing.T) {
+	t.Parallel()
+
+	got := inferColumnType([]string{
+		"11040320260000000000",
+		"11040320260000000001",
+		"11040320260000000002",
+	})
+	require.Equal(t, columnTypeText, got)
+}
+
+// TestOpenContextPreservesLargeIntegerExactly is the end-to-end regression test
+// for nao1215/sqly#218. A CSV value larger than math.MaxInt64 must round-trip
+// through the loaded database as its exact textual value, not a lossy
+// scientific-notation float.
+func TestOpenContextPreservesLargeIntegerExactly(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	csvPath := filepath.Join(dir, "bigint.csv")
+	content := "ctsn,pocode\n" +
+		"11040320260000000000,100031464478\n" +
+		"11040320260000000001,100031464478\n"
+	require.NoError(t, os.WriteFile(csvPath, []byte(content), 0600))
+
+	ctx := context.Background()
+	db, err := OpenContext(ctx, csvPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var got string
+	err = db.QueryRowContext(ctx, `SELECT ctsn FROM bigint ORDER BY ctsn LIMIT 1`).Scan(&got)
+	require.NoError(t, err)
+	require.Equal(t, "11040320260000000000", got)
+}

--- a/types.go
+++ b/types.go
@@ -639,8 +639,46 @@ func isFloat(value string) bool {
 		return false
 	}
 
+	// An integer-looking string (all digits with an optional sign) that does
+	// not fit in int64 must NOT be treated as a float. strconv.ParseFloat would
+	// succeed for such a value but silently lose precision and render it in
+	// scientific notation (e.g. "11040320260000000000" -> 1.104032026e+19).
+	// SQLite's INTEGER type also cannot hold values beyond int64, so the only
+	// lossless representation is TEXT. Returning false here lets classifyValue
+	// fall through to columnTypeText and preserve the exact digits.
+	if isIntegerLiteralOverflowingInt64(value) {
+		return false
+	}
+
 	_, err := strconv.ParseFloat(value, 64)
 	return err == nil
+}
+
+// isIntegerLiteralOverflowingInt64 reports whether value is an integer literal
+// (optional leading '+'/'-' followed solely by ASCII digits) whose magnitude
+// exceeds the range representable by int64. Such values can only be stored
+// losslessly as TEXT, since both SQLite INTEGER (int64) and float64 would lose
+// information.
+func isIntegerLiteralOverflowingInt64(value string) bool {
+	digits := value
+	if len(digits) > 0 && (digits[0] == '+' || digits[0] == '-') {
+		digits = digits[1:]
+	}
+	if len(digits) == 0 {
+		return false
+	}
+	for i := 0; i < len(digits); i++ {
+		if digits[i] < '0' || digits[i] > '9' {
+			// Contains a non-digit (decimal point, exponent, etc.), so it is
+			// not a plain integer literal and should be handled by ParseFloat.
+			return false
+		}
+	}
+
+	// It is a pure integer literal. If it fits in int64 it was already handled
+	// as an integer upstream; if ParseInt fails it overflows int64.
+	_, err := strconv.ParseInt(value, 10, 64)
+	return err != nil
 }
 
 // selectColumnType selects the best column type based on confidence analysis


### PR DESCRIPTION
## Summary

Integer strings larger than `math.MaxInt64` (e.g. `11040320260000000000`) fail `strconv.ParseInt`, so they were classified as REAL via `strconv.ParseFloat`, stored as float64, and rendered in scientific notation with precision loss.

`isFloat` now rejects integer literals that overflow int64 (via the new `isIntegerLiteralOverflowingInt64` helper) so such values fall through to TEXT, preserving the exact digits. SQLite INTEGER (int64) and float64 both cannot represent these values losslessly, so TEXT is the only correct storage.

## Tests

- Unit tests for `isFloat`, `classifyValue`, `inferColumnType` with overflow cases.
- End-to-end test loading a CSV via `OpenContext` and asserting the exact value round-trips (no scientific notation).
- `go test ./...` and `go vet ./...` pass.

Fixes nao1215/sqly#218.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of very large integer values that exceed standard integer limits. These values are now preserved exactly as text rather than being converted to floating-point format, preventing precision loss.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/filesql/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->