### PR TITLE
feat: add WithMalformedRowPolicy for ragged CSV/TSV rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`WithMalformedRowPolicy` lets callers choose how a ragged CSV/TSV row is handled.** A row whose field count differs from the header can now stop the import (`MalformedRowStop`, the default), be dropped (`MalformedRowSkip`), or be reshaped to the header width by padding short rows with empty strings and truncating long rows (`MalformedRowFill`). The policy applies to delimited text only; XLSX, LTSV, Parquet, and JSON/JSONL have no per-row field-count mismatch. (Ref [nao1215/sqly#731](https://github.com/nao1215/sqly/issues/731))
+
+### Fixed
+- **A ragged CSV/TSV row no longer silently drops data.** A row with fewer or more fields than the header made `encoding/csv` return a field-count error, which the streaming loader masked by creating an empty single-column table, losing both the malformed row and the well-formed rows before it. The default policy now aborts the import with `ErrColumnMismatch` instead of producing an empty table. (Ref [nao1215/sqly#731](https://github.com/nao1215/sqly/issues/731))
+
 ## [0.16.0] - 2026-06-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **`WithMalformedRowPolicy` lets callers choose how a ragged CSV/TSV row is handled.** A row whose field count differs from the header can now stop the import (`MalformedRowStop`, the default), be dropped (`MalformedRowSkip`), or be reshaped to the header width by padding short rows with empty strings and truncating long rows (`MalformedRowFill`). The policy applies to delimited text only; XLSX, LTSV, Parquet, and JSON/JSONL have no per-row field-count mismatch. (Ref [nao1215/sqly#731](https://github.com/nao1215/sqly/issues/731))
+- **`WithMalformedRowPolicy` lets callers choose how a ragged CSV/TSV row is handled.** A row whose field count differs from the header can now stop the import (`MalformedRowStop`, the default), be dropped (`MalformedRowSkip`), or be reshaped to the header width by padding short rows with empty strings and truncating long rows (`MalformedRowFill`). The policy applies to delimited text only; XLSX, LTSV, Parquet, and JSON/JSONL have no per-row field-count mismatch. (PR [#145](https://github.com/nao1215/filesql/pull/145), [3a625dc](https://github.com/nao1215/filesql/commit/3a625dc), Ref [nao1215/sqly#731](https://github.com/nao1215/sqly/issues/731))
 
 ### Fixed
-- **A ragged CSV/TSV row no longer silently drops data.** A row with fewer or more fields than the header made `encoding/csv` return a field-count error, which the streaming loader masked by creating an empty single-column table, losing both the malformed row and the well-formed rows before it. The default policy now aborts the import with `ErrColumnMismatch` instead of producing an empty table. (Ref [nao1215/sqly#731](https://github.com/nao1215/sqly/issues/731))
+- **A ragged CSV/TSV row no longer silently drops data.** A row with fewer or more fields than the header made `encoding/csv` return a field-count error, which the streaming loader masked by creating an empty single-column table, losing both the malformed row and the well-formed rows before it. The default policy now aborts the import with `ErrColumnMismatch` instead of producing an empty table. (PR [#145](https://github.com/nao1215/filesql/pull/145), [3a625dc](https://github.com/nao1215/filesql/commit/3a625dc), Ref [nao1215/sqly#731](https://github.com/nao1215/sqly/issues/731))
 
 ## [0.16.0] - 2026-06-29
 

--- a/builder.go
+++ b/builder.go
@@ -171,6 +171,28 @@ func (b *DBBuilder) SetDefaultChunkSize(size int) *DBBuilder {
 	return b
 }
 
+// WithMalformedRowPolicy sets how a CSV/TSV record whose field count differs
+// from the header is handled during import.
+//
+// The default is MalformedRowStop, which aborts the import with an error so a
+// corrupt or misaligned file is not imported as partial or empty data. Use
+// MalformedRowSkip to drop ragged rows and keep the well-formed ones, or
+// MalformedRowFill to keep every row by padding short rows with empty strings
+// and truncating long rows to the header width.
+//
+// The policy only affects delimited text formats. XLSX, LTSV, Parquet, and
+// JSON/JSONL have no per-row field-count mismatch and are unaffected.
+//
+// Example:
+//
+//	builder.WithMalformedRowPolicy(filesql.MalformedRowSkip)
+//
+// Returns self for chaining.
+func (b *DBBuilder) WithMalformedRowPolicy(policy MalformedRowPolicy) *DBBuilder {
+	b.streamProcessor.malformedRowPolicy = policy
+	return b
+}
+
 // WithLogger sets a custom logger for internal operations.
 //
 // The logger interface is compatible with slog.Logger. You can use the provided

--- a/file.go
+++ b/file.go
@@ -379,6 +379,9 @@ type streamingParser struct {
 	chunkSize   ChunkSize
 	memoryPool  *MemoryPool  // Pool for reusable memory allocations
 	memoryLimit *MemoryLimit // Configurable memory limits
+	// malformedRowPolicy controls how a CSV/TSV record whose field count differs
+	// from the header is handled. The zero value is MalformedRowStop.
+	malformedRowPolicy MalformedRowPolicy
 }
 
 // newFile creates a new file

--- a/filesql_test.go
+++ b/filesql_test.go
@@ -4358,8 +4358,8 @@ func TestEdgeCasesEmptyAndMalformedData(t *testing.T) {
 			name:        "Inconsistent row lengths",
 			fileContent: "col1,col2,col3\nvalue1,value2\nvalue3,value4,value5,value6",
 			fileName:    "inconsistent_rows.csv",
-			expectedErr: false,
-			description: "Should handle rows with different numbers of columns",
+			expectedErr: true,
+			description: "Should reject rows with different numbers of columns under the default stop policy",
 		},
 	}
 

--- a/malformed_row.go
+++ b/malformed_row.go
@@ -1,0 +1,70 @@
+package filesql
+
+import "fmt"
+
+// MalformedRowPolicy controls how a delimited (CSV/TSV) record whose field count
+// differs from the header row is handled during import.
+//
+// The policy only applies to delimited text formats, where a row can have more
+// or fewer fields than the header. Other formats do not have this failure mode:
+// XLSX and LTSV already pad missing cells, and Parquet and JSON/JSONL carry no
+// per-row field-count concept.
+type MalformedRowPolicy int
+
+const (
+	// MalformedRowStop aborts the import with an error on the first record whose
+	// field count differs from the header. It is the default because a ragged
+	// row usually signals a corrupt or misaligned file, and silently dropping or
+	// reshaping data would hide the problem.
+	MalformedRowStop MalformedRowPolicy = iota
+
+	// MalformedRowSkip discards any record whose field count differs from the
+	// header and imports the remaining well-formed records.
+	MalformedRowSkip
+
+	// MalformedRowFill keeps every record, padding a short record with empty
+	// strings and truncating the extra trailing fields of a long record so it
+	// matches the header width.
+	MalformedRowFill
+)
+
+// String returns the lowercase name of the policy, matching the values accepted
+// on the command line.
+func (p MalformedRowPolicy) String() string {
+	switch p {
+	case MalformedRowStop:
+		return "stop"
+	case MalformedRowSkip:
+		return "skip"
+	case MalformedRowFill:
+		return "fill"
+	default:
+		return fmt.Sprintf("MalformedRowPolicy(%d)", int(p))
+	}
+}
+
+// reconcileFieldCount reshapes a delimited record whose field count does not
+// match the header according to the policy. It returns the record to insert,
+// whether the caller should skip the record entirely, and an error when the
+// policy is to stop.
+func reconcileFieldCount(record []string, want, rowNum int, policy MalformedRowPolicy) (out []string, skip bool, err error) {
+	if len(record) == want {
+		return record, false, nil
+	}
+	switch policy {
+	case MalformedRowSkip:
+		return nil, true, nil
+	case MalformedRowFill:
+		return fitRecord(record, want), false, nil
+	default: // MalformedRowStop
+		return nil, false, fmt.Errorf("%w: row %d has %d fields, want %d", ErrColumnMismatch, rowNum, len(record), want)
+	}
+}
+
+// fitRecord returns a copy of record resized to exactly want fields: a short
+// record is padded with empty strings and a long record is truncated.
+func fitRecord(record []string, want int) []string {
+	out := make([]string, want)
+	copy(out, record)
+	return out
+}

--- a/malformed_row_test.go
+++ b/malformed_row_test.go
@@ -1,0 +1,215 @@
+package filesql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// queryColumn returns the values of a single column across all rows, ordered by
+// the given ORDER BY expression, so a test can assert on the imported content
+// regardless of physical row order.
+func queryColumn(t *testing.T, db *sql.DB, query string) []string {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(), query)
+	if err != nil {
+		t.Fatalf("query %q failed: %v", query, err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var v sql.NullString
+		if err := rows.Scan(&v); err != nil {
+			t.Fatalf("scan failed: %v", err)
+		}
+		out = append(out, v.String)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows iteration failed: %v", err)
+	}
+	return out
+}
+
+func openWithPolicy(t *testing.T, content string, ft FileType, policy MalformedRowPolicy) (*sql.DB, error) {
+	t.Helper()
+	b, err := NewBuilder().
+		AddReader(strings.NewReader(content), "t", ft).
+		WithMalformedRowPolicy(policy).
+		Build(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return b.Open(context.Background())
+}
+
+func TestMalformedRowPolicy_Stop(t *testing.T) {
+	t.Parallel()
+
+	t.Run("short row aborts import with ErrColumnMismatch instead of dropping data", func(t *testing.T) {
+		t.Parallel()
+		// Third row is missing the "zip" field. The default (stop) policy must
+		// surface an error rather than silently importing an empty table.
+		const csv = "id,name,zip\n1,alice,01234\n2,bob,123\n3,caro\n"
+		db, err := openWithPolicy(t, csv, FileTypeCSV, MalformedRowStop)
+		if db != nil {
+			defer db.Close()
+		}
+		if err == nil {
+			t.Fatalf("expected an error for a ragged row under the stop policy, got nil")
+		}
+		if !errors.Is(err, ErrColumnMismatch) {
+			t.Fatalf("expected ErrColumnMismatch, got %v", err)
+		}
+	})
+
+	t.Run("long row aborts import", func(t *testing.T) {
+		t.Parallel()
+		const csv = "id,name\n1,alice\n2,bob,extra\n"
+		db, err := openWithPolicy(t, csv, FileTypeCSV, MalformedRowStop)
+		if db != nil {
+			defer db.Close()
+		}
+		if !errors.Is(err, ErrColumnMismatch) {
+			t.Fatalf("expected ErrColumnMismatch, got %v", err)
+		}
+	})
+
+	t.Run("default policy is stop", func(t *testing.T) {
+		t.Parallel()
+		const csv = "id,name,zip\n1,alice,01234\n3,caro\n"
+		// No WithMalformedRowPolicy call: the zero value must behave as stop.
+		b, err := NewBuilder().AddReader(strings.NewReader(csv), "t", FileTypeCSV).Build(context.Background())
+		if err != nil {
+			t.Fatalf("build failed: %v", err)
+		}
+		db, err := b.Open(context.Background())
+		if db != nil {
+			defer db.Close()
+		}
+		if !errors.Is(err, ErrColumnMismatch) {
+			t.Fatalf("expected ErrColumnMismatch for default policy, got %v", err)
+		}
+	})
+}
+
+func TestMalformedRowPolicy_Skip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ragged rows are dropped and well-formed rows are imported", func(t *testing.T) {
+		t.Parallel()
+		const csv = "id,name,zip\n1,alice,01234\n2,bob,123\n3,caro\n4,dave,99999\n"
+		db, err := openWithPolicy(t, csv, FileTypeCSV, MalformedRowSkip)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer db.Close()
+
+		names := queryColumn(t, db, `SELECT name FROM t ORDER BY id`)
+		want := []string{"alice", "bob", "dave"}
+		if strings.Join(names, ",") != strings.Join(want, ",") {
+			t.Fatalf("names = %v, want %v", names, want)
+		}
+	})
+
+	t.Run("long rows are skipped too", func(t *testing.T) {
+		t.Parallel()
+		const csv = "id,name\n1,alice\n2,bob,extra\n3,carol\n"
+		db, err := openWithPolicy(t, csv, FileTypeCSV, MalformedRowSkip)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer db.Close()
+		count := queryColumn(t, db, `SELECT COUNT(*) FROM t`)
+		if count[0] != "2" {
+			t.Fatalf("row count = %s, want 2", count[0])
+		}
+	})
+}
+
+func TestMalformedRowPolicy_Fill(t *testing.T) {
+	t.Parallel()
+
+	t.Run("short rows are padded with empty strings", func(t *testing.T) {
+		t.Parallel()
+		const csv = "id,name,zip\n1,alice,01234\n3,caro\n"
+		db, err := openWithPolicy(t, csv, FileTypeCSV, MalformedRowFill)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer db.Close()
+
+		// The missing zip of row 3 becomes an empty string, and every input row
+		// is retained.
+		zip := queryColumn(t, db, `SELECT COALESCE(zip, '') FROM t ORDER BY id`)
+		if len(zip) != 2 {
+			t.Fatalf("expected 2 rows, got %d (%v)", len(zip), zip)
+		}
+		if zip[1] != "" {
+			t.Fatalf("row 3 zip = %q, want empty string", zip[1])
+		}
+	})
+
+	t.Run("long rows are truncated to the header width", func(t *testing.T) {
+		t.Parallel()
+		const csv = "id,name\n1,alice\n2,bob,extra\n"
+		db, err := openWithPolicy(t, csv, FileTypeCSV, MalformedRowFill)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer db.Close()
+		names := queryColumn(t, db, `SELECT name FROM t ORDER BY id`)
+		if strings.Join(names, ",") != "alice,bob" {
+			t.Fatalf("names = %v, want [alice bob]", names)
+		}
+	})
+}
+
+func TestMalformedRowPolicy_TSV(t *testing.T) {
+	t.Parallel()
+
+	const tsv = "id\tname\tzip\n1\talice\t01234\n3\tcaro\n"
+
+	t.Run("stop aborts on a ragged TSV row", func(t *testing.T) {
+		t.Parallel()
+		db, err := openWithPolicy(t, tsv, FileTypeTSV, MalformedRowStop)
+		if db != nil {
+			defer db.Close()
+		}
+		if !errors.Is(err, ErrColumnMismatch) {
+			t.Fatalf("expected ErrColumnMismatch, got %v", err)
+		}
+	})
+
+	t.Run("skip drops the ragged TSV row", func(t *testing.T) {
+		t.Parallel()
+		db, err := openWithPolicy(t, tsv, FileTypeTSV, MalformedRowSkip)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer db.Close()
+		count := queryColumn(t, db, `SELECT COUNT(*) FROM t`)
+		if count[0] != "1" {
+			t.Fatalf("row count = %s, want 1", count[0])
+		}
+	})
+}
+
+// TestMalformedRowPolicy_WellFormedUnaffected is a metamorphic check: a file
+// with no ragged rows imports identically under every policy.
+func TestMalformedRowPolicy_WellFormedUnaffected(t *testing.T) {
+	t.Parallel()
+	const csv = "id,name\n1,alice\n2,bob\n3,carol\n"
+	for _, policy := range []MalformedRowPolicy{MalformedRowStop, MalformedRowSkip, MalformedRowFill} {
+		db, err := openWithPolicy(t, csv, FileTypeCSV, policy)
+		if err != nil {
+			t.Fatalf("policy %v: unexpected error: %v", policy, err)
+		}
+		names := queryColumn(t, db, `SELECT name FROM t ORDER BY id`)
+		_ = db.Close()
+		if strings.Join(names, ",") != "alice,bob,carol" {
+			t.Fatalf("policy %v: names = %v", policy, names)
+		}
+	}
+}

--- a/stream.go
+++ b/stream.go
@@ -35,7 +35,9 @@ func handleCloseError(closeFunc func() error) func() {
 	}
 }
 
-// newStreamingParser creates a new streaming parser
+// newStreamingParser creates a new streaming parser. The malformed-row policy
+// defaults to MalformedRowStop (the zero value); callers that need another
+// policy set the field after construction.
 func newStreamingParser(fileType FileType, tableName string, chunkSize int) *streamingParser {
 	return &streamingParser{
 		fileType:    fileType,
@@ -148,6 +150,9 @@ func (p *streamingParser) createDecompressedReader(reader io.Reader) (io.Reader,
 func (p *streamingParser) parseDelimitedStream(reader io.Reader, delimiter rune, fileTypeName string) (*table, error) {
 	csvReader := csv.NewReader(reader)
 	csvReader.Comma = delimiter
+	// Accept a variable field count so a ragged row is handled by the configured
+	// malformed-row policy instead of aborting the whole read.
+	csvReader.FieldsPerRecord = -1
 	records, err := csvReader.ReadAll()
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to read %s: %s", ErrParsing, fileTypeName, err.Error())
@@ -165,7 +170,14 @@ func (p *streamingParser) parseDelimitedStream(reader io.Reader, delimiter rune,
 
 	tablerecords := make([]Record, 0, len(records)-1)
 	for i := 1; i < len(records); i++ {
-		tablerecords = append(tablerecords, newRecord(records[i]))
+		record, skip, err := reconcileFieldCount(records[i], len(header), i, p.malformedRowPolicy)
+		if err != nil {
+			return nil, err
+		}
+		if skip {
+			continue
+		}
+		tablerecords = append(tablerecords, newRecord(record))
 	}
 
 	return newTable(p.tableName, header, tablerecords), nil
@@ -292,6 +304,9 @@ func (p *streamingParser) processDelimitedInChunks(reader io.Reader, processor c
 	if delimiter != csvDelimiter {
 		csvReader.Comma = delimiter
 	}
+	// Accept a variable field count from the reader so a ragged row is handled by
+	// the configured malformed-row policy instead of aborting the whole read.
+	csvReader.FieldsPerRecord = -1
 
 	// Read header first
 	headerrecord, err := csvReader.Read()
@@ -318,6 +333,7 @@ func (p *streamingParser) processDelimitedInChunks(reader io.Reader, processor c
 		chunkSize = DefaultRowsPerChunk
 	}
 
+	rowNum := 0
 	for {
 		record, err := csvReader.Read()
 		if err != nil {
@@ -325,6 +341,15 @@ func (p *streamingParser) processDelimitedInChunks(reader io.Reader, processor c
 				break
 			}
 			return fmt.Errorf("%w: failed to read %s record: %s", ErrParsing, fileTypeName, err.Error())
+		}
+		rowNum++
+
+		record, skip, err := reconcileFieldCount(record, len(header), rowNum, p.malformedRowPolicy)
+		if err != nil {
+			return err
+		}
+		if skip {
+			continue
 		}
 
 		chunkrecords = append(chunkrecords, newRecord(record))

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -33,6 +33,9 @@ type streamProcessor struct {
 	// caller-owned database, where last-wins replacement is the useful default)
 	// and left false for Open (fresh in-memory database, no collisions).
 	replaceExisting bool
+	// malformedRowPolicy controls how a CSV/TSV record whose field count differs
+	// from the header is handled. The zero value is MalformedRowStop.
+	malformedRowPolicy MalformedRowPolicy
 }
 
 // dropIfReplacing drops a same-named table when replaceExisting is set, so the
@@ -70,7 +73,10 @@ func (sp *streamProcessor) streamAllFilesToDatabase(ctx context.Context, db *sql
 		sp.logger.Debug("streaming file", "path", path, "index", i+1, "total", len(collectedPaths))
 		if err := sp.streamFileToDatabase(ctx, db, path); err != nil {
 			sp.logger.Error("failed to stream file", "path", path, "error", err)
-			return streamError(ErrParsing, "failed to stream file %s: %v", path, err)
+			// Wrap the underlying error with %w as well so a sentinel it carries
+			// (for example ErrColumnMismatch from the malformed-row policy) stays
+			// detectable with errors.Is alongside ErrParsing.
+			return streamError(ErrParsing, "failed to stream file %s: %w", path, err)
 		}
 	}
 	sp.logger.Info("completed file streaming", "file_count", len(collectedPaths))
@@ -88,7 +94,7 @@ func (sp *streamProcessor) streamAllReadersToDatabase(ctx context.Context, db *s
 		if err := sp.streamReaderToDatabase(ctx, db, ri); err != nil {
 			sp.closeReaderInput(ri)
 			sp.logger.Error("failed to stream reader", logKeyTable, ri.tableName, "error", err)
-			return streamError(ErrParsing, "failed to stream reader input for table '%s': %v", ri.tableName, err)
+			return streamError(ErrParsing, "failed to stream reader input for table '%s': %w", ri.tableName, err)
 		}
 		sp.closeReaderInput(ri)
 	}
@@ -271,6 +277,7 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db *sql.D
 
 	// Create streaming parser for chunked processing
 	parser := newStreamingParser(input.fileType, input.tableName, sp.chunkSize)
+	parser.malformedRowPolicy = sp.malformedRowPolicy
 
 	// Initialize the table schema (we need to peek at the first chunk to get headers)
 	var tableCreated bool
@@ -334,31 +341,18 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db *sql.D
 
 	// Handle header-only files: if no data chunks were processed, create empty table
 	if !tableCreated {
+		// A processing error here is terminal: the input was not merely a
+		// header-only file, so surface the error instead of masking it with an
+		// empty table. Masking would silently drop data (for example a CSV whose
+		// rows have a different field count than the header under the stop policy).
 		if err != nil {
-			// Preserve certain parsing errors that should not be converted to empty tables
-			if strings.Contains(err.Error(), "duplicate column name") ||
-				strings.Contains(err.Error(), "parse error") {
-				return err
-			}
-			// For completely empty files (only newlines), propagate error instead of creating empty table
-			if strings.Contains(err.Error(), "empty") {
-				return err
-			}
-			// For LTSV with no valid key:value pairs, propagate the error
-			if strings.Contains(err.Error(), "no valid LTSV") {
-				return err
-			}
+			return err
 		}
 
-		// For header-only files, try to create an empty table by parsing headers
+		// No error and no data chunk means a header-only file; create the empty table.
 		if createErr := sp.createEmptyTable(ctx, db, input); createErr != nil {
-			// If createEmptyTable also fails, this indicates a truly empty file
-			if err != nil {
-				return err // Return the original processing error
-			}
 			return fmt.Errorf("%w: failed to create empty table for header-only file: %s", ErrDatabaseOperation, createErr.Error())
 		}
-		err = nil // Clear any previous error since we handled the header-only case
 	}
 
 	// Clean up the prepared statement
@@ -466,6 +460,7 @@ func (sp *streamProcessor) insertChunkData(ctx context.Context, stmt *sql.Stmt, 
 func (sp *streamProcessor) createEmptyTable(ctx context.Context, db *sql.DB, input readerInput) error {
 	// Parse just the header to get column information
 	tempParser := newStreamingParser(input.fileType, input.tableName, 1)
+	tempParser.malformedRowPolicy = sp.malformedRowPolicy
 	tempTable, err := tempParser.parseFromReader(input.reader)
 	if err != nil {
 		// Check if this is a parsing error we should preserve (like duplicate columns)


### PR DESCRIPTION
## Summary

A CSV/TSV row whose field count differs from the header was reported by `encoding/csv` as a field-count error, which the streaming loader masked by creating an empty single-column table without surfacing the error. Both the malformed row and the well-formed rows read before it were silently dropped.

This adds `WithMalformedRowPolicy` so callers choose how a ragged row is handled:

- `MalformedRowStop` (default): abort the import with `ErrColumnMismatch` instead of masking the failure with an empty table.
- `MalformedRowSkip`: drop ragged rows and keep the well-formed ones.
- `MalformedRowFill`: pad short rows with empty strings and truncate long rows to the header width.

The delimited reader now sets `FieldsPerRecord = -1` and reconciles the field count itself, and the streaming loader propagates a terminal parse error instead of degrading to an empty table. The policy applies to delimited text only; XLSX, LTSV, Parquet, and JSON/JSONL have no per-row field-count mismatch.

## Behavior change

The default policy is stop, so a ragged CSV/TSV now fails the import with `ErrColumnMismatch` rather than producing an empty table. One existing edge-case test that asserted the old silent behavior for inconsistent row lengths was updated to expect the error.

## Tests

- New `malformed_row_test.go` covers stop/skip/fill across CSV and TSV, short and long rows, the default policy, and a metamorphic check that a well-formed file imports identically under every policy.
- Full suite and golangci-lint are green.

Ref: https://github.com/nao1215/sqly/issues/731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option for CSV/TSV imports to control how rows with too few or too many fields are handled: stop, skip, or fill.
  * You can now choose whether malformed rows abort the import, are ignored, or are adjusted to match the header.

* **Bug Fixes**
  * Fixed an issue where ragged CSV/TSV rows could be silently dropped and an empty table produced.
  * The default behavior now stops the import with an error when column counts do not match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->