### PR TITLE
feat(dialect): add dialect package skeleton for multi-dialect queries

### DIFF
--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -1,0 +1,123 @@
+package dialect
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// Dialect is a SQL dialect accepted at query time. The storage engine is always
+// SQLite; a Dialect only selects how a caller's query text is interpreted before
+// it reaches SQLite.
+type Dialect string
+
+const (
+	// SQLite is the native dialect. Translate returns the input unchanged.
+	SQLite Dialect = "sqlite"
+	// MySQL accepts MySQL query syntax.
+	MySQL Dialect = "mysql"
+	// PostgreSQL accepts PostgreSQL query syntax.
+	PostgreSQL Dialect = "postgresql"
+	// GoogleSQL accepts GoogleSQL (BigQuery / Cloud Spanner) query syntax.
+	GoogleSQL Dialect = "googlesql"
+)
+
+// Sentinel errors returned by this package. Use errors.Is to check for them.
+var (
+	// ErrUnknownDialect indicates a dialect name that does not map to a built-in
+	// dialect and has no registered translator.
+	ErrUnknownDialect = errors.New("dialect: unknown SQL dialect")
+	// ErrUnsupportedSyntax indicates a construct that is valid in the source
+	// dialect but has no equivalent on the SQLite backend.
+	ErrUnsupportedSyntax = errors.New("dialect: syntax not supported on SQLite backend")
+	// ErrInvalidSyntax indicates the query could not be tokenized (for example an
+	// unterminated string or identifier).
+	ErrInvalidSyntax = errors.New("dialect: invalid SQL syntax")
+)
+
+// Dialects returns every built-in dialect in a stable order.
+func Dialects() []Dialect {
+	return []Dialect{SQLite, MySQL, PostgreSQL, GoogleSQL}
+}
+
+// Parse maps a user-supplied dialect name to a Dialect. Matching is
+// case-insensitive and ignores surrounding whitespace. Aliases are accepted:
+// "sqlite3" for SQLite; "postgres" and "pg" for PostgreSQL; "bigquery",
+// "spanner", and "zetasql" for GoogleSQL. An unrecognized name returns
+// ErrUnknownDialect.
+func Parse(name string) (Dialect, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case string(SQLite), "sqlite3":
+		return SQLite, nil
+	case string(MySQL):
+		return MySQL, nil
+	case string(PostgreSQL), "postgres", "pg":
+		return PostgreSQL, nil
+	case string(GoogleSQL), "bigquery", "spanner", "zetasql":
+		return GoogleSQL, nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrUnknownDialect, name)
+	}
+}
+
+// TranslatorFunc converts a single query written in some dialect into SQLite SQL.
+type TranslatorFunc func(query string) (string, error)
+
+var (
+	customMu    sync.RWMutex
+	customTrans = map[Dialect]TranslatorFunc{}
+)
+
+// RegisterTranslator installs a custom translator for name, replacing the
+// built-in translator if one exists. It is the extension point for future
+// parser-based translators. It is safe for concurrent use.
+func RegisterTranslator(name Dialect, fn TranslatorFunc) {
+	customMu.Lock()
+	defer customMu.Unlock()
+	if fn == nil {
+		delete(customTrans, name)
+		return
+	}
+	customTrans[name] = fn
+}
+
+func lookupTranslator(d Dialect) TranslatorFunc {
+	customMu.RLock()
+	defer customMu.RUnlock()
+	return customTrans[d]
+}
+
+// Translate converts a query written in dialect d into SQLite SQL. When d is
+// SQLite the input is returned unchanged. A custom translator registered with
+// RegisterTranslator takes precedence over the built-in one. Errors wrap
+// ErrUnsupportedSyntax, ErrInvalidSyntax, or ErrUnknownDialect.
+func Translate(d Dialect, query string) (string, error) {
+	if d == SQLite {
+		return query, nil
+	}
+	if fn := lookupTranslator(d); fn != nil {
+		return fn(query)
+	}
+	return builtinTranslate(d, query)
+}
+
+// builtinTranslate applies the built-in translation for a non-SQLite dialect:
+// tokenize with the dialect's lexical rules, then render back to SQLite SQL.
+// Dialect-specific token rewrite rules are applied between these two steps as
+// they are implemented; in this package's initial form there are none, so
+// translation normalizes lexical differences (identifier quoting, string
+// quoting, comment style) only.
+func builtinTranslate(d Dialect, query string) (string, error) {
+	cfg, ok := lexConfigFor(d)
+	if !ok {
+		return "", fmt.Errorf("%w: %q", ErrUnknownDialect, d)
+	}
+
+	tokens, err := tokenize(query, cfg)
+	if err != nil {
+		return "", err
+	}
+
+	return render(tokens), nil
+}

--- a/dialect/dialect_test.go
+++ b/dialect/dialect_test.go
@@ -1,0 +1,148 @@
+package dialect
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    Dialect
+		wantErr bool
+	}{
+		{"sqlite", "sqlite", SQLite, false},
+		{"sqlite3 alias", "sqlite3", SQLite, false},
+		{"mysql", "mysql", MySQL, false},
+		{"postgresql", "postgresql", PostgreSQL, false},
+		{"postgres alias", "postgres", PostgreSQL, false},
+		{"pg alias", "pg", PostgreSQL, false},
+		{"googlesql", "googlesql", GoogleSQL, false},
+		{"bigquery alias", "bigquery", GoogleSQL, false},
+		{"spanner alias", "spanner", GoogleSQL, false},
+		{"zetasql alias", "zetasql", GoogleSQL, false},
+		{"case insensitive", "MySQL", MySQL, false},
+		{"trims whitespace", "  postgres  ", PostgreSQL, false},
+		{"unknown", "oracle", "", true},
+		{"empty", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Parse(tt.input)
+			if tt.wantErr {
+				if !errors.Is(err, ErrUnknownDialect) {
+					t.Fatalf("Parse(%q) error = %v, want ErrUnknownDialect", tt.input, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Parse(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("Parse(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDialects(t *testing.T) {
+	t.Parallel()
+	got := Dialects()
+	want := []Dialect{SQLite, MySQL, PostgreSQL, GoogleSQL}
+	if len(got) != len(want) {
+		t.Fatalf("Dialects() len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Dialects()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestTranslateSQLiteIsIdentity(t *testing.T) {
+	t.Parallel()
+	// The SQLite dialect must never alter the query, including constructs the
+	// other dialects would rewrite (backticks, double-quoted strings, # comments).
+	inputs := []string{
+		"SELECT * FROM users WHERE age > 25",
+		"SELECT `weird` FROM t -- comment\n",
+		`SELECT "a" ` + "`b`" + ` FROM t`,
+		"SELECT 1; SELECT 2;",
+		"",
+	}
+	for _, in := range inputs {
+		got, err := Translate(SQLite, in)
+		if err != nil {
+			t.Fatalf("Translate(SQLite, %q) unexpected error: %v", in, err)
+		}
+		if got != in {
+			t.Fatalf("Translate(SQLite, %q) = %q, want identity", in, got)
+		}
+	}
+}
+
+func TestTranslateUnknownDialect(t *testing.T) {
+	t.Parallel()
+	_, err := Translate(Dialect("oracle"), "SELECT 1")
+	if !errors.Is(err, ErrUnknownDialect) {
+		t.Fatalf("Translate(oracle) error = %v, want ErrUnknownDialect", err)
+	}
+}
+
+func TestRegisterTranslator(t *testing.T) {
+	// Not parallel: mutates the process-global translator registry.
+	const custom = "CUSTOM OUTPUT"
+	RegisterTranslator(MySQL, func(string) (string, error) {
+		return custom, nil
+	})
+	t.Cleanup(func() { RegisterTranslator(MySQL, nil) })
+
+	got, err := Translate(MySQL, "anything at all")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != custom {
+		t.Fatalf("Translate(MySQL) = %q, want %q from custom translator", got, custom)
+	}
+
+	// Removing the custom translator restores the built-in behavior.
+	RegisterTranslator(MySQL, nil)
+	got, err = Translate(MySQL, "SELECT 1")
+	if err != nil {
+		t.Fatalf("unexpected error after removing translator: %v", err)
+	}
+	if got != "SELECT 1" {
+		t.Fatalf("Translate(MySQL, %q) = %q, want built-in result", "SELECT 1", got)
+	}
+}
+
+// TestTranslateIdempotent verifies that feeding a translated statement back
+// through the SQLite (identity) dialect leaves it unchanged, as guaranteed by
+// the package's idempotency invariant.
+func TestTranslateIdempotent(t *testing.T) {
+	t.Parallel()
+	inputs := []struct {
+		dialect Dialect
+		query   string
+	}{
+		{MySQL, "SELECT `id`, \"name\" FROM `users` # trailing\n"},
+		{PostgreSQL, `SELECT "col" FROM t WHERE x = E'a\nb'`},
+		{GoogleSQL, "SELECT `p.d.t`.x FROM `p.d.t` WHERE s = r'raw\\n'"},
+	}
+	for _, tc := range inputs {
+		out, err := Translate(tc.dialect, tc.query)
+		if err != nil {
+			t.Fatalf("Translate(%s, %q) error: %v", tc.dialect, tc.query, err)
+		}
+		again, err := Translate(SQLite, out)
+		if err != nil {
+			t.Fatalf("Translate(SQLite, %q) error: %v", out, err)
+		}
+		if again != out {
+			t.Fatalf("not idempotent: Translate(SQLite, %q) = %q", out, again)
+		}
+	}
+}

--- a/dialect/doc.go
+++ b/dialect/doc.go
@@ -1,0 +1,24 @@
+// Package dialect translates SQL written in a non-SQLite dialect (MySQL,
+// PostgreSQL, or GoogleSQL) into SQLite SQL so it can run against the SQLite
+// engine that backs filesql. Storage is always SQLite; only the query text a
+// caller supplies is translated.
+//
+// The translation is best-effort compatibility, not a full emulator. It handles
+// three classes of input:
+//
+//   - Known incompatibilities that have a SQLite equivalent are rewritten (for
+//     example MySQL's backtick identifiers become double-quoted identifiers, and
+//     PostgreSQL's "expr::type" becomes "CAST(expr AS type)").
+//   - Known constructs with no SQLite equivalent (QUALIFY, ARRAY/STRUCT types,
+//     LATERAL, DISTINCT ON, ...) are rejected with ErrUnsupportedSyntax so the
+//     caller sees a clear error instead of a confusing engine message.
+//   - Anything else is passed through unchanged and left to SQLite to accept or
+//     reject.
+//
+// Function gaps (NOW, DATE_FORMAT, TO_CHAR, SPLIT_PART, SAFE_DIVIDE, ...) are
+// filled by user-defined functions registered into the SQLite driver via
+// RegisterFunctions rather than by rewriting the SQL.
+//
+// The SQLite dialect is the identity translation: Translate returns the input
+// unchanged.
+package dialect

--- a/dialect/fuzz_test.go
+++ b/dialect/fuzz_test.go
@@ -1,0 +1,39 @@
+package dialect
+
+import "testing"
+
+// FuzzTranslate checks that translation never panics and that a successful
+// translation is stable under the SQLite identity dialect (its output feeds
+// back through Translate(SQLite, ...) unchanged), across every built-in dialect.
+func FuzzTranslate(f *testing.F) {
+	seeds := []string{
+		"SELECT * FROM t",
+		"SELECT `a`, \"b\" FROM `t` WHERE x = 'v'",
+		"SELECT a::int FROM t -- c",
+		"SELECT $$d$$, E'e\\n', $1",
+		"SELECT r'raw', b'AB', `p.d.t`.x # h",
+		"SELECT count(*) /* mid */ FROM t;",
+		"'unterminated",
+		"/* unterminated",
+		"",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, query string) {
+		for _, d := range Dialects() {
+			out, err := Translate(d, query)
+			if err != nil {
+				continue
+			}
+			again, err := Translate(SQLite, out)
+			if err != nil {
+				t.Fatalf("Translate(SQLite, %q) after Translate(%s): %v", out, d, err)
+			}
+			if again != out {
+				t.Fatalf("not idempotent for dialect %s: %q -> %q -> %q", d, query, out, again)
+			}
+		}
+	})
+}

--- a/dialect/render.go
+++ b/dialect/render.go
@@ -1,0 +1,49 @@
+package dialect
+
+import "strings"
+
+// render serializes tokens back into SQLite SQL. Quoted identifiers, strings,
+// and blobs are re-encoded in SQLite form (double-quoted identifiers,
+// single-quoted strings, x'..' blobs); every other token is written verbatim.
+// Whitespace runs collapse to a single space, and line comments are emitted with
+// a trailing newline so a following token can never be swallowed by the comment.
+func render(tokens []token) string {
+	var b strings.Builder
+	for _, t := range tokens {
+		switch t.kind {
+		case tokWhitespace:
+			b.WriteByte(' ')
+		case tokLineComment:
+			b.WriteString("--")
+			b.WriteString(t.text)
+			b.WriteByte('\n')
+		case tokBlockComment:
+			b.WriteString("/*")
+			b.WriteString(t.text)
+			b.WriteString("*/")
+		case tokQuotedIdent:
+			b.WriteString(quoteIdent(t.text))
+		case tokString:
+			b.WriteString(quoteString(t.text))
+		case tokBlob:
+			b.WriteString("x'")
+			b.WriteString(t.text)
+			b.WriteByte('\'')
+		case tokWord, tokNumber, tokOp, tokPlaceholder:
+			b.WriteString(t.text)
+		}
+	}
+	return b.String()
+}
+
+// quoteIdent renders name as a SQLite double-quoted identifier, doubling any
+// embedded double quote.
+func quoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// quoteString renders value as a SQLite single-quoted string literal, doubling
+// any embedded single quote.
+func quoteString(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}

--- a/dialect/token.go
+++ b/dialect/token.go
@@ -1,0 +1,421 @@
+package dialect
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// tokenKind classifies a lexical token. Rendering and rewrite rules branch on
+// the kind.
+type tokenKind int
+
+const (
+	tokWhitespace   tokenKind = iota // runs of spaces/tabs/newlines; rendered as a single space
+	tokLineComment                   // -- or # comment; text holds the content after the leader
+	tokBlockComment                  // /* ... */ comment; text holds the content between the delimiters
+	tokWord                          // unquoted identifier, keyword, or function name
+	tokNumber                        // numeric literal (rendered verbatim)
+	tokQuotedIdent                   // quoted identifier; text holds the decoded name
+	tokString                        // string literal; text holds the decoded content
+	tokBlob                          // blob/bytes literal; text holds lowercase hex
+	tokOp                            // operator or punctuation (rendered verbatim)
+	tokPlaceholder                   // bind placeholder such as ?, ?1, $1, @name, :name
+)
+
+// token is one lexical unit. offset is the byte offset of the token in the
+// source query and is used for error messages. The meaning of text depends on
+// kind: for tokString/tokQuotedIdent it is the decoded value (escapes resolved,
+// doubled quotes collapsed); for tokBlob it is lowercase hex; for the remaining
+// kinds it is the verbatim source text (tokWhitespace and the comment kinds hold
+// the content the renderer needs, not the surrounding delimiters).
+type token struct {
+	kind   tokenKind
+	text   string
+	offset int
+}
+
+// lexConfig describes the lexical rules that differ between dialects. The rest
+// of the grammar (single-quoted strings, blob literals, numbers, operators,
+// placeholders, /* */ and -- comments) is common to every dialect.
+type lexConfig struct {
+	identBacktick     bool // ` opens a quoted identifier (MySQL, GoogleSQL)
+	identDoubleQuote  bool // " opens a quoted identifier (PostgreSQL)
+	stringDoubleQuote bool // " opens a string literal (MySQL, GoogleSQL)
+	hashComment       bool // # starts a line comment (MySQL, GoogleSQL)
+	backslashEscapes  bool // backslash is an escape inside single-quoted strings (MySQL, GoogleSQL)
+	ePrefixString     bool // E'...' escape-string literals (PostgreSQL)
+	dollarQuote       bool // $tag$...$tag$ dollar-quoted strings (PostgreSQL)
+	rawStringPrefix   bool // r'...'/r"..." raw strings (GoogleSQL)
+	byteStringPrefix  bool // b'...'/b"..." byte strings (GoogleSQL)
+}
+
+// lexConfigFor returns the lexical configuration for a built-in non-SQLite
+// dialect. It reports false for SQLite (handled as identity before tokenizing)
+// and for any unknown dialect.
+func lexConfigFor(d Dialect) (lexConfig, bool) {
+	switch d {
+	case MySQL:
+		return lexConfig{
+			identBacktick:     true,
+			stringDoubleQuote: true,
+			hashComment:       true,
+			backslashEscapes:  true,
+		}, true
+	case PostgreSQL:
+		return lexConfig{
+			identDoubleQuote: true,
+			ePrefixString:    true,
+			dollarQuote:      true,
+		}, true
+	case GoogleSQL:
+		return lexConfig{
+			identBacktick:     true,
+			stringDoubleQuote: true,
+			hashComment:       true,
+			backslashEscapes:  true,
+			rawStringPrefix:   true,
+			byteStringPrefix:  true,
+		}, true
+	default:
+		return lexConfig{}, false
+	}
+}
+
+// tokenize splits query into tokens using cfg. It returns ErrInvalidSyntax
+// (wrapped, with the byte offset) when a quoted literal or identifier is not
+// terminated.
+func tokenize(query string, cfg lexConfig) ([]token, error) {
+	tokens := make([]token, 0, len(query)/4+1)
+	i := 0
+	for i < len(query) {
+		c := query[i]
+		start := i
+
+		switch {
+		case isSpace(c):
+			j := i + 1
+			for j < len(query) && isSpace(query[j]) {
+				j++
+			}
+			tokens = append(tokens, token{kind: tokWhitespace, text: query[i:j], offset: start})
+			i = j
+
+		case c == '-' && next(query, i) == '-':
+			j := i + 2
+			for j < len(query) && query[j] != '\n' {
+				j++
+			}
+			tokens = append(tokens, token{kind: tokLineComment, text: query[i+2 : j], offset: start})
+			i = j
+
+		case c == '#' && cfg.hashComment:
+			j := i + 1
+			for j < len(query) && query[j] != '\n' {
+				j++
+			}
+			tokens = append(tokens, token{kind: tokLineComment, text: query[i+1 : j], offset: start})
+			i = j
+
+		case c == '/' && next(query, i) == '*':
+			j := i + 2
+			for j+1 < len(query) && (query[j] != '*' || query[j+1] != '/') {
+				j++
+			}
+			if j+1 >= len(query) {
+				return nil, fmt.Errorf("%w: unterminated block comment at offset %d", ErrInvalidSyntax, start)
+			}
+			tokens = append(tokens, token{kind: tokBlockComment, text: query[i+2 : j], offset: start})
+			i = j + 2
+
+		case c == '\'':
+			content, ni, ok := scanQuoted(query, i, '\'', cfg.backslashEscapes)
+			if !ok {
+				return nil, fmt.Errorf("%w: unterminated string literal at offset %d", ErrInvalidSyntax, start)
+			}
+			tokens = append(tokens, token{kind: tokString, text: content, offset: start})
+			i = ni
+
+		case c == '"' && cfg.identDoubleQuote:
+			content, ni, ok := scanQuoted(query, i, '"', false)
+			if !ok {
+				return nil, fmt.Errorf("%w: unterminated quoted identifier at offset %d", ErrInvalidSyntax, start)
+			}
+			tokens = append(tokens, token{kind: tokQuotedIdent, text: content, offset: start})
+			i = ni
+
+		case c == '"' && cfg.stringDoubleQuote:
+			content, ni, ok := scanQuoted(query, i, '"', cfg.backslashEscapes)
+			if !ok {
+				return nil, fmt.Errorf("%w: unterminated string literal at offset %d", ErrInvalidSyntax, start)
+			}
+			tokens = append(tokens, token{kind: tokString, text: content, offset: start})
+			i = ni
+
+		case c == '`' && cfg.identBacktick:
+			content, ni, ok := scanQuoted(query, i, '`', false)
+			if !ok {
+				return nil, fmt.Errorf("%w: unterminated quoted identifier at offset %d", ErrInvalidSyntax, start)
+			}
+			tokens = append(tokens, token{kind: tokQuotedIdent, text: content, offset: start})
+			i = ni
+
+		case (c == 'x' || c == 'X') && next(query, i) == '\'':
+			content, ni, ok := scanQuoted(query, i+1, '\'', false)
+			if !ok {
+				return nil, fmt.Errorf("%w: unterminated blob literal at offset %d", ErrInvalidSyntax, start)
+			}
+			tokens = append(tokens, token{kind: tokBlob, text: strings.ToLower(content), offset: start})
+			i = ni
+
+		case cfg.ePrefixString && (c == 'e' || c == 'E') && next(query, i) == '\'':
+			content, ni, ok := scanQuoted(query, i+1, '\'', true)
+			if !ok {
+				return nil, fmt.Errorf("%w: unterminated string literal at offset %d", ErrInvalidSyntax, start)
+			}
+			tokens = append(tokens, token{kind: tokString, text: content, offset: start})
+			i = ni
+
+		case cfg.rawStringPrefix && (c == 'r' || c == 'R') && (next(query, i) == '\'' || next(query, i) == '"'):
+			content, ni, ok := scanQuoted(query, i+1, query[i+1], false)
+			if !ok {
+				return nil, fmt.Errorf("%w: unterminated raw string literal at offset %d", ErrInvalidSyntax, start)
+			}
+			tokens = append(tokens, token{kind: tokString, text: content, offset: start})
+			i = ni
+
+		case cfg.byteStringPrefix && (c == 'b' || c == 'B') && (next(query, i) == '\'' || next(query, i) == '"'):
+			content, ni, ok := scanQuoted(query, i+1, query[i+1], true)
+			if !ok {
+				return nil, fmt.Errorf("%w: unterminated byte string literal at offset %d", ErrInvalidSyntax, start)
+			}
+			tokens = append(tokens, token{kind: tokBlob, text: hex.EncodeToString([]byte(content)), offset: start})
+			i = ni
+
+		case cfg.dollarQuote && c == '$' && isDollarQuoteStart(query, i):
+			content, ni, ok := scanDollarQuoted(query, i)
+			if !ok {
+				return nil, fmt.Errorf("%w: unterminated dollar-quoted string at offset %d", ErrInvalidSyntax, start)
+			}
+			tokens = append(tokens, token{kind: tokString, text: content, offset: start})
+			i = ni
+
+		case c == '?':
+			j := i + 1
+			for j < len(query) && isDigit(query[j]) {
+				j++
+			}
+			tokens = append(tokens, token{kind: tokPlaceholder, text: query[i:j], offset: start})
+			i = j
+
+		case c == '$' && isDigit(next(query, i)):
+			j := i + 1
+			for j < len(query) && isDigit(query[j]) {
+				j++
+			}
+			tokens = append(tokens, token{kind: tokPlaceholder, text: query[i:j], offset: start})
+			i = j
+
+		case (c == '@' || c == ':') && isIdentStart(next(query, i)):
+			j := i + 1
+			for j < len(query) && isIdentPart(query[j]) {
+				j++
+			}
+			tokens = append(tokens, token{kind: tokPlaceholder, text: query[i:j], offset: start})
+			i = j
+
+		case isDigit(c) || (c == '.' && isDigit(next(query, i))):
+			j := scanNumber(query, i)
+			tokens = append(tokens, token{kind: tokNumber, text: query[i:j], offset: start})
+			i = j
+
+		case isIdentStart(c):
+			j := i + 1
+			for j < len(query) && isIdentPart(query[j]) {
+				j++
+			}
+			tokens = append(tokens, token{kind: tokWord, text: query[i:j], offset: start})
+			i = j
+
+		default:
+			op := matchOperator(query, i)
+			tokens = append(tokens, token{kind: tokOp, text: op, offset: start})
+			i += len(op)
+		}
+	}
+	return tokens, nil
+}
+
+// next returns the byte after position i, or 0 if i is the last byte.
+func next(s string, i int) byte {
+	if i+1 < len(s) {
+		return s[i+1]
+	}
+	return 0
+}
+
+// scanQuoted reads a quoted literal whose opening quote is at s[i]. The closing
+// quote is a matching quote that is not doubled; a doubled quote ("" or ”)
+// yields one literal quote. When honorBackslash is true a backslash escapes the
+// following byte. It returns the decoded content, the index just past the
+// closing quote, and whether a closing quote was found.
+func scanQuoted(s string, i int, quote byte, honorBackslash bool) (content string, ni int, ok bool) {
+	var b strings.Builder
+	i++ // skip opening quote
+	for i < len(s) {
+		c := s[i]
+		switch {
+		case c == quote:
+			if i+1 < len(s) && s[i+1] == quote {
+				b.WriteByte(quote)
+				i += 2
+				continue
+			}
+			return b.String(), i + 1, true
+		case honorBackslash && c == '\\' && i+1 < len(s):
+			esc, adv := decodeBackslash(s, i)
+			b.WriteString(esc)
+			i += adv
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	return "", i, false
+}
+
+// decodeBackslash decodes the escape sequence starting at s[i] (which is a
+// backslash). It returns the decoded text and the number of bytes consumed. An
+// unrecognized escape drops the backslash and keeps the following byte, matching
+// the lenient behavior of MySQL and GoogleSQL for unknown escapes.
+func decodeBackslash(s string, i int) (string, int) {
+	if i+1 >= len(s) {
+		return "\\", 1
+	}
+	switch s[i+1] {
+	case 'n':
+		return "\n", 2
+	case 't':
+		return "\t", 2
+	case 'r':
+		return "\r", 2
+	case '0':
+		return "\x00", 2
+	case 'b':
+		return "\b", 2
+	case 'f':
+		return "\f", 2
+	case 'v':
+		return "\v", 2
+	case '\\':
+		return "\\", 2
+	case '\'':
+		return "'", 2
+	case '"':
+		return "\"", 2
+	case '`':
+		return "`", 2
+	default:
+		return string(s[i+1]), 2
+	}
+}
+
+// isDollarQuoteStart reports whether a dollar-quoted string opens at s[i] (which
+// is a '$'). The tag between the dollars must be empty or an identifier.
+func isDollarQuoteStart(s string, i int) bool {
+	j := i + 1
+	for j < len(s) && isIdentPart(s[j]) {
+		j++
+	}
+	return j < len(s) && s[j] == '$'
+}
+
+// scanDollarQuoted reads a PostgreSQL dollar-quoted string ($tag$...$tag$)
+// starting at s[i]. The content is taken verbatim (no escape processing).
+func scanDollarQuoted(s string, i int) (content string, ni int, ok bool) {
+	j := i + 1
+	for j < len(s) && isIdentPart(s[j]) {
+		j++
+	}
+	// s[i:j+1] is the opening delimiter "$tag$".
+	delim := s[i : j+1]
+	rest := s[j+1:]
+	idx := strings.Index(rest, delim)
+	if idx < 0 {
+		return "", len(s), false
+	}
+	return rest[:idx], j + 1 + idx + len(delim), true
+}
+
+// scanNumber returns the index just past the numeric literal starting at s[i].
+// It handles hexadecimal (0x...), a fractional part, and a signed exponent.
+func scanNumber(s string, i int) int {
+	if s[i] == '0' && i+1 < len(s) && (s[i+1] == 'x' || s[i+1] == 'X') {
+		j := i + 2
+		for j < len(s) && isHex(s[j]) {
+			j++
+		}
+		return j
+	}
+	j := i
+	for j < len(s) && isDigit(s[j]) {
+		j++
+	}
+	if j < len(s) && s[j] == '.' {
+		j++
+		for j < len(s) && isDigit(s[j]) {
+			j++
+		}
+	}
+	if j < len(s) && (s[j] == 'e' || s[j] == 'E') {
+		k := j + 1
+		if k < len(s) && (s[k] == '+' || s[k] == '-') {
+			k++
+		}
+		if k < len(s) && isDigit(s[k]) {
+			j = k
+			for j < len(s) && isDigit(s[j]) {
+				j++
+			}
+		}
+	}
+	return j
+}
+
+// multiCharOperators lists the multi-byte operators to recognize as one token,
+// longest first so matchOperator prefers the longest match.
+var multiCharOperators = []string{
+	"!~*", "->>", "!~", "~*", "->", "<=", ">=", "<>", "!=", "||", "<<", ">>", "::", ":=",
+}
+
+// matchOperator returns the operator or punctuation token starting at s[i],
+// preferring the longest known multi-byte operator and otherwise the single
+// byte at s[i].
+func matchOperator(s string, i int) string {
+	for _, op := range multiCharOperators {
+		if strings.HasPrefix(s[i:], op) {
+			return op
+		}
+	}
+	return s[i : i+1]
+}
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v'
+}
+
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}
+
+func isHex(c byte) bool {
+	return isDigit(c) || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c >= 0x80
+}
+
+func isIdentPart(c byte) bool {
+	return isIdentStart(c) || isDigit(c)
+}

--- a/dialect/token_test.go
+++ b/dialect/token_test.go
@@ -1,0 +1,115 @@
+package dialect
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestTranslateLexical exercises the lexical normalization that translation
+// performs for the non-SQLite dialects: identifier quoting, string quoting,
+// comment style, string escapes, blob/byte literals, and passthrough of
+// operators, numbers, and placeholders. Dialect-specific token rewrites are
+// covered by the per-dialect rule tests added alongside those rules.
+func TestTranslateLexical(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		dialect Dialect
+		input   string
+		want    string
+	}{
+		// MySQL lexical rules.
+		{"mysql backtick identifier", MySQL, "SELECT `id` FROM `users`", `SELECT "id" FROM "users"`},
+		{"mysql double-quoted string", MySQL, `SELECT "hello" AS x`, `SELECT 'hello' AS x`},
+		{"mysql hash comment", MySQL, "SELECT 1 # note", "SELECT 1 -- note\n"},
+		{"mysql backslash escape", MySQL, `SELECT 'It\'s'`, `SELECT 'It''s'`},
+		{"mysql doubled quote", MySQL, `SELECT 'a''b'`, `SELECT 'a''b'`},
+		{"mysql blob passthrough", MySQL, `SELECT x'4142'`, `SELECT x'4142'`},
+
+		// PostgreSQL lexical rules.
+		{"postgres double-quoted identifier", PostgreSQL, `SELECT "col" FROM t`, `SELECT "col" FROM t`},
+		{"postgres escape string", PostgreSQL, `SELECT E'a\tb'`, "SELECT 'a\tb'"},
+		{"postgres dollar quote", PostgreSQL, `SELECT $$hi$$`, `SELECT 'hi'`},
+		{"postgres tagged dollar quote", PostgreSQL, `SELECT $q$a'b$q$`, `SELECT 'a''b'`},
+		{"postgres numbered placeholder", PostgreSQL, `SELECT $1`, `SELECT $1`},
+		{"postgres cast passthrough", PostgreSQL, `SELECT a::int`, `SELECT a::int`},
+
+		// GoogleSQL lexical rules.
+		{"googlesql backtick path", GoogleSQL, "SELECT `p.d.t`", `SELECT "p.d.t"`},
+		{"googlesql double-quoted string", GoogleSQL, `SELECT "str"`, `SELECT 'str'`},
+		{"googlesql raw string", GoogleSQL, `SELECT r'a\nb'`, `SELECT 'a\nb'`},
+		{"googlesql byte string", GoogleSQL, `SELECT b'AB'`, `SELECT x'4142'`},
+		{"googlesql hash comment", GoogleSQL, "SELECT 1 # c", "SELECT 1 -- c\n"},
+
+		// Common passthrough and whitespace normalization.
+		{"whitespace collapses", MySQL, "SELECT    *   FROM t", "SELECT * FROM t"},
+		{"operators preserved", PostgreSQL, "SELECT a <> b, c || d", "SELECT a <> b, c || d"},
+		{"numbers preserved", MySQL, "SELECT 3.5e+10, 0xFF, .25", "SELECT 3.5e+10, 0xFF, .25"},
+		{"placeholders preserved", MySQL, "SELECT ?, ?1, @v, :name", "SELECT ?, ?1, @v, :name"},
+		{"block comment preserved", MySQL, "SELECT /* hi */ 1", "SELECT /* hi */ 1"},
+		{"function call no spacing", MySQL, "SELECT count(*) FROM t", "SELECT count(*) FROM t"},
+		{"empty query", MySQL, "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Translate(tt.dialect, tt.input)
+			if err != nil {
+				t.Fatalf("Translate(%s, %q) unexpected error: %v", tt.dialect, tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("Translate(%s, %q) = %q, want %q", tt.dialect, tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTranslateInvalidSyntax(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		dialect Dialect
+		input   string
+	}{
+		{"unterminated string", MySQL, "SELECT 'abc"},
+		{"unterminated block comment", MySQL, "SELECT 1 /* x"},
+		{"unterminated backtick identifier", MySQL, "SELECT `abc"},
+		{"unterminated double-quoted identifier", PostgreSQL, `SELECT "abc`},
+		{"unterminated dollar quote", PostgreSQL, "SELECT $$abc"},
+		{"unterminated blob", MySQL, "SELECT x'41"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Translate(tt.dialect, tt.input)
+			if !errors.Is(err, ErrInvalidSyntax) {
+				t.Fatalf("Translate(%s, %q) error = %v, want ErrInvalidSyntax", tt.dialect, tt.input, err)
+			}
+		})
+	}
+}
+
+// TestTokenizeOffsets verifies that token offsets are monotonically
+// non-decreasing and within the source, a property the Fuzz test also relies on.
+func TestTokenizeOffsets(t *testing.T) {
+	t.Parallel()
+	const query = "SELECT `a`, 'b', 1 + 2 -- tail\nFROM t"
+	cfg, ok := lexConfigFor(MySQL)
+	if !ok {
+		t.Fatal("lexConfigFor(MySQL) not ok")
+	}
+	tokens, err := tokenize(query, cfg)
+	if err != nil {
+		t.Fatalf("tokenize error: %v", err)
+	}
+	prev := -1
+	for i, tok := range tokens {
+		if tok.offset < 0 || tok.offset >= len(query) {
+			t.Fatalf("token %d offset %d out of range [0,%d)", i, tok.offset, len(query))
+		}
+		if tok.offset <= prev {
+			t.Fatalf("token %d offset %d not increasing (prev %d)", i, tok.offset, prev)
+		}
+		prev = tok.offset
+	}
+}


### PR DESCRIPTION
## What

Introduce a new `dialect` package that translates SQL written in a non-SQLite dialect (MySQL / PostgreSQL / GoogleSQL) into SQLite SQL. The storage engine stays SQLite (modernc.org/sqlite); only the query text a caller supplies is translated. This is the first of several PRs that add multi-dialect query support to filesql (design lives outside the repo).

This PR lands the **core infrastructure only** — dialect-specific rewrite rules and UDF registration come in follow-up PRs. For now, translation normalizes lexical differences (identifier quoting, string quoting, comment style, string escapes) and leaves everything else to SQLite.

## Public API

```go
type Dialect string
const ( SQLite; MySQL; PostgreSQL; GoogleSQL )

func Dialects() []Dialect
func Parse(name string) (Dialect, error)          // case-insensitive, with aliases
func Translate(d Dialect, query string) (string, error)
func RegisterTranslator(name Dialect, fn TranslatorFunc)  // extension point; overrides built-ins

var ( ErrUnknownDialect; ErrUnsupportedSyntax; ErrInvalidSyntax )
```

- `Translate(SQLite, q)` is the identity (returns `q` unchanged).
- Non-SQLite dialects go through a dialect-aware tokenizer → renderer that emits canonical SQLite quoting.

## Design

Best-effort compatibility, not a full emulator. Three classes of input:
1. Known incompatibilities with a SQLite equivalent → rewritten.
2. Known constructs with no equivalent → `ErrUnsupportedSyntax` (added with the per-dialect rules).
3. Everything else → passed through for SQLite to accept or reject.

The tokenizer handles backtick/double-quote identifiers, single/double-quoted strings, `E'...'` / `$$...$$` / `r'...'` / `b'...'` literals, blob literals, backslash escapes, `--`/`#`/block comments, numbers, operators, and placeholders, switched per dialect via a `lexConfig`. Each token keeps its byte offset for error messages.

## Tests

- Golden tests for lexical normalization (20+ cases), `Parse`, identity, unknown-dialect, `RegisterTranslator`.
- Idempotency property: a translated statement fed back through the SQLite (identity) dialect is unchanged.
- Fuzz test (`FuzzTranslate`): no panics, idempotency holds (ran 2.5M+ execs locally).

Package coverage **93.9%**; module total stays at **89.5%**. `golangci-lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for translating MySQL, PostgreSQL, and GoogleSQL queries into SQLite-compatible SQL.
  * Added dialect detection with case-insensitive names and aliases.
  * Added support for custom query translators.
  * Added compatibility handling for dialect-specific quoting, literals, comments, placeholders, and syntax.

* **Documentation**
  * Documented translation behavior, unsupported syntax, and SQLite passthrough behavior.

* **Tests**
  * Added comprehensive unit and fuzz testing for translation, parsing, invalid SQL, and idempotency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->