### PR TITLE
fix: preserve SQL NULL through a Parquet round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Parquet export and reload now preserve SQL `NULL`. A null cell was written as an empty string and reloaded as an empty string, so `NULL` and `""` became indistinguishable after a round-trip. The Parquet writer now stores a real null, and the streaming reader reloads it as SQL `NULL`. Other formats are unaffected, since they carry no null concept. (Ref [nao1215/sqly#686](https://github.com/nao1215/sqly/issues/686))
 - LTSV imports now reject a label repeated within a single record (for example `x:1\tx:2`) instead of silently keeping only the last value and dropping the earlier one. Both the streaming parser and the chunked parser fail with a `duplicate column name` error, matching the CSV/TSV parsers, so LTSV imports stay lossless. A label repeated across separate records (the normal column-per-row case) still parses. (Ref [nao1215/sqly#467](https://github.com/nao1215/sqly/issues/467))
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Parquet export and reload now preserve SQL `NULL`. A null cell was written as an empty string and reloaded as an empty string, so `NULL` and `""` became indistinguishable after a round-trip. The Parquet writer now stores a real null, and the streaming reader reloads it as SQL `NULL`. Other formats are unaffected, since they carry no null concept. (Ref [nao1215/sqly#686](https://github.com/nao1215/sqly/issues/686))
+- Parquet export and reload now preserve SQL `NULL`. A null cell was written as an empty string and reloaded as an empty string, so `NULL` and `""` became indistinguishable after a round-trip. The Parquet writer now stores a real null, and the streaming reader reloads it as SQL `NULL`. Other formats are unaffected, since they carry no null concept. (PR [#136](https://github.com/nao1215/filesql/pull/136), Ref [nao1215/sqly#686](https://github.com/nao1215/sqly/issues/686))
 - LTSV imports now reject a label repeated within a single record (for example `x:1\tx:2`) instead of silently keeping only the last value and dropping the earlier one. Both the streaming parser and the chunked parser fail with a `duplicate column name` error, matching the CSV/TSV parsers, so LTSV imports stay lossless. A label repeated across separate records (the normal column-per-row case) still parses. (Ref [nao1215/sqly#467](https://github.com/nao1215/sqly/issues/467))
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -9,27 +9,25 @@
 
 ![logo](./doc/image/filesql-logo.png)
 
-**filesql** is a Go SQL driver that enables you to query CSV, TSV, LTSV, Parquet, and Excel (XLSX) files using SQLite3 SQL syntax. Query your data files directly without any imports or transformations!
+filesql is a Go SQL driver that queries CSV, TSV, LTSV, Parquet, and Excel (XLSX) files using SQLite3 SQL syntax. It queries data files directly without imports or transformations.
 
-**Want to try filesql's capabilities?** Check out **[sqly](https://github.com/nao1215/sqly)** - a command-line tool that uses filesql to easily execute SQL queries against CSV, TSV, LTSV, and Excel files directly from your shell. It's the perfect way to experience the power of filesql in action!
+[sqly](https://github.com/nao1215/sqly) is a command-line tool built on filesql that runs SQL queries against CSV, TSV, LTSV, and Excel files from the shell.
 
 ## Why filesql?
 
-This library was born from the experience of maintaining two separate CLI tools - [sqly](https://github.com/nao1215/sqly) and [sqluv](https://github.com/nao1215/sqluv). Both tools shared a common feature: executing SQL queries against CSV, TSV, and other file formats. 
-
-Rather than maintaining duplicate code across both projects, we extracted the core functionality into this reusable SQL driver. Now, any Go developer can leverage this capability in their own applications!
+filesql was extracted from the shared file-to-SQL logic in [sqly](https://github.com/nao1215/sqly) and [sqluv](https://github.com/nao1215/sqluv). Both tools executed SQL queries against CSV, TSV, and other file formats. The common functionality was moved into this SQL driver so any Go developer can reuse it.
 
 ## Features
 
-- SQLite3 SQL Interface - Use SQLite3's powerful SQL dialect to query your files
-- Multiple File Formats - Support for CSV, TSV, LTSV, Parquet, and Excel (XLSX) files
-- Compression Support - Automatically handles .gz, .bz2, .xz, .zst, .z, .snappy, .s2, and .lz4 compressed files
-- Stream Processing - Efficiently handles large files through streaming with configurable chunk sizes
-- Flexible Input Sources - Support for file paths, directories, io.Reader, and embed.FS
-- Zero Setup - No database server required, everything runs in-memory
-- Auto-Save - Automatically persist changes back to files
-- Cross-Platform - Works seamlessly on Linux, macOS, and Windows
-- SQLite3 Powered - Built on the robust SQLite3 engine for reliable SQL processing
+- SQLite3 SQL Interface - Use SQLite3's SQL dialect to query files
+- Multiple File Formats - CSV, TSV, LTSV, Parquet, and Excel (XLSX) files
+- Compression Support - Handles .gz, .bz2, .xz, .zst, .z, .snappy, .s2, and .lz4 compressed files
+- Stream Processing - Handles large files through streaming with configurable chunk sizes
+- Flexible Input Sources - File paths, directories, io.Reader, and embed.FS
+- Zero Setup - No database server required, runs in-memory
+- Auto-Save - Persist changes back to files
+- Cross-Platform - Linux, macOS, and Windows
+- SQLite3 Powered - Built on the SQLite3 engine for SQL processing
 
 ## Supported File Formats
 
@@ -50,8 +48,8 @@ Rather than maintaining duplicate code across both projects, we extracted the co
 | `.csv.snappy`, `.tsv.snappy`, `.ltsv.snappy`, `.parquet.snappy`, `.xlsx.snappy`, `.json.snappy`, `.jsonl.snappy` | Snappy compressed | Snappy compressed files |
 | `.csv.s2`, `.tsv.s2`, `.ltsv.s2`, `.parquet.s2`, `.xlsx.s2`, `.json.s2`, `.jsonl.s2` | S2 compressed | S2 compressed files (Snappy compatible) |
 | `.csv.lz4`, `.tsv.lz4`, `.ltsv.lz4`, `.parquet.lz4`, `.xlsx.lz4`, `.json.lz4`, `.jsonl.lz4` | LZ4 compressed | LZ4 compressed files |
-| `.ach` | ACH (NACHA) | Automated Clearing House files (**Experimental**) |
-| `.fed` | Fedwire | Legacy Fedwire message files (**Experimental**) |
+| `.ach` | ACH (NACHA) | Automated Clearing House files (Experimental) |
+| `.fed` | Fedwire | Legacy Fedwire message files (Experimental) |
 
 ## Installation
 
@@ -61,8 +59,8 @@ go get github.com/nao1215/filesql
 
 ## Requirements
 
-- **Go Version**: 1.25 or later
-- **Operating Systems**:
+- Go Version: 1.25 or later
+- Operating Systems:
   - Linux
   - macOS  
   - Windows
@@ -473,7 +471,7 @@ Since filesql uses SQLite3 as its underlying engine, all SQL syntax follows [SQL
 
 ### Data Modifications
 - `INSERT`, `UPDATE`, and `DELETE` operations affect the in-memory database
-- **Original files remain unchanged by default**
+- Original files remain unchanged by default
 - Use auto-save features or `DumpDatabase()` to persist changes
 - This makes it safe to experiment with data transformations
 
@@ -485,7 +483,7 @@ Since filesql uses SQLite3 as its underlying engine, all SQL syntax follows [SQL
 
 ## Benchmark
 
-Performance with a **100,000-row CSV file**:
+Performance with a 100,000-row CSV file:
 
 | Metric | Value |
 |--------|-------|
@@ -498,16 +496,16 @@ make benchmark
 ```
 
 ### Concurrency Limitations
-⚠️ **IMPORTANT**: This library is **NOT thread-safe** and has **concurrency limitations**:
-- **Do NOT** share database connections across goroutines
-- **Do NOT** perform concurrent operations on the same database instance
-- **Do NOT** call `db.Close()` while queries are active in other goroutines
+This library is not thread-safe and has concurrency limitations:
+- Do not share database connections across goroutines
+- Do not perform concurrent operations on the same database instance
+- Do not call `db.Close()` while queries are active in other goroutines
 - Use separate database instances for concurrent operations if needed
 - Race conditions may cause segmentation faults or data corruption
 
-**Recommended pattern for concurrent access**:
+Recommended pattern for concurrent access:
 ```go
-// ✅ GOOD: Separate database instances per goroutine
+// GOOD: Separate database instances per goroutine
 func processFileConcurrently(filename string) error {
     db, err := filesql.Open(filename)  // Each goroutine gets its own instance
     if err != nil {
@@ -519,30 +517,30 @@ func processFileConcurrently(filename string) error {
     return processData(db)
 }
 
-// ❌ BAD: Sharing database instance across goroutines
+// BAD: Sharing database instance across goroutines
 var sharedDB *sql.DB  // This will cause race conditions
 ```
 
 ### Parquet Support
-- **Reading**: Full support for Apache Parquet files with complex data types
-- **Writing**: Export functionality is implemented (external compression not supported, use Parquet's built-in compression)
-- **Type Mapping**: Parquet types are mapped to SQLite types
-- **Compression**: Parquet's built-in compression is used instead of external compression
-- **Large Data**: Parquet files are efficiently processed with Arrow's columnar format
+- Reading: Full support for Apache Parquet files with complex data types
+- Writing: Export functionality is implemented (external compression not supported, use Parquet's built-in compression)
+- Type Mapping: Parquet types are mapped to SQLite types
+- Compression: Parquet's built-in compression is used instead of external compression
+- Large Data: Parquet files are processed with Arrow's columnar format
 
 ### Excel (XLSX) Support
-- **1-Sheet-1-Table Structure**: Each sheet in an Excel workbook becomes a separate SQL table
-- **Table Naming**: SQL table names follow the format `{filename}_{sheetname}` (e.g., "sales_Q1", "sales_Q2")
-- **Header Row Processing**: First row of each sheet becomes the column headers for that table
-- **Standard SQL Operations**: Query each sheet independently or use JOINs to combine data across sheets
-- **Memory Requirements**: XLSX files require full loading into memory due to the ZIP-based format structure, even during streaming operations
-- **Implementation Note**: XLSX files are fully loaded into memory due to ZIP structure and all sheets are processed (CSV/TSV streaming parsers are not applicable)
-- **Export Functionality**: When exporting to XLSX format, table names become sheet names automatically
-- **Compression Support**: Full support for compressed XLSX files (.xlsx.gz, .xlsx.bz2, .xlsx.xz, .xlsx.zst, .xlsx.z, .xlsx.snappy, .xlsx.s2, .xlsx.lz4)
+- 1-Sheet-1-Table Structure: Each sheet in an Excel workbook becomes a separate SQL table
+- Table Naming: SQL table names follow the format `{filename}_{sheetname}` (e.g., "sales_Q1", "sales_Q2")
+- Header Row Processing: First row of each sheet becomes the column headers for that table
+- Standard SQL Operations: Query each sheet independently or use JOINs to combine data across sheets
+- Memory Requirements: XLSX files require full loading into memory due to the ZIP-based format structure, even during streaming operations
+- Implementation Note: XLSX files are fully loaded into memory due to ZIP structure and all sheets are processed (CSV/TSV streaming parsers are not applicable)
+- Export Functionality: When exporting to XLSX format, table names become sheet names automatically
+- Compression Support: Full support for compressed XLSX files (.xlsx.gz, .xlsx.bz2, .xlsx.xz, .xlsx.zst, .xlsx.z, .xlsx.snappy, .xlsx.s2, .xlsx.lz4)
 
 ### ACH (NACHA) Support - Experimental
 
-> **Warning**: ACH file support is **experimental**. The API may change in future versions.
+> Warning: ACH file support is experimental. The API may change in future versions.
 
 ACH (Automated Clearing House) files following the NACHA format can be queried using SQL. Each ACH file is converted to multiple tables:
 
@@ -557,14 +555,14 @@ ACH (Automated Clearing House) files following the NACHA format can be queried u
 
 #### Limitations
 
-**Read-only fields**: The following fields are exported for viewing but changes are not written back:
+Read-only fields: The following fields are exported for viewing but changes are not written back:
 - IAT Addenda sequence numbers (`entry_detail_sequence_number`, `sequence_number`)
 
-**Addenda05 index behavior**: When an entry has multiple addenda types (e.g., Addenda02 + Addenda05), the `addenda_index` represents the position within all addenda for that entry, not the index within Addenda05 array. For updates targeting specific Addenda05 records, use `addenda_type = '05'` to filter correctly.
+Addenda05 index behavior: When an entry has multiple addenda types (e.g., Addenda02 + Addenda05), the `addenda_index` represents the position within all addenda for that entry, not the index within Addenda05 array. For updates targeting specific Addenda05 records, use `addenda_type = '05'` to filter correctly.
 
-**Validation**: Modifying ACH data via SQL may create invalid ACH files. Users should ensure data consistency (e.g., `AddendaRecordIndicator` matches actual addenda presence).
+Validation: Modifying ACH data via SQL may create invalid ACH files. Users should ensure data consistency (e.g., `AddendaRecordIndicator` matches actual addenda presence).
 
-**Compression**: ACH files do not support compression wrappers (`.ach.gz`, etc.).
+Compression: ACH files do not support compression wrappers (`.ach.gz`, etc.).
 
 #### Example
 
@@ -593,7 +591,7 @@ rows, err := db.QueryContext(ctx, `
 
 ### Fedwire Support - Experimental
 
-> **Warning**: Fedwire file support is **experimental**. The API may change in future versions.
+> Warning: Fedwire file support is experimental. The API may change in future versions.
 
 Legacy Fedwire message files (`.fed`) can be loaded, queried, modified, and exported back to Fedwire format. Each Fedwire file contains a single FEDWireMessage and is converted to a single flat table with approximately 326 columns.
 
@@ -605,13 +603,13 @@ All columns are TEXT type since the wire format stores all values as fixed-width
 
 #### Limitations
 
-**UPDATE only**: Only UPDATE operations on existing rows are supported for round-trip editing. INSERT/DELETE operations in SQL are not reflected in the output wire file.
+UPDATE only: Only UPDATE operations on existing rows are supported for round-trip editing. INSERT/DELETE operations in SQL are not reflected in the output wire file.
 
-**No new sections**: Optional message sections that were not present in the original file cannot be added via SQL modifications.
+No new sections: Optional message sections that were not present in the original file cannot be added via SQL modifications.
 
-**Compression**: Fedwire files do not support compression wrappers (`.fed.gz`, etc.).
+Compression: Fedwire files do not support compression wrappers (`.fed.gz`, etc.).
 
-**Security**: Fedwire data contains sensitive banking information including routing numbers, account numbers, names, and transaction amounts. Do not log or export wire table data verbatim in production environments.
+Security: Fedwire data contains sensitive banking information including routing numbers, account numbers, names, and transaction amounts. Do not log or export wire table data verbatim in production environments.
 
 #### Example
 
@@ -741,12 +739,12 @@ The [examples](./examples) directory contains sample code demonstrating various 
 
 ## Data Preprocessing with fileprep
 
-For data validation and preprocessing before querying with filesql, we recommend using **[nao1215/fileprep](https://github.com/nao1215/fileprep)**.
+For data validation and preprocessing before querying with filesql, use [nao1215/fileprep](https://github.com/nao1215/fileprep).
 
 fileprep is a companion library that provides:
-- **Struct tag-based preprocessing** (`prep` tag): trim, lowercase, uppercase, default values, and more
-- **Struct tag-based validation** (`validate` tag): required fields, format validation, cross-field validation
-- **Seamless filesql integration**: Returns `io.Reader` for direct use with filesql's Builder pattern
+- Struct tag-based preprocessing (`prep` tag): trim, lowercase, uppercase, default values, and more
+- Struct tag-based validation (`validate` tag): required fields, format validation, cross-field validation
+- filesql integration: Returns `io.Reader` for direct use with filesql's Builder pattern
 
 ```go
 // Define struct with preprocessing and validation tags
@@ -805,7 +803,7 @@ For the complete list of preprocessing and validation options, see the [fileprep
 
 ## Related Projects
 
-Using filesql in your project? We'd love to hear about it! Please [open an issue](https://github.com/nao1215/filesql/issues) to let us know, and we'll add your project to the list below.
+If you use filesql in your project, [open an issue](https://github.com/nao1215/filesql/issues) and it will be added to the list below.
 
 ### Related Libraries
 
@@ -824,16 +822,14 @@ Using filesql in your project? We'd love to hear about it! Please [open an issue
 
 ## Contributing
 
-Contributions are welcome! Please see the [Contributing Guide](./CONTRIBUTING.md) for more details.
+Contributions are welcome. See the [Contributing Guide](./CONTRIBUTING.md) for more details.
 
 ## Support
 
-If you find this project useful, please consider:
+If you find this project useful, consider:
 
 - Giving it a star on GitHub - it helps others discover the project
-- [Becoming a sponsor](https://github.com/sponsors/nao1215) - your support keeps the project alive and motivates continued development
-
-Your support, whether through stars, sponsorships, or contributions, is what drives this project forward. Thank you!
+- [Becoming a sponsor](https://github.com/sponsors/nao1215)
 
 ### Star History
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ![logo](./doc/image/filesql-logo.png)
 
-filesql is a Go SQL driver that queries CSV, TSV, LTSV, Parquet, and Excel (XLSX) files using SQLite3 SQL syntax. It queries data files directly without imports or transformations.
+filesql is a Go SQL driver that queries CSV, TSV, LTSV, JSON, JSONL, Parquet, and Excel (XLSX) files using SQLite3 SQL syntax. It queries data files directly without imports or transformations.
 
 [sqly](https://github.com/nao1215/sqly) is a command-line tool built on filesql that runs SQL queries against CSV, TSV, LTSV, and Excel files from the shell.
 

--- a/file.go
+++ b/file.go
@@ -326,6 +326,11 @@ type tableChunk struct {
 	headers    header
 	records    []Record
 	columnInfo []columnInfo
+	// nulls, when non-nil, marks which cells were SQL NULL (nulls[row][col]).
+	// Formats without a null concept leave it nil, and the insert then treats
+	// every cell as a string. Parquet sets it so a stored null reloads as SQL NULL
+	// rather than an empty string.
+	nulls [][]bool
 }
 
 // getTableName returns the name of the table
@@ -346,6 +351,12 @@ func (tc *tableChunk) getRecords() []Record {
 // getColumnInfo returns the column information with inferred types
 func (tc *tableChunk) getColumnInfo() []columnInfo {
 	return tc.columnInfo
+}
+
+// getNulls returns the per-cell NULL mask, or nil when the source format has no
+// null concept.
+func (tc *tableChunk) getNulls() [][]bool {
+	return tc.nulls
 }
 
 // chunkProcessor is a function type for processing table chunks

--- a/filesql.go
+++ b/filesql.go
@@ -642,8 +642,11 @@ func writeParquetTableData(outputPath string, columns []string, rows *sql.Rows, 
 		return fmt.Errorf("%w: external compression not supported for Parquet format - use Parquet's built-in compression instead", ErrUnsupportedFormat)
 	}
 
-	// Read all rows into memory first
+	// Read all rows into memory first. nulls runs parallel to rows and marks the
+	// cells that were SQL NULL, so the Parquet writer can store a real null rather
+	// than collapsing it into an empty string.
 	var allRows [][]string
+	var allNulls [][]bool
 
 	// Prepare for scanning
 	values := make([]any, len(columns))
@@ -658,25 +661,28 @@ func writeParquetTableData(outputPath string, columns []string, rows *sql.Rows, 
 		}
 
 		row := make([]string, len(columns))
+		nullRow := make([]bool, len(columns))
 		for i, value := range values {
 			if value == nil {
-				row[i] = ""
+				nullRow[i] = true
 			} else {
 				row[i] = fmt.Sprintf("%v", value)
 			}
 		}
 		allRows = append(allRows, row)
+		allNulls = append(allNulls, nullRow)
 	}
 
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("%w: error iterating rows: %s", ErrDatabaseOperation, err.Error())
 	}
 
-	return writeParquetData(outputPath, columns, allRows)
+	return writeParquetData(outputPath, columns, allRows, allNulls)
 }
 
-// writeParquetData writes data to Parquet format
-func writeParquetData(outputPath string, columns []string, rows [][]string) error {
+// writeParquetData writes data to Parquet format. nulls, when non-nil, marks the
+// cells to store as a Parquet null; rows[r][c] is ignored for a cell marked null.
+func writeParquetData(outputPath string, columns []string, rows [][]string, nulls [][]bool) error {
 	if len(rows) == 0 {
 		return fmt.Errorf("%w: no data to write", ErrEmptyData)
 	}
@@ -695,8 +701,9 @@ func writeParquetData(outputPath string, columns []string, rows [][]string) erro
 	fields := make([]arrow.Field, len(columns))
 	for i, col := range columns {
 		fields[i] = arrow.Field{
-			Name: col,
-			Type: arrow.BinaryTypes.String,
+			Name:     col,
+			Type:     arrow.BinaryTypes.String,
+			Nullable: true, // allow a stored null so SQL NULL survives the round-trip
 		}
 	}
 	schema := arrow.NewSchema(fields, nil)
@@ -707,14 +714,18 @@ func writeParquetData(outputPath string, columns []string, rows [][]string) erro
 	defer builder.Release()
 
 	// Add data to builders
-	for _, row := range rows {
+	for r, row := range rows {
 		for i, value := range row {
 			if i < len(columns) {
 				strBuilder, ok := builder.Field(i).(*array.StringBuilder)
 				if !ok {
 					return fmt.Errorf("%w: failed to cast field %d to StringBuilder", ErrInvalidData, i)
 				}
-				strBuilder.Append(value)
+				if nulls != nil && r < len(nulls) && i < len(nulls[r]) && nulls[r][i] {
+					strBuilder.AppendNull()
+				} else {
+					strBuilder.Append(value)
+				}
 			}
 		}
 	}

--- a/parquet_null_test.go
+++ b/parquet_null_test.go
@@ -1,0 +1,130 @@
+package filesql
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestParquetRoundTripPreservesNull checks that a SQL NULL survives a Parquet
+// dump and reload instead of collapsing into an empty string, so NULL and ""
+// stay distinguishable.
+func TestParquetRoundTripPreservesNull(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "src.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE t (id TEXT, name TEXT);`); err != nil {
+		t.Fatal(err)
+	}
+	// Row 0 id is NULL, row 1 id is an empty string, row 2 id is a value.
+	if _, err := db.ExecContext(ctx, `INSERT INTO t VALUES (NULL,'A'),('','B'),('1','C');`); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(dir, "out")
+	opts := NewDumpOptions().WithFormat(OutputFormatParquet)
+	if err := DumpDatabase(db, out, opts); err != nil {
+		t.Fatalf("DumpDatabase: %v", err)
+	}
+
+	files, err := filepath.Glob(filepath.Join(out, "*.parquet"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("expected one parquet file, got %v (err %v)", files, err)
+	}
+
+	rdb, err := OpenContext(ctx, files[0])
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	defer func() { _ = rdb.Close() }()
+
+	rows, err := rdb.QueryContext(ctx, "SELECT id FROM t")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var got []sql.NullString
+	for rows.Next() {
+		var v sql.NullString
+		if err := rows.Scan(&v); err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, v)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("reimported %d rows, want 3", len(got))
+	}
+	if got[0].Valid {
+		t.Errorf("row 0 id = %q, want SQL NULL", got[0].String)
+	}
+	if !got[1].Valid || got[1].String != "" {
+		t.Errorf("row 1 id = %#v, want an empty string (not NULL)", got[1])
+	}
+	if !got[2].Valid || got[2].String != "1" {
+		t.Errorf("row 2 id = %#v, want \"1\"", got[2])
+	}
+}
+
+// TestParquetRoundTripPreservesNullInLaterColumn checks that a NULL in a column
+// other than the first survives the round-trip and does not shift the values of
+// the surrounding columns.
+func TestParquetRoundTripPreservesNullInLaterColumn(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "src.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE t (a TEXT, b TEXT, c TEXT);`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO t VALUES ('x', NULL, 'z');`); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(dir, "out")
+	if err := DumpDatabase(db, out, NewDumpOptions().WithFormat(OutputFormatParquet)); err != nil {
+		t.Fatalf("DumpDatabase: %v", err)
+	}
+	files, err := filepath.Glob(filepath.Join(out, "*.parquet"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("expected one parquet file, got %v (err %v)", files, err)
+	}
+
+	rdb, err := OpenContext(ctx, files[0])
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	defer func() { _ = rdb.Close() }()
+
+	var a, c string
+	var b sql.NullString
+	if err := rdb.QueryRowContext(ctx, "SELECT a, b, c FROM t").Scan(&a, &b, &c); err != nil {
+		t.Fatal(err)
+	}
+	if a != "x" || c != "z" {
+		t.Errorf("a,c = %q,%q, want x,z (neighbors unaffected)", a, c)
+	}
+	if b.Valid {
+		t.Errorf("b = %q, want SQL NULL", b.String)
+	}
+}

--- a/parquet_null_test.go
+++ b/parquet_null_test.go
@@ -48,7 +48,9 @@ func TestParquetRoundTripPreservesNull(t *testing.T) {
 	}
 	defer func() { _ = rdb.Close() }()
 
-	rows, err := rdb.QueryContext(ctx, "SELECT id FROM t")
+	// Order by name so the asserted row order is deterministic regardless of how
+	// the dump/reload path returns rows.
+	rows, err := rdb.QueryContext(ctx, "SELECT id FROM t ORDER BY name")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stream.go
+++ b/stream.go
@@ -709,14 +709,20 @@ func (p *streamingParser) processParquetInChunks(reader io.Reader, processor chu
 		batch := tableReader.Record()
 
 		var chunkRecords []Record
+		var chunkNulls [][]bool
 		numRows := batch.NumRows()
 		for i := range numRows {
 			row := make(Record, batch.NumCols())
+			nullRow := make([]bool, batch.NumCols())
 			for j, col := range batch.Columns() {
-				value := extractValueFromArrowArray(col, i)
-				row[j] = value
+				if col.IsNull(int(i)) {
+					nullRow[j] = true
+					continue
+				}
+				row[j] = extractValueFromArrowArray(col, i)
 			}
 			chunkRecords = append(chunkRecords, row)
+			chunkNulls = append(chunkNulls, nullRow)
 		}
 
 		if len(chunkRecords) > 0 {
@@ -725,6 +731,7 @@ func (p *streamingParser) processParquetInChunks(reader io.Reader, processor chu
 				headers:    headerSlice,
 				records:    chunkRecords,
 				columnInfo: columnInfoList,
+				nulls:      chunkNulls,
 			}
 
 			if err := processor(chunk); err != nil {

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -427,8 +427,9 @@ func (sp *streamProcessor) insertChunkData(ctx context.Context, stmt *sql.Stmt, 
 	// Use header count as the authoritative column count to ensure consistency
 	colCount := len(chunk.getHeaders())
 	values := make([]any, colCount)
+	nulls := chunk.getNulls()
 
-	for _, record := range records {
+	for rowIdx, record := range records {
 		// Fail fast if record has more columns than headers to prevent silent data truncation
 		if len(record) > colCount {
 			return fmt.Errorf("%w: record has more columns (%d) than headers (%d)", ErrColumnMismatch, len(record), colCount)
@@ -437,9 +438,12 @@ func (sp *streamProcessor) insertChunkData(ctx context.Context, stmt *sql.Stmt, 
 		// Fill values slice based on header count, handling records with fewer columns
 		// by setting missing columns to nil (NULL in SQLite)
 		for i := range colCount {
-			if i < len(record) {
+			switch {
+			case nulls != nil && rowIdx < len(nulls) && i < len(nulls[rowIdx]) && nulls[rowIdx][i]:
+				values[i] = nil // a source NULL (e.g. a Parquet null) inserts as SQL NULL
+			case i < len(record):
 				values[i] = record[i]
-			} else {
+			default:
 				values[i] = nil
 			}
 		}


### PR DESCRIPTION
## Summary

A SQL NULL was lost through a Parquet dump and reload. The Parquet writer wrote a null cell as an empty string, and the streaming reader read it back as an empty string, so NULL and "" became indistinguishable after a round-trip.

## Changes

- The Parquet writer marks each column nullable and stores a real null for a SQL NULL value (`writeParquetTableData` tracks a per-row null mask, `writeParquetData` calls `AppendNull`).
- The streaming Parquet reader records a per-cell null mask from the Arrow array (`processParquetInChunks`), carried on `tableChunk`.
- The chunk insert binds SQL NULL for masked cells (`insertChunkData`).
- Formats without a null concept leave the mask nil, so their inserts are unchanged. Parquet is the only load path that sets it.

This is backward compatible: the null mask is optional, and the full test suite passes unchanged.

## Tests

`parquet_null_test.go` asserts a NULL stays NULL (and stays distinct from "") after a `DumpDatabase` + `OpenContext` round-trip, including a NULL in a non-first column with neighbors unaffected.

The README is also restyled to a plain, terse tone (no bold, no marketing prose) in a separate commit.

Ref https://github.com/nao1215/sqly/issues/686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parquet export/import now preserves SQL `NULL` values correctly, keeping them distinct from empty strings during round trips.
  * Null handling is also maintained in streamed Parquet reads across all columns.

* **Documentation**
  * Updated the README and changelog with clearer guidance on supported formats, requirements, benchmarking, concurrency, and advanced format notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->