### PR TITLE
test(examples): add tested API examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,63 @@ ACH (`.ach`) and Fedwire (`.fed`) support are experimental. They are useful for 
 
 ## Examples
 
+### API example index
+
+The GoDoc examples are fully tested with `go test`. The tables below show the fastest path from a feature name in the README to the exact example function in the repo.
+
+#### filesql
+
+| Feature | Example function | Source |
+|---------|------------------|--------|
+| Open files and query them | `ExampleOpen`, `ExampleOpenContext` | [example_api_test.go](./example_api_test.go), [example_test.go](./example_test.go) |
+| Load files into an existing `*sql.DB` | `ExampleLoadInto`, `ExampleDBBuilder_LoadInto` | [example_api_test.go](./example_api_test.go) |
+| Build from readers, paths, or embedded FS | `ExampleNewBuilder`, `ExampleDBBuilder_AddReader`, `ExampleDBBuilder_AddPath`, `ExampleDBBuilder_AddFS` | [example_test.go](./example_test.go) |
+| Tune chunked loading | `ExampleDBBuilder_SetDefaultChunkSize` | [example_api_test.go](./example_api_test.go) |
+| Handle malformed CSV/TSV rows | `ExampleDBBuilder_WithMalformedRowPolicy` | [example_api_test.go](./example_api_test.go) |
+| Attach your own logger | `ExampleDBBuilder_WithLogger`, `ExampleNewSlogAdapter` | [example_api_test.go](./example_api_test.go) |
+| Open a read-only wrapper | `ExampleDBBuilder_OpenReadOnly` | [example_api_test.go](./example_api_test.go) |
+| Save on close or commit | `ExampleDBBuilder_EnableAutoSave`, `ExampleDBBuilder_EnableAutoSaveOnCommit`, `ExampleDBBuilder_DisableAutoSave` | [example_api_test.go](./example_api_test.go), [example_test.go](./example_test.go) |
+| Export tables with format/compression options | `ExampleDumpDatabase`, `ExampleNewDumpOptions`, `ExampleDumpOptions_WithFormat`, `ExampleDumpOptions_WithCompression` | [example_api_test.go](./example_api_test.go), [example_test.go](./example_test.go) |
+| Work with compression helpers directly | `ExampleNewCompressionHandler`, `ExampleNewCompressionFactory`, `ExampleCompressionFactory_DetectCompressionType` | [example_api_test.go](./example_api_test.go) |
+| Strip compression suffixes and inspect file types | `ExampleCompressionFactory_RemoveCompressionExtension`, `ExampleCompressionFactory_GetBaseFileType` | [example_api_test.go](./example_api_test.go) |
+| Build contextual errors | `ExampleNewErrorContext`, `ExampleMalformedRowPolicy_String` | [example_api_test.go](./example_api_test.go) |
+
+#### prep
+
+| Feature | Example function | Source |
+|---------|------------------|--------|
+| Strict tag parsing for invalid prep/validate tags | `ExampleWithStrictTagParsing` | [prep/example_api_test.go](./prep/example_api_test.go) |
+| Keep only valid rows in the output stream | `ExampleWithValidRowsOnly` | [prep/example_api_test.go](./prep/example_api_test.go) |
+| Clean CSV data into structs and a reusable reader | `ExampleProcessor_Process` | [prep/example_api_test.go](./prep/example_api_test.go) |
+| Convert JSON arrays into JSONL output | `ExampleProcessor_Process_json` | [prep/example_api_test.go](./prep/example_api_test.go) |
+| Stream cleaned output into any writer | `ExampleProcessor_ProcessToWriter` | [prep/example_api_test.go](./prep/example_api_test.go) |
+| Inspect validation counts | `ExampleProcessResult_InvalidRowCount`, `ExampleProcessResult_HasErrors` | [prep/example_api_test.go](./prep/example_api_test.go) |
+| Read validation error details | `ExampleProcessResult_ValidationErrors` | [prep/example_api_test.go](./prep/example_api_test.go) |
+| Read preprocessing error details | `ExampleProcessResult_PrepErrors` | [prep/example_api_test.go](./prep/example_api_test.go) |
+| Detect compressed inputs | `ExampleIsCompressed`, `Example_detectFileType` | [prep/example_api_test.go](./prep/example_api_test.go), [prep/example_test.go](./prep/example_test.go) |
+| Check output and original formats | `ExampleStream_Format`, `ExampleStream_OriginalFormat` | [prep/example_api_test.go](./prep/example_api_test.go) |
+| Rewind and reread the processed stream | `Example_streamLen`, `Example_streamSeek` | [prep/example_api_test.go](./prep/example_api_test.go) |
+
+#### frame
+
+| Feature | Example function | Source |
+|---------|------------------|--------|
+| Create a DataFrame from a reader or path | `ExampleNewDataFrame`, `ExampleNewDataFrameFromPath` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Build a DataFrame directly from Go records | `ExampleNewDataFrameFromRecords` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Write transformed data back to CSV or TSV | `ExampleDataFrame_ToCSV`, `ExampleDataFrame_ToTSV` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Select, filter, and mutate rows | `ExampleDataFrame_Select`, `ExampleDataFrame_Filter`, `ExampleDataFrame_Mutate` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Join in-memory tables | `ExampleDataFrame_Join` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Append frames with matching or mixed schemas | `ExampleDataFrame_Concat`, `ExampleConcatAll` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Group rows for aggregation | `ExampleDataFrame_GroupBy`, `ExampleGroupedDataFrame_Count` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Run built-in or custom aggregations | `ExampleGroupedDataFrame_Sum`, `ExampleGroupedDataFrame_Agg` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Sort by one or multiple columns | `ExampleDataFrame_Sort`, `ExampleDataFrame_SortBy` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Remove duplicates by key columns | `ExampleDataFrame_DistinctBy` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Keep only the first rows | `ExampleDataFrame_Head` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Rename columns in bulk | `ExampleDataFrame_RenameColumns` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Fill or drop missing values | `ExampleDataFrame_FillNAByColumn`, `ExampleDataFrame_DropNASubset` | [frame/example_api_test.go](./frame/example_api_test.go) |
+
+### Integration examples
+
 The [examples](./examples) directory shows how to use filesql with regular Go database tooling:
 
 | Example | Description |

--- a/example_api_test.go
+++ b/example_api_test.go
@@ -1,4 +1,3 @@
-//nolint:gosec // Example files use simplified temporary file handling for clarity.
 package filesql_test
 
 import (
@@ -47,14 +46,6 @@ func createFilesqlExampleDir(files map[string]string) string {
 	return dir
 }
 
-func readExampleFile(path string) string {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		log.Fatal(err)
-	}
-	return strings.TrimSpace(string(data))
-}
-
 func openExampleSQLiteDB() *sql.DB {
 	db, err := sql.Open("sqlite", ":memory:")
 	if err != nil {
@@ -77,22 +68,24 @@ id,name
 	db := openExampleSQLiteDB()
 	defer db.Close()
 
-	if _, err := db.Exec(`CREATE TABLE notes (body TEXT)`); err != nil {
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE notes (body TEXT)`); err != nil {
 		log.Fatal(err)
 	}
-	if _, err := db.Exec(`INSERT INTO notes VALUES ('kept')`); err != nil {
+	if _, err := db.ExecContext(ctx, `INSERT INTO notes VALUES ('kept')`); err != nil {
 		log.Fatal(err)
 	}
 
-	if err := filesql.LoadInto(context.Background(), db, filepath.Join(dir, "users.csv")); err != nil {
+	if err := filesql.LoadInto(ctx, db, filepath.Join(dir, "users.csv")); err != nil {
 		log.Fatal(err)
 	}
 
 	var users, notes int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&users); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&users); err != nil {
 		log.Fatal(err)
 	}
-	if err := db.QueryRow(`SELECT COUNT(*) FROM notes`).Scan(&notes); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM notes`).Scan(&notes); err != nil {
 		log.Fatal(err)
 	}
 
@@ -117,8 +110,9 @@ func ExampleDBBuilder_SetDefaultChunkSize() {
 	}
 	defer db.Close()
 
+	ctx := context.Background()
 	var rows int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&rows); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&rows); err != nil {
 		log.Fatal(err)
 	}
 
@@ -144,8 +138,9 @@ func ExampleDBBuilder_WithMalformedRowPolicy() {
 	}
 	defer db.Close()
 
+	ctx := context.Background()
 	var rows int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&rows); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&rows); err != nil {
 		log.Fatal(err)
 	}
 
@@ -201,7 +196,8 @@ id,name
 	if err != nil {
 		log.Fatal(err)
 	}
-	if _, err := db.Exec(`INSERT INTO users VALUES (2, 'Bob')`); err != nil {
+	ctx := context.Background()
+	if _, err := db.ExecContext(ctx, `INSERT INTO users VALUES (2, 'Bob')`); err != nil {
 		log.Fatal(err)
 	}
 	if err := db.Close(); err != nil {
@@ -243,10 +239,12 @@ func ExampleDBBuilder_LoadInto() {
 	db := openExampleSQLiteDB()
 	defer db.Close()
 
-	if _, err := db.Exec(`CREATE TABLE notes (body TEXT)`); err != nil {
+	ctx := context.Background()
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE notes (body TEXT)`); err != nil {
 		log.Fatal(err)
 	}
-	if _, err := db.Exec(`INSERT INTO notes VALUES ('ready')`); err != nil {
+	if _, err := db.ExecContext(ctx, `INSERT INTO notes VALUES ('ready')`); err != nil {
 		log.Fatal(err)
 	}
 
@@ -257,15 +255,15 @@ func ExampleDBBuilder_LoadInto() {
 		log.Fatal(err)
 	}
 
-	if err := validated.LoadInto(context.Background(), db); err != nil {
+	if err := validated.LoadInto(ctx, db); err != nil {
 		log.Fatal(err)
 	}
 
 	var users, notes int
-	if err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&users); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM users`).Scan(&users); err != nil {
 		log.Fatal(err)
 	}
-	if err := db.QueryRow(`SELECT COUNT(*) FROM notes`).Scan(&notes); err != nil {
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM notes`).Scan(&notes); err != nil {
 		log.Fatal(err)
 	}
 

--- a/example_api_test.go
+++ b/example_api_test.go
@@ -1,0 +1,402 @@
+//nolint:gosec // Example files use simplified temporary file handling for clarity.
+package filesql_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nao1215/filesql"
+	_ "modernc.org/sqlite"
+)
+
+type exampleLogger struct {
+	messages []string
+}
+
+func (l *exampleLogger) Debug(msg string, _ ...any) { l.messages = append(l.messages, msg) }
+func (l *exampleLogger) Info(msg string, _ ...any)  { l.messages = append(l.messages, msg) }
+func (l *exampleLogger) Warn(msg string, _ ...any)  { l.messages = append(l.messages, msg) }
+func (l *exampleLogger) Error(msg string, _ ...any) { l.messages = append(l.messages, msg) }
+func (l *exampleLogger) With(_ ...any) filesql.Logger {
+	return l
+}
+
+func createFilesqlExampleDir(files map[string]string) string {
+	dir, err := os.MkdirTemp("", "filesql-api-example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for name, body := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+			log.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(strings.TrimLeft(body, "\n")), 0600); err != nil {
+			log.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func readExampleFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func openExampleSQLiteDB() *sql.DB {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		log.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	return db
+}
+
+func ExampleLoadInto() {
+	dir := createFilesqlExampleDir(map[string]string{
+		"users.csv": `
+id,name
+1,Alice
+2,Bob
+`,
+	})
+	defer os.RemoveAll(dir)
+
+	db := openExampleSQLiteDB()
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE notes (body TEXT)`); err != nil {
+		log.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO notes VALUES ('kept')`); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := filesql.LoadInto(context.Background(), db, filepath.Join(dir, "users.csv")); err != nil {
+		log.Fatal(err)
+	}
+
+	var users, notes int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&users); err != nil {
+		log.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM notes`).Scan(&notes); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("users=%d notes=%d\n", users, notes)
+	// Output:
+	// users=2 notes=1
+}
+
+func ExampleDBBuilder_SetDefaultChunkSize() {
+	builder := filesql.NewBuilder().
+		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n3,Cora\n"), "users", filesql.FileTypeCSV).
+		SetDefaultChunkSize(2)
+
+	validated, err := builder.Build(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db, err := validated.Open(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	var rows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&rows); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("chunk=2 rows=%d\n", rows)
+	// Output:
+	// chunk=2 rows=3
+}
+
+func ExampleDBBuilder_WithMalformedRowPolicy() {
+	csvData := "id,name\n1,Alice\n2\n3,Cora,extra\n4,Dave\n"
+
+	validated, err := filesql.NewBuilder().
+		AddReader(strings.NewReader(csvData), "users", filesql.FileTypeCSV).
+		WithMalformedRowPolicy(filesql.MalformedRowSkip).
+		Build(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db, err := validated.Open(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	var rows int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&rows); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("loaded rows=%d\n", rows)
+	// Output:
+	// loaded rows=2
+}
+
+func ExampleDBBuilder_WithLogger() {
+	recorder := &exampleLogger{}
+
+	validated, err := filesql.NewBuilder().
+		WithLogger(recorder).
+		AddReader(strings.NewReader("id,name\n1,Alice\n"), "users", filesql.FileTypeCSV).
+		Build(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db, err := validated.Open(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	fmt.Println(recorder.messages[0])
+	fmt.Println(recorder.messages[len(recorder.messages)-1])
+	// Output:
+	// starting build
+	// database opened successfully
+}
+
+func ExampleDBBuilder_DisableAutoSave() {
+	dir := createFilesqlExampleDir(map[string]string{
+		"users.csv": `
+id,name
+1,Alice
+`,
+	})
+	defer os.RemoveAll(dir)
+
+	outputDir := filepath.Join(dir, "backup")
+	validated, err := filesql.NewBuilder().
+		AddPath(filepath.Join(dir, "users.csv")).
+		EnableAutoSave(outputDir).
+		DisableAutoSave().
+		Build(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db, err := validated.Open(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO users VALUES (2, 'Bob')`); err != nil {
+		log.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = os.Stat(filepath.Join(outputDir, "users.csv"))
+	fmt.Printf("autosaved=%t\n", err == nil)
+	// Output:
+	// autosaved=false
+}
+
+func ExampleDBBuilder_OpenReadOnly() {
+	validated, err := filesql.NewBuilder().
+		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", filesql.FileTypeCSV).
+		Build(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rodb, err := validated.OpenReadOnly(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rodb.Close()
+
+	var rows int
+	if err := rodb.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&rows); err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = rodb.Exec(`INSERT INTO users VALUES (3, 'Cora')`)
+	fmt.Printf("rows=%d write_blocked=%t\n", rows, errors.Is(err, filesql.ErrReadOnly))
+	// Output:
+	// rows=2 write_blocked=true
+}
+
+func ExampleDBBuilder_LoadInto() {
+	db := openExampleSQLiteDB()
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE notes (body TEXT)`); err != nil {
+		log.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO notes VALUES ('ready')`); err != nil {
+		log.Fatal(err)
+	}
+
+	validated, err := filesql.NewBuilder().
+		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", filesql.FileTypeCSV).
+		Build(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := validated.LoadInto(context.Background(), db); err != nil {
+		log.Fatal(err)
+	}
+
+	var users, notes int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM users`).Scan(&users); err != nil {
+		log.Fatal(err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM notes`).Scan(&notes); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("users=%d notes=%d\n", users, notes)
+	// Output:
+	// users=2 notes=1
+}
+
+func ExampleNewCompressionHandler() {
+	handler := filesql.NewCompressionHandler(filesql.CompressionGZ)
+
+	var compressed bytes.Buffer
+	writer, closeWriter, err := handler.CreateWriter(&compressed)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if _, err := io.WriteString(writer, "hello"); err != nil {
+		log.Fatal(err)
+	}
+	if err := closeWriter(); err != nil {
+		log.Fatal(err)
+	}
+
+	reader, closeReader, err := handler.CreateReader(bytes.NewReader(compressed.Bytes()))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer closeReader()
+
+	plain, err := io.ReadAll(reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(string(plain))
+	// Output:
+	// hello
+}
+
+func ExampleNewCompressionFactory() {
+	factory := filesql.NewCompressionFactory()
+	fmt.Println(factory.CreateHandlerForFile("orders.csv.zst").Extension())
+	// Output:
+	// .zst
+}
+
+func ExampleCompressionFactory_DetectCompressionType() {
+	factory := filesql.NewCompressionFactory()
+	fmt.Println(factory.DetectCompressionType("orders.csv.xz"))
+	// Output:
+	// xz
+}
+
+func ExampleCompressionFactory_RemoveCompressionExtension() {
+	factory := filesql.NewCompressionFactory()
+	fmt.Println(factory.RemoveCompressionExtension("orders.csv.gz"))
+	// Output:
+	// orders.csv
+}
+
+func ExampleCompressionFactory_GetBaseFileType() {
+	factory := filesql.NewCompressionFactory()
+	fmt.Println(factory.GetBaseFileType("orders.csv.gz"))
+	// Output:
+	// CSV
+}
+
+func ExampleNewDumpOptions() {
+	opts := filesql.NewDumpOptions()
+	fmt.Printf("%s %q\n", opts.Format, opts.FileExtension())
+	// Output:
+	// csv ".csv"
+}
+
+func ExampleDumpOptions_WithFormat() {
+	opts := filesql.NewDumpOptions().WithFormat(filesql.OutputFormatTSV)
+	fmt.Println(opts.FileExtension())
+	// Output:
+	// .tsv
+}
+
+func ExampleDumpOptions_WithCompression() {
+	opts := filesql.NewDumpOptions().WithCompression(filesql.CompressionGZ)
+	fmt.Println(opts.FileExtension())
+	// Output:
+	// .csv.gz
+}
+
+func ExampleOutputFormat_Extension() {
+	fmt.Println(filesql.OutputFormatParquet.Extension())
+	// Output:
+	// .parquet
+}
+
+func ExampleCompressionType_Extension() {
+	fmt.Println(filesql.CompressionXZ.Extension())
+	// Output:
+	// .xz
+}
+
+func ExampleNewErrorContext() {
+	err := filesql.NewErrorContext("import", "users.csv").
+		WithTable("users").
+		WithDetails("duplicate column").
+		Error(filesql.ErrDuplicateColumn)
+	fmt.Println(err)
+	// Output:
+	// filesql: import failed, file: users.csv, table: users, details: duplicate column: filesql: duplicate column name
+}
+
+func ExampleMalformedRowPolicy_String() {
+	fmt.Println(filesql.MalformedRowStop)
+	fmt.Println(filesql.MalformedRowSkip)
+	fmt.Println(filesql.MalformedRowFill)
+	// Output:
+	// stop
+	// skip
+	// fill
+}
+
+func ExampleNewSlogAdapter() {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{ReplaceAttr: func(_ []string, attr slog.Attr) slog.Attr {
+		if attr.Key == slog.TimeKey {
+			return slog.Attr{}
+		}
+		return attr
+	}}))
+
+	filesql.NewSlogAdapter(logger).Info("loaded", "rows", 2)
+	fmt.Println(strings.Contains(buf.String(), "loaded"))
+	// Output:
+	// true
+}

--- a/frame/example_api_test.go
+++ b/frame/example_api_test.go
@@ -131,7 +131,11 @@ func ExampleDataFrame_Filter() {
 	})
 
 	filtered := df.Filter(func(row map[string]any) bool {
-		return row["qty"].(int64) >= 2
+		qty, ok := row["qty"].(int64)
+		if !ok {
+			log.Fatalf("qty has type %T, want int64", row["qty"])
+		}
+		return qty >= 2
 	})
 
 	fmt.Println(filtered.ToRecords()[0]["name"])
@@ -145,7 +149,15 @@ func ExampleDataFrame_Mutate() {
 	})
 
 	withTotal := df.Mutate("total", func(row map[string]any) any {
-		return row["qty"].(int64) * row["price"].(int64)
+		qty, ok := row["qty"].(int64)
+		if !ok {
+			log.Fatalf("qty has type %T, want int64", row["qty"])
+		}
+		price, ok := row["price"].(int64)
+		if !ok {
+			log.Fatalf("price has type %T, want int64", row["price"])
+		}
+		return qty * price
 	})
 
 	fmt.Println(withTotal.ToRecords()[0]["total"])
@@ -263,17 +275,24 @@ func ExampleGroupedDataFrame_Agg() {
 	}
 
 	spread, err := grouped.Agg("sales", func(values []any) any {
-		min, max := values[0].(int), values[0].(int)
+		low, ok := values[0].(int)
+		if !ok {
+			log.Fatalf("sales has type %T, want int", values[0])
+		}
+		high := low
 		for _, value := range values[1:] {
-			n := value.(int)
-			if n < min {
-				min = n
+			n, ok := value.(int)
+			if !ok {
+				log.Fatalf("sales has type %T, want int", value)
 			}
-			if n > max {
-				max = n
+			if n < low {
+				low = n
+			}
+			if n > high {
+				high = n
 			}
 		}
-		return max - min
+		return high - low
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/frame/example_api_test.go
+++ b/frame/example_api_test.go
@@ -1,0 +1,419 @@
+//nolint:gosec // Example files use simplified temporary file handling for clarity.
+package frame_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nao1215/filesql/frame"
+)
+
+func createFrameExampleFile(body string) string {
+	dir, err := os.MkdirTemp("", "frame-example")
+	if err != nil {
+		log.Fatal(err)
+	}
+	path := filepath.Join(dir, "data.csv")
+	if err := os.WriteFile(path, []byte(strings.TrimLeft(body, "\n")), 0600); err != nil {
+		log.Fatal(err)
+	}
+	return path
+}
+
+func ExampleNewDataFrame() {
+	df, err := frame.NewDataFrame(strings.NewReader("name,qty\napple,3\nbanana,2\n"), frame.CSV)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%v %d\n", df.Columns(), df.Len())
+	// Output:
+	// [name qty] 2
+}
+
+func ExampleNewDataFrameFromPath() {
+	path := createFrameExampleFile("name,qty\napple,3\nbanana,2\n")
+	defer os.RemoveAll(filepath.Dir(path))
+
+	df, err := frame.NewDataFrameFromPath(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(df.Len())
+	// Output:
+	// 2
+}
+
+func ExampleNewDataFrameFromRecords() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"name": "apple", "qty": 3},
+		{"name": "banana", "qty": 2},
+	})
+
+	fmt.Println(df.Columns())
+	// Output:
+	// [name qty]
+}
+
+func ExampleDataFrame_ToCSV() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"name": "apple", "qty": 3},
+	})
+
+	dir, err := os.MkdirTemp("", "frame-csv")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "out.csv")
+	if err := df.ToCSV(path); err != nil {
+		log.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Print(string(data))
+	// Output:
+	// name,qty
+	// apple,3
+}
+
+func ExampleDataFrame_ToTSV() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"name": "apple", "qty": 3},
+	})
+
+	dir, err := os.MkdirTemp("", "frame-tsv")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "out.tsv")
+	if err := df.ToTSV(path); err != nil {
+		log.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Print(string(data))
+	// Output:
+	// name	qty
+	// apple	3
+}
+
+func ExampleDataFrame_Select() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"name": "apple", "qty": 3, "region": "north"},
+	})
+
+	selected := df.Select("name", "region")
+	fmt.Println(selected.Columns())
+	// Output:
+	// [name region]
+}
+
+func ExampleDataFrame_Filter() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"name": "apple", "qty": int64(3)},
+		{"name": "banana", "qty": int64(1)},
+	})
+
+	filtered := df.Filter(func(row map[string]any) bool {
+		return row["qty"].(int64) >= 2
+	})
+
+	fmt.Println(filtered.ToRecords()[0]["name"])
+	// Output:
+	// apple
+}
+
+func ExampleDataFrame_Mutate() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"product": "apple", "qty": int64(3), "price": int64(4)},
+	})
+
+	withTotal := df.Mutate("total", func(row map[string]any) any {
+		return row["qty"].(int64) * row["price"].(int64)
+	})
+
+	fmt.Println(withTotal.ToRecords()[0]["total"])
+	// Output:
+	// 12
+}
+
+func ExampleDataFrame_Join() {
+	users := frame.NewDataFrameFromRecords([]map[string]any{
+		{"user_id": 1, "name": "Alice"},
+		{"user_id": 2, "name": "Bob"},
+	})
+	orders := frame.NewDataFrameFromRecords([]map[string]any{
+		{"customer_id": 1, "item": "laptop"},
+	})
+
+	joined, err := users.Join(orders, frame.JoinOption{
+		On:  []string{"user_id", "customer_id"},
+		How: frame.LeftJoin,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	row := joined.ToRecords()[0]
+	fmt.Printf("%s %s\n", row["name"], row["item"])
+	// Output:
+	// Alice laptop
+}
+
+func ExampleDataFrame_Concat() {
+	jan := frame.NewDataFrameFromRecords([]map[string]any{
+		{"month": "Jan", "sales": 10},
+	})
+	feb := frame.NewDataFrameFromRecords([]map[string]any{
+		{"month": "Feb", "sales": 12},
+	})
+	mar := frame.NewDataFrameFromRecords([]map[string]any{
+		{"month": "Mar", "sales": 14},
+	})
+
+	all, err := jan.Concat(feb, mar)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(all.Len())
+	// Output:
+	// 3
+}
+
+func ExampleConcatAll() {
+	users := frame.NewDataFrameFromRecords([]map[string]any{
+		{"name": "Alice", "age": 30},
+	})
+	offices := frame.NewDataFrameFromRecords([]map[string]any{
+		{"name": "Bob", "city": "Tokyo"},
+	})
+
+	combined, err := frame.ConcatAll(users, offices)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%v %d\n", combined.Columns(), combined.Len())
+	// Output:
+	// [age city name] 2
+}
+
+func ExampleDataFrame_GroupBy() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"region": "east", "sales": 10},
+		{"region": "east", "sales": 20},
+		{"region": "west", "sales": 15},
+	})
+
+	grouped, err := df.GroupBy("region")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(grouped.Count().Len())
+	// Output:
+	// 2
+}
+
+func ExampleGroupedDataFrame_Count() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"region": "east", "sales": 10},
+		{"region": "east", "sales": 20},
+		{"region": "west", "sales": 15},
+	})
+
+	grouped, err := df.GroupBy("region")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	row := grouped.Count().ToRecords()[0]
+	fmt.Printf("%s %v\n", row["region"], row["count"])
+	// Output:
+	// east 2
+}
+
+func ExampleGroupedDataFrame_Agg() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"region": "east", "sales": 10},
+		{"region": "east", "sales": 20},
+		{"region": "west", "sales": 15},
+	})
+
+	grouped, err := df.GroupBy("region")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	spread, err := grouped.Agg("sales", func(values []any) any {
+		min, max := values[0].(int), values[0].(int)
+		for _, value := range values[1:] {
+			n := value.(int)
+			if n < min {
+				min = n
+			}
+			if n > max {
+				max = n
+			}
+		}
+		return max - min
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	row := spread.ToRecords()[0]
+	fmt.Printf("%s %v\n", row["region"], row["agg_sales"])
+	// Output:
+	// east 10
+}
+
+func ExampleGroupedDataFrame_Sum() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"region": "east", "sales": 10},
+		{"region": "east", "sales": 20},
+		{"region": "west", "sales": 15},
+	})
+
+	grouped, err := df.GroupBy("region")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sum, err := grouped.Sum("sales")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	row := sum.ToRecords()[0]
+	fmt.Printf("%s %.0f\n", row["region"], row["sum_sales"])
+	// Output:
+	// east 30
+}
+
+func ExampleDataFrame_Sort() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"product": "banana", "qty": int64(1)},
+		{"product": "apple", "qty": int64(3)},
+	})
+
+	sorted, err := df.Sort("qty", frame.Descending)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(sorted.ToRecords()[0]["product"])
+	// Output:
+	// apple
+}
+
+func ExampleDataFrame_SortBy() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"category": "fruit", "product": "banana", "qty": int64(1)},
+		{"category": "fruit", "product": "apple", "qty": int64(3)},
+		{"category": "vegetable", "product": "carrot", "qty": int64(2)},
+	})
+
+	sorted, err := df.SortBy(
+		frame.SortOption{Column: "category", Order: frame.Ascending},
+		frame.SortOption{Column: "qty", Order: frame.Descending},
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	row := sorted.ToRecords()[0]
+	fmt.Printf("%s %s\n", row["category"], row["product"])
+	// Output:
+	// fruit apple
+}
+
+func ExampleDataFrame_DistinctBy() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"email": "alice@example.com", "team": "east"},
+		{"email": "alice@example.com", "team": "west"},
+		{"email": "bob@example.com", "team": "east"},
+	})
+
+	fmt.Println(df.DistinctBy("email").Len())
+	// Output:
+	// 2
+}
+
+func ExampleDataFrame_Head() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"name": "Alice"},
+		{"name": "Bob"},
+		{"name": "Cora"},
+	})
+
+	head := df.Head(2)
+	fmt.Printf("%d %s\n", head.Len(), head.ToRecords()[0]["name"])
+	// Output:
+	// 2 Alice
+}
+
+func ExampleDataFrame_RenameColumns() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"name": "apple", "qty": 3},
+	})
+
+	renamed, err := df.RenameColumns(map[string]string{
+		"name": "product",
+		"qty":  "units",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(renamed.Columns())
+	// Output:
+	// [product units]
+}
+
+func ExampleDataFrame_FillNAByColumn() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"task": "import", "status": nil, "owner": "alice"},
+		{"task": "review", "status": "done", "owner": nil},
+	})
+
+	filled := df.FillNAByColumn(map[string]any{
+		"status": "pending",
+		"owner":  "unassigned",
+	})
+
+	rows := filled.ToRecords()
+	fmt.Printf("%s %s\n", rows[0]["status"], rows[1]["owner"])
+	// Output:
+	// pending unassigned
+}
+
+func ExampleDataFrame_DropNASubset() {
+	df := frame.NewDataFrameFromRecords([]map[string]any{
+		{"name": "Alice", "email": "alice@example.com"},
+		{"name": "Bob", "email": ""},
+		{"name": "Cora", "email": "cora@example.com"},
+	})
+
+	cleaned := df.DropNASubset("email")
+	fmt.Println(cleaned.Len())
+	// Output:
+	// 2
+}

--- a/prep/example_api_test.go
+++ b/prep/example_api_test.go
@@ -217,7 +217,10 @@ func ExampleStream_Format() {
 		log.Fatal(err)
 	}
 
-	stream := reader.(prep.Stream)
+	stream, ok := reader.(prep.Stream)
+	if !ok {
+		log.Fatalf("reader has type %T, want prep.Stream", reader)
+	}
 	fmt.Println(stream.Format())
 	// Output:
 	// CSV
@@ -236,7 +239,10 @@ func ExampleStream_OriginalFormat() {
 		log.Fatal(err)
 	}
 
-	stream := reader.(prep.Stream)
+	stream, ok := reader.(prep.Stream)
+	if !ok {
+		log.Fatalf("reader has type %T, want prep.Stream", reader)
+	}
 	fmt.Printf("output=%s original=%s\n", stream.Format(), stream.OriginalFormat())
 	// Output:
 	// output=JSONL original=JSON
@@ -255,10 +261,13 @@ func Example_streamLen() {
 		log.Fatal(err)
 	}
 
-	stream := reader.(interface {
+	stream, ok := reader.(interface {
 		prep.Stream
 		Len() int
 	})
+	if !ok {
+		log.Fatalf("reader has type %T, want prep.Stream with Len", reader)
+	}
 	fmt.Println(stream.Len() > 0)
 	// Output:
 	// true
@@ -277,10 +286,13 @@ func Example_streamSeek() {
 		log.Fatal(err)
 	}
 
-	stream := reader.(interface {
+	stream, ok := reader.(interface {
 		prep.Stream
 		io.Seeker
 	})
+	if !ok {
+		log.Fatalf("reader has type %T, want prep.Stream with io.Seeker", reader)
+	}
 	buf := make([]byte, 4)
 	if _, err := io.ReadFull(stream, buf); err != nil {
 		log.Fatal(err)

--- a/prep/example_api_test.go
+++ b/prep/example_api_test.go
@@ -1,0 +1,300 @@
+package prep_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/nao1215/filesql/prep"
+)
+
+func ExampleWithStrictTagParsing() {
+	type record struct {
+		Value string `validate:"eq=abc"`
+	}
+
+	processor := prep.NewProcessor(prep.FileTypeCSV, prep.WithStrictTagParsing())
+	var records []record
+
+	_, _, err := processor.Process(strings.NewReader("value\ntest\n"), &records)
+	fmt.Println(errors.Is(err, prep.ErrInvalidTagFormat))
+	// Output:
+	// true
+}
+
+func ExampleWithValidRowsOnly() {
+	type user struct {
+		Name  string `prep:"trim" validate:"required"`
+		Email string `prep:"trim,lowercase" validate:"required,email"`
+	}
+
+	csvData := "name,email\n Alice ,ALICE@EXAMPLE.COM\n,bad-email\n Bob ,BOB@EXAMPLE.COM\n"
+	processor := prep.NewProcessor(prep.FileTypeCSV, prep.WithValidRowsOnly())
+	var users []user
+
+	reader, result, err := processor.Process(strings.NewReader(csvData), &users)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("valid=%d invalid=%d\n", result.ValidRowCount, result.InvalidRowCount())
+	fmt.Print(string(output))
+	// Output:
+	// valid=2 invalid=1
+	// name,email
+	// Alice,alice@example.com
+	// Bob,bob@example.com
+}
+
+func ExampleProcessor_Process() {
+	type user struct {
+		Name  string `prep:"trim" validate:"required"`
+		Email string `prep:"trim,lowercase" validate:"required,email"`
+	}
+
+	processor := prep.NewProcessor(prep.FileTypeCSV)
+	var users []user
+
+	reader, result, err := processor.Process(strings.NewReader("name,email\n Alice ,ALICE@EXAMPLE.COM\n"), &users)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%s %d\n", users[0].Email, result.ValidRowCount)
+	fmt.Print(string(output))
+	// Output:
+	// alice@example.com 1
+	// name,email
+	// Alice,alice@example.com
+}
+
+func ExampleProcessor_Process_json() {
+	type record struct {
+		Data string `name:"data" prep:"trim"`
+	}
+
+	jsonData := `[{"id":1},{"id":2}]`
+	processor := prep.NewProcessor(prep.FileTypeJSON)
+	var records []record
+
+	reader, result, err := processor.Process(strings.NewReader(jsonData), &records)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("rows=%d format=%q\n", result.RowCount, string(output))
+	// Output:
+	// rows=2 format="{\"id\":1}\n{\"id\":2}\n"
+}
+
+func ExampleProcessor_ProcessToWriter() {
+	type user struct {
+		Name string `prep:"trim"`
+	}
+
+	processor := prep.NewProcessor(prep.FileTypeCSV)
+	var users []user
+	var buf bytes.Buffer
+
+	result, err := processor.ProcessToWriter(strings.NewReader("name\n Alice \n"), &users, &buf)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("valid=%d output=%q\n", result.ValidRowCount, buf.String())
+	// Output:
+	// valid=1 output="name\nAlice\n"
+}
+
+func ExampleProcessResult_InvalidRowCount() {
+	type user struct {
+		Email string `validate:"email"`
+	}
+
+	processor := prep.NewProcessor(prep.FileTypeCSV)
+	var users []user
+
+	_, result, err := processor.Process(strings.NewReader("email\nbad\nok@example.com\n"), &users)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(result.InvalidRowCount())
+	// Output:
+	// 1
+}
+
+func ExampleProcessResult_HasErrors() {
+	type user struct {
+		Email string `validate:"email"`
+	}
+
+	processor := prep.NewProcessor(prep.FileTypeCSV)
+	var users []user
+
+	_, result, err := processor.Process(strings.NewReader("email\nnot-an-email\n"), &users)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(result.HasErrors())
+	// Output:
+	// true
+}
+
+func ExampleProcessResult_ValidationErrors() {
+	type user struct {
+		Email string `validate:"email"`
+	}
+
+	processor := prep.NewProcessor(prep.FileTypeCSV)
+	var users []user
+
+	_, result, err := processor.Process(strings.NewReader("email\nnot-an-email\n"), &users)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	validationErrors := result.ValidationErrors()
+	fmt.Printf("%s: %s\n", validationErrors[0].Column, validationErrors[0].Message)
+	// Output:
+	// email: value must be a valid email address
+}
+
+func ExampleProcessResult_PrepErrors() {
+	type record struct {
+		Data string `name:"data" prep:"nullify={}"`
+	}
+
+	processor := prep.NewProcessor(prep.FileTypeJSON)
+	var records []record
+
+	_, result, err := processor.Process(strings.NewReader(`[{}, {"id": 2}]`), &records)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	prepErrors := result.PrepErrors()
+	fmt.Printf("%s %d\n", prepErrors[0].Tag, result.ValidRowCount)
+	// Output:
+	// empty_json_data 1
+}
+
+func ExampleIsCompressed() {
+	fmt.Println(prep.IsCompressed(prep.DetectFileType("users.csv.gz")))
+	// Output:
+	// true
+}
+
+func ExampleStream_Format() {
+	type user struct {
+		Name string
+	}
+
+	processor := prep.NewProcessor(prep.FileTypeCSV)
+	var users []user
+
+	reader, _, err := processor.Process(strings.NewReader("name\nAlice\n"), &users)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	stream := reader.(prep.Stream)
+	fmt.Println(stream.Format())
+	// Output:
+	// CSV
+}
+
+func ExampleStream_OriginalFormat() {
+	type record struct {
+		Data string `name:"data"`
+	}
+
+	processor := prep.NewProcessor(prep.FileTypeJSON)
+	var records []record
+
+	reader, _, err := processor.Process(strings.NewReader(`[{"id":1}]`), &records)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	stream := reader.(prep.Stream)
+	fmt.Printf("output=%s original=%s\n", stream.Format(), stream.OriginalFormat())
+	// Output:
+	// output=JSONL original=JSON
+}
+
+func Example_streamLen() {
+	type user struct {
+		Name string
+	}
+
+	processor := prep.NewProcessor(prep.FileTypeCSV)
+	var users []user
+
+	reader, _, err := processor.Process(strings.NewReader("name\nAlice\n"), &users)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	stream := reader.(interface {
+		prep.Stream
+		Len() int
+	})
+	fmt.Println(stream.Len() > 0)
+	// Output:
+	// true
+}
+
+func Example_streamSeek() {
+	type user struct {
+		Name string
+	}
+
+	processor := prep.NewProcessor(prep.FileTypeCSV)
+	var users []user
+
+	reader, _, err := processor.Process(strings.NewReader("name\nAlice\n"), &users)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	stream := reader.(interface {
+		prep.Stream
+		io.Seeker
+	})
+	buf := make([]byte, 4)
+	if _, err := io.ReadFull(stream, buf); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(buf))
+
+	if _, err := stream.Seek(0, io.SeekStart); err != nil {
+		log.Fatal(err)
+	}
+	if _, err := io.ReadFull(stream, buf); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(buf))
+	// Output:
+	// name
+	// name
+}


### PR DESCRIPTION
## Summary
This PR adds a broad set of tested GoDoc examples across `filesql`, `prep`, and `frame` so users can find concrete usage patterns directly from package docs. It also adds a README index that links feature-by-feature to those examples instead of only listing integration demos.

## Changes
- add package-level API example suites for `filesql`, `prep`, and `frame`
- cover builder, load, dump, compression, validation, stream, dataframe, join, aggregation, and missing-value workflows with executable examples
- add a README example index that maps major features to exact example functions and source files
- verify the new examples with `go test ./...`

## Design Decisions
- keep the new examples small and API-scoped so they surface cleanly in GoDoc and are easier to scan than the existing end-to-end examples
- leave the existing integration examples in place and position the README index as the top-level discovery layer for both README and GoDoc users

## Limitations
- this PR focuses on discoverability and tested usage coverage; it does not change runtime behavior or add new library features
