### PR TITLE
fix(types): preserve leading zeros on zero-padded numeric codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **A zero-padded numeric code no longer loses its leading zeros on import.** Type inference classified a column as INTEGER when every value looked like an integer, so a ZIP code, product ID, or bank code such as `02134` was stored as `2134` and `00501` as `501`. An integer literal with a redundant leading zero (an optional sign, then a `0` followed by more digits) is now classified as TEXT, since both SQLite INTEGER and float64 would drop the leading zero. A lone `0` stays an integer, and a column that also contains a non-numeric value was already TEXT. (Ref [nao1215/sqly](https://github.com/nao1215/sqly))
+- **A zero-padded numeric code no longer loses its leading zeros on import.** Type inference classified a column as INTEGER when every value looked like an integer, so a ZIP code, product ID, or bank code such as `02134` was stored as `2134` and `00501` as `501`. An integer literal with a redundant leading zero (an optional sign, then a `0` followed by more digits) is now classified as TEXT, since both SQLite INTEGER and float64 would drop the leading zero. A lone `0` stays an integer, and a column that also contains a non-numeric value was already TEXT. (PR [#149](https://github.com/nao1215/filesql/pull/149), [eeb798e](https://github.com/nao1215/filesql/commit/eeb798e), Ref [nao1215/sqly](https://github.com/nao1215/sqly))
 
 ## [0.17.1] - 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A zero-padded numeric code no longer loses its leading zeros on import.** Type inference classified a column as INTEGER when every value looked like an integer, so a ZIP code, product ID, or bank code such as `02134` was stored as `2134` and `00501` as `501`. An integer literal with a redundant leading zero (an optional sign, then a `0` followed by more digits) is now classified as TEXT, since both SQLite INTEGER and float64 would drop the leading zero. A lone `0` stays an integer, and a column that also contains a non-numeric value was already TEXT. (Ref [nao1215/sqly](https://github.com/nao1215/sqly))
+
 ## [0.17.1] - 2026-07-06
 
 ### Fixed

--- a/column_zero_padded_test.go
+++ b/column_zero_padded_test.go
@@ -1,0 +1,105 @@
+package filesql
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsIntegerRejectsZeroPadded guards zero-padded codes such as ZIP codes and
+// product IDs: an integer literal with a redundant leading zero must not be
+// classified as an integer, because SQLite INTEGER would drop the leading zero
+// (for example "02134" -> 2134). A lone "0" is a normal integer.
+func TestIsIntegerRejectsZeroPadded(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"plain integer", "123", true},
+		{"lone zero stays integer", "0", true},
+		{"negative integer", "-42", true},
+		{"zero-padded code is not an integer", "007", false},
+		{"zip code is not an integer", "02134", false},
+		{"double zero is not an integer", "00", false},
+		{"signed zero-padded is not an integer", "-01", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isInteger(tt.value))
+		})
+	}
+}
+
+// TestIsFloatRejectsZeroPadded ensures a zero-padded integer literal does not
+// slip through to REAL either (float64 would render "007" as 7 too). A genuine
+// decimal keeps its float classification.
+func TestIsFloatRejectsZeroPadded(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"zero-padded code is not a float", "007", false},
+		{"zip code is not a float", "02134", false},
+		{"decimal stays float", "0.5", true},
+		{"plain integer stays float-parseable", "42", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, isFloat(tt.value))
+		})
+	}
+}
+
+// TestClassifyValueZeroPadded verifies a zero-padded code is classified as TEXT
+// while ordinary numbers keep their numeric types.
+func TestClassifyValueZeroPadded(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, columnTypeText, classifyValue("02134"))
+	require.Equal(t, columnTypeText, classifyValue("007"))
+	require.Equal(t, columnTypeInteger, classifyValue("0"))
+	require.Equal(t, columnTypeInteger, classifyValue("42"))
+	require.Equal(t, columnTypeReal, classifyValue("0.5"))
+}
+
+// TestInferColumnTypeZeroPadded verifies a column entirely made of zero-padded
+// codes is inferred as TEXT, so the leading zeros survive.
+func TestInferColumnTypeZeroPadded(t *testing.T) {
+	t.Parallel()
+
+	got := inferColumnType([]string{"02134", "00501", "10001"})
+	require.Equal(t, columnTypeText, got)
+}
+
+// TestOpenContextPreservesZeroPaddedCodes is the end-to-end regression test: a
+// column of zero-padded codes must round-trip through the loaded database as its
+// exact textual value, not an integer with the leading zeros stripped.
+func TestOpenContextPreservesZeroPaddedCodes(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	csvPath := filepath.Join(dir, "zips.csv")
+	content := "zip\n02134\n00501\n"
+	require.NoError(t, os.WriteFile(csvPath, []byte(content), 0600))
+
+	ctx := context.Background()
+	db, err := OpenContext(ctx, csvPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var got string
+	err = db.QueryRowContext(ctx, `SELECT zip FROM zips ORDER BY zip LIMIT 1`).Scan(&got)
+	require.NoError(t, err)
+	require.Equal(t, "00501", got)
+}

--- a/types.go
+++ b/types.go
@@ -624,8 +624,37 @@ func isInteger(value string) bool {
 		return false
 	}
 
+	// A zero-padded literal such as "007" or "02134" is not an integer: the
+	// leading zero is significant (ZIP codes, product IDs), and SQLite INTEGER
+	// would drop it. Preserve it as TEXT instead.
+	if isZeroPaddedIntegerLiteral(value) {
+		return false
+	}
+
 	_, err := strconv.ParseInt(value, 10, 64)
 	return err == nil
+}
+
+// isZeroPaddedIntegerLiteral reports whether value is an integer literal
+// (optional leading '+'/'-' followed solely by ASCII digits) with a redundant
+// leading zero, such as "007" or "02134". A leading zero is semantically
+// significant, and both SQLite INTEGER and float64 would drop it, so the only
+// lossless representation is TEXT. A lone "0" is a normal integer and is
+// excluded.
+func isZeroPaddedIntegerLiteral(value string) bool {
+	digits := value
+	if len(digits) > 0 && (digits[0] == '+' || digits[0] == '-') {
+		digits = digits[1:]
+	}
+	if len(digits) < 2 || digits[0] != '0' {
+		return false
+	}
+	for i := range len(digits) {
+		if digits[i] < '0' || digits[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // isFloat checks if a value is a float with optimized parsing
@@ -650,6 +679,12 @@ func isFloat(value string) bool {
 	// lossless representation is TEXT. Returning false here lets classifyValue
 	// fall through to columnTypeText and preserve the exact digits.
 	if isIntegerLiteralOverflowingInt64(value) {
+		return false
+	}
+
+	// A zero-padded integer literal ("007") is not a float either: float64 would
+	// drop the leading zero just as INTEGER does. Keep it as TEXT.
+	if isZeroPaddedIntegerLiteral(value) {
 		return false
 	}
 

--- a/types_test.go
+++ b/types_test.go
@@ -335,7 +335,7 @@ func TestInferColumnType(t *testing.T) {
 		},
 		{
 			name:     "zero values",
-			values:   []string{"0", "0.0", "000"},
+			values:   []string{"0", "0.0", "0"},
 			expected: columnTypeReal,
 		},
 		{


### PR DESCRIPTION
## Summary

Type inference classified a column as INTEGER whenever every value looked like an integer, so a zero-padded code lost its leading zeros on import: a ZIP code `02134` was stored as `2134` and `00501` as `501`. This is silent data corruption for ZIP codes, product IDs, bank codes, and other zero-padded identifiers.

## Changes

- `types.go`: add `isZeroPaddedIntegerLiteral`, and reject such literals in both `isInteger` and `isFloat` so a value like `02134` falls through to TEXT. A leading zero is significant, and both SQLite INTEGER and float64 would drop it.
- `column_zero_padded_test.go` (new): unit tests for `isInteger`, `isFloat`, `classifyValue`, and `inferColumnType`, plus an end-to-end `OpenContext` test that a ZIP column round-trips as its exact text.
- `types_test.go`: the existing "zero values" case used `000` to mean numeric zero; it now uses `0`, since `000` is intentionally TEXT under the new rule (the zero-padded behavior is covered in the new test file).

## Design Decisions

The rule mirrors the existing int64-overflow handling: an integer literal (optional sign, then digits) with a redundant leading zero can only be represented losslessly as TEXT, so it is excluded from both the integer and float classifiers rather than parsed numerically. A lone `0` is a normal integer and is excluded from the rule, and a column that already contains any non-numeric value was TEXT before this change. Only pure integer literals are affected; a genuine decimal such as `0.5` keeps its float type.

## Limitations

A zero-padded value inside an otherwise-decimal column (for example `00.5`) is still parsed as a float, since the leading zero on a decimal is far less commonly significant than on an integer code.