### PR TITLE
feat: add LoadInto to load files into an existing database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `LoadInto(ctx, db, paths...)` and `(*DBBuilder).LoadInto(ctx, db)` load files into an existing `*sql.DB` instead of creating a new in-memory database. This lets callers combine file-derived tables with a database they already manage (for example a long-lived session that imports files repeatedly) without copying the data through a second database. A table whose name matches a loaded file is replaced (last-wins); other tables are left untouched, and the caller's database is never closed. `Open`/`OpenContext` behavior is unchanged.
+
 ## [0.12.1] - 2026-05-30
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `LoadInto(ctx, db, paths...)` and `(*DBBuilder).LoadInto(ctx, db)` load files into an existing `*sql.DB` instead of creating a new in-memory database. This lets callers combine file-derived tables with a database they already manage (for example a long-lived session that imports files repeatedly) without copying the data through a second database. A table whose name matches a loaded file is replaced (last-wins); other tables are left untouched, and the caller's database is never closed. `Open`/`OpenContext` behavior is unchanged.
+- `LoadInto(ctx, db, paths...)` and `(*DBBuilder).LoadInto(ctx, db)` load files into an existing `*sql.DB` instead of creating a new in-memory database. This lets callers combine file-derived tables with a database they already manage (for example a long-lived session that imports files repeatedly) without copying the data through a second database. A table whose name matches a loaded file is replaced (last-wins); other tables are left untouched, and the caller's database is never closed. `Open`/`OpenContext` behavior is unchanged. (PR [#129](https://github.com/nao1215/filesql/pull/129), [5afc764](https://github.com/nao1215/filesql/commit/5afc764))
 
 ## [0.12.1] - 2026-05-30
 

--- a/README.md
+++ b/README.md
@@ -233,6 +233,46 @@ func main() {
 }
 ```
 
+### Loading into an Existing Database
+
+`Open`/`OpenContext` create a new in-memory database. When you already manage a database, use `LoadInto` to load files into it instead of copying through a second database. Use it for a long-lived session that imports files over time, or to join file data with tables you created yourself.
+
+```go
+package main
+
+import (
+    "context"
+    "database/sql"
+    "log"
+
+    "github.com/nao1215/filesql"
+    _ "modernc.org/sqlite"
+)
+
+func main() {
+    db, err := sql.Open("sqlite", ":memory:")
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer db.Close()
+    // ":memory:" is private per connection; pin the pool so the loaded tables
+    // are visible to later queries on the same database.
+    db.SetMaxOpenConns(1)
+
+    // Load files into the database you own. LoadInto does not close db.
+    if err := filesql.LoadInto(context.Background(), db, "users.csv", "orders.parquet"); err != nil {
+        log.Fatal(err)
+    }
+
+    // Load more files later into the same database (last-wins on same names).
+    if err := filesql.LoadInto(context.Background(), db, "more_users.csv"); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+A table whose name matches a loaded file is replaced, so reloading a file is idempotent; tables you created yourself are left untouched. For readers or filesystems, configure a builder and call its `LoadInto` method. Auto-save is not supported here because the caller owns the database lifecycle.
+
 ### Auto-Save Features
 
 #### Auto-Save on Database Close

--- a/ach.go
+++ b/ach.go
@@ -402,7 +402,7 @@ func IsACHBaseTableName(tableName string) (baseName string, isACH bool) {
 }
 
 // streamACHFileToDatabase streams an ACH file to the database as multiple tables
-func streamACHFileToDatabase(ctx context.Context, db *sql.DB, reader io.Reader, filePath string) error {
+func streamACHFileToDatabase(ctx context.Context, db *sql.DB, reader io.Reader, filePath string, replaceExisting bool) error {
 	baseTableName := sanitizeTableName(tableFromFilePath(filePath))
 
 	tables, tableSet, err := parseACHFile(reader, baseTableName)
@@ -425,7 +425,13 @@ func streamACHFileToDatabase(ctx context.Context, db *sql.DB, reader io.Reader, 
 		}
 
 		if tableExists > 0 {
-			return fmt.Errorf("%w: table '%s' already exists", ErrDuplicateTable, t.getName())
+			if !replaceExisting {
+				return fmt.Errorf("%w: table '%s' already exists", ErrDuplicateTable, t.getName())
+			}
+			// Replace mode: drop the old table so the reloaded file's tables win.
+			if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS "`+t.getName()+`"`); err != nil {
+				return fmt.Errorf("%w: failed to drop existing table %s: %s", ErrDatabaseOperation, t.getName(), err.Error())
+			}
 		}
 
 		// Create table

--- a/builder.go
+++ b/builder.go
@@ -481,8 +481,10 @@ func (b *DBBuilder) LoadInto(ctx context.Context, db *sql.DB) error {
 	b.collectedPaths = b.fileProcessor.deduplicateCompressedFiles(b.collectedPaths)
 
 	// Replace same-named tables so loading into an existing database is last-wins
-	// rather than erroring on or appending to a pre-existing table.
+	// rather than erroring on or appending to a pre-existing table. Reset
+	// afterward so reusing the builder (e.g. a later Open) is not affected.
 	b.streamProcessor.replaceExisting = true
+	defer func() { b.streamProcessor.replaceExisting = false }()
 
 	if err := b.streamProcessor.streamAllFilesToDatabase(ctx, db, b.collectedPaths); err != nil {
 		return err

--- a/builder.go
+++ b/builder.go
@@ -433,6 +433,66 @@ func (b *DBBuilder) OpenReadOnly(ctx context.Context) (*ReadOnlyDB, error) {
 	return NewReadOnlyDB(db), nil
 }
 
+// LoadInto loads the builder's configured inputs into an existing database
+// instead of creating a new in-memory one as Open does. Use it to combine
+// file-derived tables with a caller-managed database, such as a long-lived
+// session or a database that already holds other tables, without copying the
+// data through a second database.
+//
+// Semantics:
+//   - A table whose name matches a loaded file or sheet is replaced (dropped and
+//     recreated), so reloading a file is idempotent and same-named inputs are
+//     last-wins. Other tables in db are left untouched.
+//   - The caller keeps ownership of db. LoadInto never closes it, even on error.
+//   - For an in-memory database, pin the pool to one connection
+//     (db.SetMaxOpenConns(1)). SQLite ":memory:" is private per connection, so a
+//     multi-connection pool would not share the loaded tables.
+//
+// Auto-save is not supported because the caller owns the database lifecycle;
+// configuring it returns an error.
+//
+// Example:
+//
+//	db, _ := sql.Open("sqlite", ":memory:")
+//	db.SetMaxOpenConns(1)
+//	builder, err := filesql.NewBuilder().AddPath("users.csv").Build(ctx)
+//	if err != nil {
+//		return err
+//	}
+//	if err := builder.LoadInto(ctx, db); err != nil {
+//		return err
+//	}
+//	// db now has a "users" table alongside any tables it already had.
+func (b *DBBuilder) LoadInto(ctx context.Context, db *sql.DB) error {
+	if db == nil {
+		return fmt.Errorf("%w: target database is nil", ErrDatabaseOperation)
+	}
+	if b.autoSaveConfig != nil && b.autoSaveConfig.enabled {
+		return fmt.Errorf("%w: auto-save is not supported by LoadInto; the caller owns the database lifecycle", ErrDatabaseOperation)
+	}
+
+	if err := b.validator.validateInputsAvailable(b.collectedPaths, b.readers); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	b.collectedPaths = b.fileProcessor.deduplicateCompressedFiles(b.collectedPaths)
+
+	// Replace same-named tables so loading into an existing database is last-wins
+	// rather than erroring on or appending to a pre-existing table.
+	b.streamProcessor.replaceExisting = true
+
+	if err := b.streamProcessor.streamAllFilesToDatabase(ctx, db, b.collectedPaths); err != nil {
+		return err
+	}
+	if err := b.streamProcessor.streamAllReadersToDatabase(ctx, db, b.readers); err != nil {
+		return err
+	}
+	return nil
+}
+
 // deduplicateCompressedFiles removes compressed duplicates when uncompressed versions exist.
 // DEPRECATED: This method has been moved to fileProcessor.deduplicateCompressedFiles()
 // createInMemoryDatabase creates a new in-memory SQLite database connection.

--- a/filesql.go
+++ b/filesql.go
@@ -181,6 +181,36 @@ func OpenContext(ctx context.Context, paths ...string) (*sql.DB, error) {
 	return validatedBuilder.Open(ctx)
 }
 
+// LoadInto loads the given file or directory paths into an existing database
+// instead of creating a new one, and returns without closing it. This lets a
+// caller combine file-derived tables with a database it already manages (for
+// example a long-lived session that imports files repeatedly).
+//
+// A table whose name matches a loaded file is replaced, so reloading is
+// idempotent (last-wins for same-named inputs); other tables in db are left
+// untouched. For an in-memory database, pin the pool to a single connection
+// (db.SetMaxOpenConns(1)) because SQLite ":memory:" is private per connection.
+// See (*DBBuilder).LoadInto for the full semantics and for loading readers or
+// filesystems.
+//
+// Example:
+//
+//	db, _ := sql.Open("sqlite", ":memory:")
+//	db.SetMaxOpenConns(1)
+//	if err := filesql.LoadInto(ctx, db, "users.csv", "orders.csv"); err != nil {
+//		return err
+//	}
+func LoadInto(ctx context.Context, db *sql.DB, paths ...string) error {
+	builder := NewBuilder().AddPaths(paths...)
+
+	validatedBuilder, err := builder.Build(ctx)
+	if err != nil {
+		return err
+	}
+
+	return validatedBuilder.LoadInto(ctx, db)
+}
+
 // DumpDatabase saves all database tables to files in the specified directory.
 //
 // Basic usage:

--- a/load_into_test.go
+++ b/load_into_test.go
@@ -1,0 +1,281 @@
+package filesql
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// newCallerDB returns an in-memory SQLite database owned by the test, standing
+// in for a caller-managed database. ":memory:" is private per connection, so the
+// pool is pinned to one connection; otherwise tables created on one connection
+// would be invisible to the next.
+func newCallerDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func listTables(t *testing.T, db *sql.DB) []string {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(), `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	var names []string
+	for rows.Next() {
+		var n string
+		require.NoError(t, rows.Scan(&n))
+		names = append(names, n)
+	}
+	require.NoError(t, rows.Err())
+	return names
+}
+
+func countRows(t *testing.T, db *sql.DB, table string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM "`+table+`"`).Scan(&n))
+	return n
+}
+
+func writeTempCSV(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+	return p
+}
+
+func TestLoadInto_PackageFunc_CSV(t *testing.T) {
+	db := newCallerDB(t)
+	require.NoError(t, LoadInto(context.Background(), db, filepath.Join("testdata", "sample.csv")))
+
+	assert.Equal(t, []string{"sample"}, listTables(t, db))
+	assert.Equal(t, 3, countRows(t, db, "sample"))
+
+	var name string
+	require.NoError(t, db.QueryRowContext(context.Background(), `SELECT name FROM sample WHERE id = 1`).Scan(&name))
+	assert.Equal(t, "John Doe", name)
+}
+
+func TestLoadInto_PreservesExistingCallerTables(t *testing.T) {
+	db := newCallerDB(t)
+	_, err := db.ExecContext(context.Background(), `CREATE TABLE app (k TEXT); INSERT INTO app VALUES ('keep')`)
+	require.NoError(t, err)
+
+	require.NoError(t, LoadInto(context.Background(), db, filepath.Join("testdata", "sample.csv")))
+
+	assert.Equal(t, []string{"app", "sample"}, listTables(t, db))
+	assert.Equal(t, 1, countRows(t, db, "app")) // caller's table is untouched
+	assert.Equal(t, 3, countRows(t, db, "sample"))
+}
+
+func TestLoadInto_ReplacesSameNamedTable(t *testing.T) {
+	db := newCallerDB(t)
+	// Pre-create a table named like the file; loading must replace, not append.
+	_, err := db.ExecContext(context.Background(), `CREATE TABLE sample (x TEXT); INSERT INTO sample VALUES ('old1'); INSERT INTO sample VALUES ('old2')`)
+	require.NoError(t, err)
+
+	require.NoError(t, LoadInto(context.Background(), db, filepath.Join("testdata", "sample.csv")))
+
+	assert.Equal(t, 3, countRows(t, db, "sample")) // file rows, not 2 old + 3 new
+	// The replaced table has the file's schema (id column exists).
+	var id int
+	require.NoError(t, db.QueryRowContext(context.Background(), `SELECT id FROM sample ORDER BY id LIMIT 1`).Scan(&id))
+	assert.Equal(t, 1, id)
+}
+
+func TestLoadInto_IncrementalAcrossCalls(t *testing.T) {
+	dir := t.TempDir()
+	a := writeTempCSV(t, dir, "left.csv", "id,word\n1,hello\n")
+	b := writeTempCSV(t, dir, "right.csv", "id,word\n1,world\n")
+
+	db := newCallerDB(t)
+	require.NoError(t, LoadInto(context.Background(), db, a))
+	require.NoError(t, LoadInto(context.Background(), db, b))
+
+	assert.Equal(t, []string{"left", "right"}, listTables(t, db))
+
+	// Cross-source JOIN proves both live in one database.
+	var joined string
+	require.NoError(t, db.QueryRowContext(context.Background(),
+		`SELECT left.word || ' ' || right.word FROM left JOIN right ON left.id = right.id`,
+	).Scan(&joined))
+	assert.Equal(t, "hello world", joined)
+}
+
+func TestLoadInto_LastWinsWithinOneCall(t *testing.T) {
+	dir := t.TempDir()
+	sub1 := filepath.Join(dir, "d1")
+	sub2 := filepath.Join(dir, "d2")
+	require.NoError(t, os.MkdirAll(sub1, 0o750))
+	require.NoError(t, os.MkdirAll(sub2, 0o750))
+	first := writeTempCSV(t, sub1, "users.csv", "id\n1\n2\n")           // 2 rows
+	second := writeTempCSV(t, sub2, "users.csv", "id\n9\n8\n7\n6\n5\n") // 5 rows
+
+	db := newCallerDB(t)
+	require.NoError(t, LoadInto(context.Background(), db, first, second))
+
+	assert.Equal(t, []string{"users"}, listTables(t, db))
+	assert.Equal(t, 5, countRows(t, db, "users")) // last file wins
+}
+
+func TestLoadInto_Directory(t *testing.T) {
+	dir := t.TempDir()
+	writeTempCSV(t, dir, "one.csv", "a\n1\n")
+	writeTempCSV(t, dir, "two.csv", "b\n2\n")
+
+	db := newCallerDB(t)
+	require.NoError(t, LoadInto(context.Background(), db, dir))
+
+	assert.Equal(t, []string{"one", "two"}, listTables(t, db))
+}
+
+func TestLoadInto_CompressedCSV(t *testing.T) {
+	db := newCallerDB(t)
+	require.NoError(t, LoadInto(context.Background(), db, filepath.Join("testdata", "sample.csv.gz")))
+	assert.Equal(t, []string{"sample"}, listTables(t, db))
+	assert.Positive(t, countRows(t, db, "sample"))
+}
+
+func TestLoadInto_Parquet(t *testing.T) {
+	db := newCallerDB(t)
+	require.NoError(t, LoadInto(context.Background(), db, filepath.Join("testdata", "products.parquet")))
+	assert.Equal(t, []string{"products"}, listTables(t, db))
+	assert.Positive(t, countRows(t, db, "products"))
+}
+
+func TestLoadInto_JSONL(t *testing.T) {
+	db := newCallerDB(t)
+	require.NoError(t, LoadInto(context.Background(), db, filepath.Join("testdata", "sample.jsonl")))
+	assert.Equal(t, []string{"sample"}, listTables(t, db))
+	assert.Positive(t, countRows(t, db, "sample"))
+}
+
+func TestLoadInto_Excel(t *testing.T) {
+	db := newCallerDB(t)
+	require.NoError(t, LoadInto(context.Background(), db, filepath.Join("testdata", "excel", "sample.xlsx")))
+	tables := listTables(t, db)
+	require.NotEmpty(t, tables)
+	for _, name := range tables {
+		assert.True(t, strings.HasPrefix(name, "sample_"), "excel sheet table %q should be prefixed with the file name", name)
+	}
+}
+
+func TestLoadInto_ACH_MultiTableAndReplaceOnReload(t *testing.T) {
+	db := newCallerDB(t)
+	ach := filepath.Join("testdata", "ppd-debit.ach")
+
+	require.NoError(t, LoadInto(context.Background(), db, ach))
+	first := listTables(t, db)
+	require.GreaterOrEqual(t, len(first), 2, "ACH file should produce multiple tables")
+
+	// Re-loading the same ACH file must replace its tables, not error with
+	// ErrDuplicateTable.
+	require.NoError(t, LoadInto(context.Background(), db, ach))
+	second := listTables(t, db)
+	assert.Equal(t, first, second)
+}
+
+func TestLoadInto_Fedwire(t *testing.T) {
+	db := newCallerDB(t)
+	require.NoError(t, LoadInto(context.Background(), db, filepath.Join("testdata", "customer-transfer.fed")))
+	assert.NotEmpty(t, listTables(t, db))
+}
+
+func TestLoadInto_PreservesTypeInference(t *testing.T) {
+	dir := t.TempDir()
+	csv := writeTempCSV(t, dir, "typed.csv", "n,label\n1,a\n2,b\n")
+
+	db := newCallerDB(t)
+	require.NoError(t, LoadInto(context.Background(), db, csv))
+
+	types := map[string]string{}
+	rows, err := db.QueryContext(context.Background(), `PRAGMA table_info("typed")`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notnull, pk int
+		var dflt sql.NullString
+		require.NoError(t, rows.Scan(&cid, &name, &typ, &notnull, &dflt, &pk))
+		types[name] = typ
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, "INTEGER", types["n"], "integer column should keep INTEGER affinity")
+}
+
+func TestLoadInto_BuilderReaders(t *testing.T) {
+	db := newCallerDB(t)
+	builder, err := NewBuilder().
+		AddReader(strings.NewReader("id,v\n1,x\n2,y\n"), "from_reader", FileTypeCSV).
+		Build(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, builder.LoadInto(context.Background(), db))
+
+	assert.Equal(t, []string{"from_reader"}, listTables(t, db))
+	assert.Equal(t, 2, countRows(t, db, "from_reader"))
+}
+
+func TestLoadInto_Errors(t *testing.T) {
+	t.Run("nil database", func(t *testing.T) {
+		err := LoadInto(context.Background(), nil, filepath.Join("testdata", "sample.csv"))
+		require.Error(t, err)
+	})
+
+	t.Run("nonexistent path", func(t *testing.T) {
+		db := newCallerDB(t)
+		err := LoadInto(context.Background(), db, filepath.Join("testdata", "does_not_exist.csv"))
+		require.Error(t, err)
+	})
+
+	t.Run("unsupported format", func(t *testing.T) {
+		dir := t.TempDir()
+		bad := filepath.Join(dir, "data.unknown")
+		require.NoError(t, os.WriteFile(bad, []byte("x"), 0o600))
+		db := newCallerDB(t)
+		err := LoadInto(context.Background(), db, bad)
+		require.Error(t, err)
+	})
+
+	t.Run("cancelled context", func(t *testing.T) {
+		db := newCallerDB(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := LoadInto(ctx, db, filepath.Join("testdata", "sample.csv"))
+		require.Error(t, err)
+	})
+
+	t.Run("auto-save configured is rejected", func(t *testing.T) {
+		db := newCallerDB(t)
+		builder, err := NewBuilder().
+			AddPath(filepath.Join("testdata", "sample.csv")).
+			EnableAutoSave(t.TempDir()).
+			Build(context.Background())
+		require.NoError(t, err)
+		err = builder.LoadInto(context.Background(), db)
+		require.Error(t, err)
+	})
+}
+
+func TestLoadInto_DoesNotCloseCallerDB(t *testing.T) {
+	db := newCallerDB(t)
+	require.NoError(t, LoadInto(context.Background(), db, filepath.Join("testdata", "sample.csv")))
+	// The caller still owns the connection; it must remain usable.
+	require.NoError(t, db.PingContext(context.Background()))
+
+	got := listTables(t, db)
+	sort.Strings(got)
+	assert.Equal(t, []string{"sample"}, got)
+}

--- a/load_into_test.go
+++ b/load_into_test.go
@@ -23,7 +23,7 @@ func newCallerDB(t *testing.T) *sql.DB {
 	db, err := sql.Open("sqlite", ":memory:")
 	require.NoError(t, err)
 	db.SetMaxOpenConns(1)
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() { assert.NoError(t, db.Close()) })
 	return db
 }
 
@@ -31,7 +31,7 @@ func listTables(t *testing.T, db *sql.DB) []string {
 	t.Helper()
 	rows, err := db.QueryContext(context.Background(), `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name`)
 	require.NoError(t, err)
-	defer func() { _ = rows.Close() }()
+	defer func() { assert.NoError(t, rows.Close()) }()
 	var names []string
 	for rows.Next() {
 		var n string
@@ -203,7 +203,7 @@ func TestLoadInto_PreservesTypeInference(t *testing.T) {
 	types := map[string]string{}
 	rows, err := db.QueryContext(context.Background(), `PRAGMA table_info("typed")`)
 	require.NoError(t, err)
-	defer func() { _ = rows.Close() }()
+	defer func() { assert.NoError(t, rows.Close()) }()
 	for rows.Next() {
 		var cid int
 		var name, typ string
@@ -249,7 +249,7 @@ func TestLoadInto_Errors(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("cancelled context", func(t *testing.T) {
+	t.Run("canceled context", func(t *testing.T) {
 		db := newCallerDB(t)
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -267,6 +267,20 @@ func TestLoadInto_Errors(t *testing.T) {
 		err = builder.LoadInto(context.Background(), db)
 		require.Error(t, err)
 	})
+}
+
+func TestLoadInto_DoesNotLeakReplaceModeToBuilder(t *testing.T) {
+	db := newCallerDB(t)
+	builder, err := NewBuilder().
+		AddPath(filepath.Join("testdata", "sample.csv")).
+		Build(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, builder.LoadInto(context.Background(), db))
+
+	// Replace mode must not persist on the builder; a later Open must see the
+	// default (non-replace) behavior.
+	assert.False(t, builder.streamProcessor.replaceExisting,
+		"LoadInto must reset replaceExisting so reusing the builder is unaffected")
 }
 
 func TestLoadInto_DoesNotCloseCallerDB(t *testing.T) {

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -22,6 +22,24 @@ func streamError(sentinel error, format string, args ...any) error {
 type streamProcessor struct {
 	chunkSize int
 	logger    Logger
+	// replaceExisting makes table creation drop a same-named table first instead
+	// of erroring or appending. It is enabled for LoadInto (loading into a
+	// caller-owned database, where last-wins replacement is the useful default)
+	// and left false for Open (fresh in-memory database, no collisions).
+	replaceExisting bool
+}
+
+// dropIfReplacing drops a same-named table when replaceExisting is set, so the
+// following CREATE installs the file's schema and rows in place of any prior
+// table. It is a no-op in Open mode.
+func (sp *streamProcessor) dropIfReplacing(ctx context.Context, db *sql.DB, tableName string) error {
+	if !sp.replaceExisting {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS "`+tableName+`"`); err != nil {
+		return fmt.Errorf("%w: failed to drop existing table %q: %s", ErrDatabaseOperation, tableName, err.Error())
+	}
+	return nil
 }
 
 // newStreamProcessor creates a new stream processor instance
@@ -184,7 +202,7 @@ func (sp *streamProcessor) streamACHFileToDatabase(ctx context.Context, db *sql.
 	}
 
 	sp.logger.Debug("streaming ACH file to database", "path", filePath, "size", fileInfo.Size())
-	return streamACHFileToDatabase(ctx, db, file, filePath)
+	return streamACHFileToDatabase(ctx, db, file, filePath, sp.replaceExisting)
 }
 
 // streamFedWireFileToDatabase handles Fedwire files by creating a single message table
@@ -211,17 +229,17 @@ func (sp *streamProcessor) streamFedWireFileToDatabase(ctx context.Context, db *
 	}
 
 	sp.logger.Debug("streaming Fedwire file to database", "path", filePath, "size", fileInfo.Size())
-	return streamWireFileToDatabase(ctx, db, file, filePath)
+	return streamWireFileToDatabase(ctx, db, file, filePath, sp.replaceExisting)
 }
 
 // streamReaderToDatabase streams data from io.Reader directly to SQLite database
 func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db *sql.DB, input readerInput) error {
 	// Route ACH/Fedwire readers to dedicated handlers
 	if input.fileType == FileTypeACH {
-		return streamACHFileToDatabase(ctx, db, input.reader, input.tableName+extACH)
+		return streamACHFileToDatabase(ctx, db, input.reader, input.tableName+extACH, sp.replaceExisting)
 	}
 	if input.fileType == FileTypeFedWire {
-		return streamWireFileToDatabase(ctx, db, input.reader, input.tableName+extFED)
+		return streamWireFileToDatabase(ctx, db, input.reader, input.tableName+extFED, sp.replaceExisting)
 	}
 
 	// Reader should already be validated at Build time, but ensure it's buffered
@@ -239,10 +257,11 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db *sql.D
 		return fmt.Errorf("%w: failed to check table existence: %s", ErrDatabaseOperation, err.Error())
 	}
 
-	if tableExists > 0 {
+	if tableExists > 0 && !sp.replaceExisting {
 		sp.logger.Warn("table already exists", "table", input.tableName)
 		return fmt.Errorf("%w: table '%s' already exists from another file", ErrDuplicateTable, input.tableName)
 	}
+	// When replacing, createTableFromChunk drops the old table before recreating it.
 
 	// Create streaming parser for chunked processing
 	parser := newStreamingParser(input.fileType, input.tableName, sp.chunkSize)
@@ -354,6 +373,10 @@ func (sp *streamProcessor) createTableFromChunk(ctx context.Context, db *sql.DB,
 	columns := make([]string, 0, len(columnInfo))
 	for _, col := range columnInfo {
 		columns = append(columns, fmt.Sprintf(`"%s" %s`, col.Name, col.Type.string()))
+	}
+
+	if err := sp.dropIfReplacing(ctx, db, chunk.getTableName()); err != nil {
+		return err
 	}
 
 	query := fmt.Sprintf(
@@ -578,9 +601,10 @@ func (sp *streamProcessor) streamXLSXFileToDatabase(ctx context.Context, db *sql
 			return fmt.Errorf("%w: failed to check table existence: %s", ErrDatabaseOperation, err.Error())
 		}
 
-		if tableExists > 0 {
+		if tableExists > 0 && !sp.replaceExisting {
 			return fmt.Errorf("%w: table '%s' already exists from another file", ErrDuplicateTable, tableName)
 		}
+		// When replacing, createTableFromChunk drops the old table before recreating it.
 
 		// Convert XLSX rows to table headers and records
 		headers, records := convertXLSXRowsToTable(rows)

--- a/wire.go
+++ b/wire.go
@@ -158,7 +158,7 @@ func IsWireBaseTableName(tableName string) (baseName string, isWire bool) {
 }
 
 // streamWireFileToDatabase streams a Fedwire file to the database as a single table.
-func streamWireFileToDatabase(ctx context.Context, db *sql.DB, reader io.Reader, filePath string) error {
+func streamWireFileToDatabase(ctx context.Context, db *sql.DB, reader io.Reader, filePath string, replaceExisting bool) error {
 	baseTableName := sanitizeTableName(tableFromFilePath(filePath))
 
 	tables, tableSet, err := parseFedWireFile(reader, baseTableName)
@@ -181,7 +181,13 @@ func streamWireFileToDatabase(ctx context.Context, db *sql.DB, reader io.Reader,
 		}
 
 		if tableExists > 0 {
-			return fmt.Errorf("%w: table '%s' already exists", ErrDuplicateTable, t.getName())
+			if !replaceExisting {
+				return fmt.Errorf("%w: table '%s' already exists", ErrDuplicateTable, t.getName())
+			}
+			// Replace mode: drop the old table so the reloaded file's tables win.
+			if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS "`+t.getName()+`"`); err != nil {
+				return fmt.Errorf("%w: failed to drop existing table %s: %s", ErrDatabaseOperation, t.getName(), err.Error())
+			}
 		}
 
 		// Create table


### PR DESCRIPTION
## Summary
`Open`/`OpenContext` always create a new in-memory database, so a caller that manages its own `*sql.DB` cannot load files directly into it; it must open a separate filesql database and copy every table across. This adds `LoadInto`, which streams files into a caller-provided database, so file-derived tables can sit alongside tables the caller already has, and a long-lived session can import files repeatedly without a second database.

## API
- `func LoadInto(ctx context.Context, db *sql.DB, paths ...string) error` -- package convenience, mirrors `OpenContext`.
- `func (b *DBBuilder) LoadInto(ctx context.Context, db *sql.DB) error` -- builder method, also supports readers and filesystems.

## Semantics
A table whose name matches a loaded file or sheet is replaced (dropped then recreated), so reloading a file is idempotent and same-named inputs are last-wins. Other tables in the database are left untouched. The caller keeps ownership of the database; LoadInto never closes it, even on error. Auto-save is rejected because the caller owns the lifecycle. For an in-memory database the caller should pin the pool to one connection, since SQLite ":memory:" is private per connection.

`Open`/`OpenContext` behavior is unchanged: replacement is opt-in through a `replaceExisting` flag on the stream processor that only `LoadInto` sets, so the existing duplicate-table errors and create-if-not-exists behavior on the Open path are preserved.

## Changes
The stream processor gains a `replaceExisting` flag and a `dropIfReplacing` helper. Every table-creation site honors it: the chunked file/reader path (`createTableFromChunk`), the Excel sheet path, and the ACH and Fedwire paths (threaded as a parameter to `streamACHFileToDatabase`/`streamWireFileToDatabase`). When the flag is off (Open), all sites behave exactly as before.

## Tests
`load_into_test.go` covers loading CSV/compressed CSV/JSONL/Parquet/Excel/ACH/Fedwire into a caller database, preserving unrelated caller tables, replacing same-named tables, last-wins within one call, incremental loads across calls with a cross-source JOIN, directory loads, builder readers, type-inference preservation, and error cases (nil db, missing path, unsupported format, cancelled context, auto-save rejected, and that the caller database is not closed).

## Compatibility
Backward compatible. No existing signatures change; `LoadInto` is additive and `Open`/`OpenContext` are untouched. Suggested release: minor (v0.13.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New API to load data files into an existing SQLite database with idempotent "last-wins" table replacement while preserving user-created tables.
* **Documentation**
  * Added "Loading into an Existing Database" guide covering connection-pinning for in-memory DBs and noting auto-save is not supported when you manage DB lifecycle.
* **Tests**
  * Comprehensive test suite validating loading, replacement semantics, formats, error cases, and that the caller-owned DB remains open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->