### PR TITLE
chore: release v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2026-07-06
+
 ### Fixed
 - **A zero-padded numeric code no longer loses its leading zeros on import.** Type inference classified a column as INTEGER when every value looked like an integer, so a ZIP code, product ID, or bank code such as `02134` was stored as `2134` and `00501` as `501`. An integer literal with a redundant leading zero (an optional sign, then a `0` followed by more digits) is now classified as TEXT, since both SQLite INTEGER and float64 would drop the leading zero. A lone `0` stays an integer, and a column that also contains a non-numeric value was already TEXT. (PR [#149](https://github.com/nao1215/filesql/pull/149), [eeb798e](https://github.com/nao1215/filesql/commit/eeb798e), Ref [nao1215/sqly](https://github.com/nao1215/sqly))
 
@@ -752,7 +754,8 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.17.1...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.17.2...HEAD
+[0.17.2]: https://github.com/nao1215/filesql/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/nao1215/filesql/compare/v0.17.0...v0.17.1
 [0.17.0]: https://github.com/nao1215/filesql/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/nao1215/filesql/compare/v0.15.0...v0.16.0


### PR DESCRIPTION
Release v0.17.2.

Preserves leading zeros on zero-padded numeric codes: an integer literal with a redundant leading zero (a ZIP code, product ID, or bank code such as 02134) is now classified as TEXT instead of INTEGER, so it no longer imports as 2134. See the CHANGELOG for details.

Merging this finalizes the CHANGELOG; the v0.17.2 tag is pushed after merge and the release workflow publishes from the tag.