### PR TITLE
feat(dialect): add MySQL translator and dialect helper functions

### DIFF
--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -119,5 +119,22 @@ func builtinTranslate(d Dialect, query string) (string, error) {
 		return "", err
 	}
 
+	tokens, err = rewriteTokens(d, tokens)
+	if err != nil {
+		return "", err
+	}
+
 	return render(tokens), nil
+}
+
+// rewriteTokens applies the dialect-specific token rewrite rules. Dialects
+// without a rewrite pass yet fall through and are translated by lexical
+// normalization alone.
+func rewriteTokens(d Dialect, tokens []token) ([]token, error) {
+	switch d {
+	case MySQL:
+		return rewriteMySQL(tokens)
+	default:
+		return tokens, nil
+	}
 }

--- a/dialect/functions.go
+++ b/dialect/functions.go
@@ -1,0 +1,632 @@
+package dialect
+
+import (
+	"crypto/rand"
+	"database/sql/driver"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	sqlite "modernc.org/sqlite"
+)
+
+// randFloat returns a uniform float64 in [0, 1) sourced from crypto/rand, so no
+// package-global PRNG state is seeded or shared.
+func randFloat() float64 {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return 0
+	}
+	return float64(binary.BigEndian.Uint64(b[:])>>11) / float64(uint64(1)<<53)
+}
+
+// RegisterFunctions registers the dialect helper functions (REGEXP, NOW,
+// DATE_FORMAT, DATE_PART, ...) into the modernc.org/sqlite driver so translated
+// queries that call them succeed. Registration is process-global and applies to
+// connections opened afterward, so callers should invoke it during startup,
+// before opening the database that runs dialect queries.
+//
+// It is idempotent and safe to call multiple times and from multiple
+// goroutines; the functions are registered only once. The functions are always
+// registered as a set regardless of which dialect is in use, so a helper such as
+// SPLIT_PART is available even under the SQLite dialect.
+func RegisterFunctions() error {
+	registerOnce.Do(func() {
+		errRegister = registerAll()
+	})
+	return errRegister
+}
+
+var (
+	registerOnce sync.Once
+	errRegister  error
+)
+
+// layoutDateTime is the canonical datetime string the helpers emit.
+const layoutDateTime = "2006-01-02 15:04:05"
+
+// Date-part / interval unit names shared by the date helpers and the interval
+// rewrite so the same spelling is used for a function name, an INTERVAL unit,
+// and a DATE_PART argument.
+const (
+	unitYear      = "year"
+	unitMonth     = "month"
+	unitDay       = "day"
+	unitHour      = "hour"
+	unitMinute    = "minute"
+	unitSecond    = "second"
+	unitDayOfWeek = "dayofweek"
+	unitDayOfYear = "dayofyear"
+	unitWeekday   = "weekday"
+)
+
+// scalarFn adapts a simpler signature (no context) to the driver's scalar
+// function shape.
+type scalarFn func(args []driver.Value) (driver.Value, error)
+
+func registerAll() error {
+	// deterministic functions: same output for the same inputs.
+	det := map[string]struct {
+		nArg int32
+		fn   scalarFn
+	}{
+		"regexp":          {2, fnRegexp}, // REGEXP(pattern, s); also the "x REGEXP y" operator
+		"regexp_contains": {2, fnRegexp}, // GoogleSQL alias used by later dialects
+		"if":              {3, fnIf},     // IF(cond, a, b)
+		"date_format":     {2, fnDateFormat},
+		"str_to_date":     {2, fnStrToDate},
+		"datediff":        {2, fnDateDiff},
+		"date_part":       {2, fnDatePart},
+		unitYear:          {1, unaryDatePart(unitYear)},
+		unitMonth:         {1, unaryDatePart(unitMonth)},
+		unitDay:           {1, unaryDatePart(unitDay)},
+		unitHour:          {1, unaryDatePart(unitHour)},
+		unitMinute:        {1, unaryDatePart(unitMinute)},
+		unitSecond:        {1, unaryDatePart(unitSecond)},
+		unitDayOfWeek:     {1, unaryDatePart(unitDayOfWeek)},
+		unitDayOfYear:     {1, unaryDatePart(unitDayOfYear)},
+		unitWeekday:       {1, unaryDatePart(unitWeekday)},
+		"locate":          {-1, fnLocate},
+		"lpad":            {3, fnLpad},
+		"rpad":            {3, fnRpad},
+		"substring_index": {3, fnSubstringIndex},
+		"repeat":          {2, fnRepeat},
+		"space":           {1, fnSpace},
+		"truncate":        {2, fnTruncate},
+	}
+	for name, spec := range det {
+		if err := sqlite.RegisterDeterministicScalarFunction(name, spec.nArg, wrapScalar(spec.fn)); err != nil {
+			return fmt.Errorf("dialect: register %s: %w", name, err)
+		}
+	}
+
+	// Non-deterministic functions must not be registered as deterministic.
+	nondet := map[string]struct {
+		nArg int32
+		fn   scalarFn
+	}{
+		"now":     {0, fnNow},
+		"curdate": {0, fnCurdate},
+		"curtime": {0, fnCurtime},
+		"rand":    {0, fnRand},
+	}
+	for name, spec := range nondet {
+		if err := sqlite.RegisterScalarFunction(name, spec.nArg, wrapScalar(spec.fn)); err != nil {
+			return fmt.Errorf("dialect: register %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func wrapScalar(fn scalarFn) func(ctx *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+	return func(_ *sqlite.FunctionContext, args []driver.Value) (driver.Value, error) {
+		return fn(args)
+	}
+}
+
+// --- value coercion helpers ---
+
+// toString converts a driver.Value to its string form, reporting whether the
+// value was non-NULL.
+func toString(v driver.Value) (string, bool) {
+	switch x := v.(type) {
+	case nil:
+		return "", false
+	case string:
+		return x, true
+	case []byte:
+		return string(x), true
+	case int64:
+		return strconv.FormatInt(x, 10), true
+	case float64:
+		return strconv.FormatFloat(x, 'g', -1, 64), true
+	case bool:
+		if x {
+			return "1", true
+		}
+		return "0", true
+	case time.Time:
+		return x.Format(layoutDateTime), true
+	default:
+		return fmt.Sprintf("%v", x), true
+	}
+}
+
+// toInt converts a driver.Value to an int64, reporting whether it was non-NULL
+// and numeric.
+func toInt(v driver.Value) (int64, bool) {
+	switch x := v.(type) {
+	case nil:
+		return 0, false
+	case int64:
+		return x, true
+	case float64:
+		return int64(x), true
+	case bool:
+		if x {
+			return 1, true
+		}
+		return 0, true
+	case string:
+		n, err := strconv.ParseInt(strings.TrimSpace(x), 10, 64)
+		return n, err == nil
+	case []byte:
+		n, err := strconv.ParseInt(strings.TrimSpace(string(x)), 10, 64)
+		return n, err == nil
+	default:
+		return 0, false
+	}
+}
+
+// toFloat converts a driver.Value to a float64, reporting success.
+func toFloat(v driver.Value) (float64, bool) {
+	switch x := v.(type) {
+	case nil:
+		return 0, false
+	case float64:
+		return x, true
+	case int64:
+		return float64(x), true
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(x), 64)
+		return f, err == nil
+	case []byte:
+		f, err := strconv.ParseFloat(strings.TrimSpace(string(x)), 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+// --- common / MySQL scalar functions ---
+
+var (
+	regexpCacheMu sync.RWMutex
+	regexpCache   = map[string]*regexp.Regexp{}
+)
+
+// compileRegexp compiles pattern, caching the result. Compilation errors are
+// returned so the caller can surface them.
+func compileRegexp(pattern string) (*regexp.Regexp, error) {
+	regexpCacheMu.RLock()
+	re, ok := regexpCache[pattern]
+	regexpCacheMu.RUnlock()
+	if ok {
+		return re, nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	regexpCacheMu.Lock()
+	regexpCache[pattern] = re
+	regexpCacheMu.Unlock()
+	return re, nil
+}
+
+// fnRegexp implements REGEXP(pattern, subject), the function SQLite invokes for
+// the "subject REGEXP pattern" operator. It returns 1 on match, 0 otherwise, and
+// NULL when either argument is NULL.
+func fnRegexp(args []driver.Value) (driver.Value, error) {
+	pattern, ok1 := toString(args[0])
+	subject, ok2 := toString(args[1])
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+	re, err := compileRegexp(pattern)
+	if err != nil {
+		return nil, err
+	}
+	if re.MatchString(subject) {
+		return int64(1), nil
+	}
+	return int64(0), nil
+}
+
+// fnIf implements IF(cond, a, b): a when cond is truthy, else b.
+func fnIf(args []driver.Value) (driver.Value, error) {
+	if isTruthy(args[0]) {
+		return args[1], nil
+	}
+	return args[2], nil
+}
+
+// isTruthy applies SQLite-like truthiness: NULL and zero are false.
+func isTruthy(v driver.Value) bool {
+	switch x := v.(type) {
+	case nil:
+		return false
+	case int64:
+		return x != 0
+	case float64:
+		return x != 0
+	case bool:
+		return x
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(x), 64)
+		if err != nil {
+			return x != ""
+		}
+		return f != 0
+	case []byte:
+		return len(x) != 0
+	default:
+		return true
+	}
+}
+
+func fnNow(_ []driver.Value) (driver.Value, error) {
+	return time.Now().Format(layoutDateTime), nil
+}
+
+func fnCurdate(_ []driver.Value) (driver.Value, error) {
+	return time.Now().Format("2006-01-02"), nil
+}
+
+func fnCurtime(_ []driver.Value) (driver.Value, error) {
+	return time.Now().Format("15:04:05"), nil
+}
+
+func fnRand(_ []driver.Value) (driver.Value, error) {
+	return randFloat(), nil
+}
+
+// mysqlToGoLayout maps the MySQL DATE_FORMAT specifiers to Go reference-time
+// layout fragments. Unlisted specifiers are passed through without the percent.
+var mysqlToGoLayout = map[byte]string{
+	'Y': "2006",
+	'y': "06",
+	'm': "01",
+	'c': "1",
+	'd': "02",
+	'e': "2",
+	'H': "15",
+	'h': "03",
+	'I': "03",
+	'i': "04",
+	's': "05",
+	'S': "05",
+	'p': "PM",
+	'M': "January",
+	'b': "Jan",
+	'W': "Monday",
+	'a': "Mon",
+}
+
+// fnDateFormat implements MySQL DATE_FORMAT(date, format).
+func fnDateFormat(args []driver.Value) (driver.Value, error) {
+	s, ok := toString(args[0])
+	format, ok2 := toString(args[1])
+	if !ok || !ok2 {
+		return nil, nil
+	}
+	tm, ok := parseTime(s)
+	if !ok {
+		return nil, nil
+	}
+	var b strings.Builder
+	for i := 0; i < len(format); i++ {
+		if format[i] == '%' && i+1 < len(format) {
+			if layout, found := mysqlToGoLayout[format[i+1]]; found {
+				b.WriteString(tm.Format(layout))
+			} else if extra, found := dateFormatSpecial(tm, format[i+1]); found {
+				b.WriteString(extra)
+			} else {
+				b.WriteByte(format[i+1])
+			}
+			i++
+			continue
+		}
+		b.WriteByte(format[i])
+	}
+	return b.String(), nil
+}
+
+// dateFormatSpecial handles DATE_FORMAT specifiers that have no direct Go layout
+// (day of year, weekday index).
+func dateFormatSpecial(tm time.Time, spec byte) (string, bool) {
+	switch spec {
+	case 'j':
+		return fmt.Sprintf("%03d", tm.YearDay()), true
+	case 'w':
+		return strconv.Itoa(int(tm.Weekday())), true
+	case '%':
+		return "%", true
+	default:
+		return "", false
+	}
+}
+
+// fnStrToDate implements a pragmatic MySQL STR_TO_DATE(str, format): it parses
+// str against a Go layout derived from the MySQL format and returns a canonical
+// datetime string.
+func fnStrToDate(args []driver.Value) (driver.Value, error) {
+	s, ok := toString(args[0])
+	format, ok2 := toString(args[1])
+	if !ok || !ok2 {
+		return nil, nil
+	}
+	var layout strings.Builder
+	for i := 0; i < len(format); i++ {
+		if format[i] == '%' && i+1 < len(format) {
+			if l, found := mysqlToGoLayout[format[i+1]]; found {
+				layout.WriteString(l)
+			} else {
+				layout.WriteByte(format[i+1])
+			}
+			i++
+			continue
+		}
+		layout.WriteByte(format[i])
+	}
+	tm, ok3 := parseLayout(layout.String(), s)
+	if !ok3 {
+		return nil, nil
+	}
+	return tm.Format(layoutDateTime), nil
+}
+
+// parseLayout parses s against a single Go layout, reporting success.
+func parseLayout(layout, s string) (time.Time, bool) {
+	tm, err := time.Parse(layout, s)
+	return tm, err == nil
+}
+
+// fnDateDiff implements MySQL DATEDIFF(a, b) = whole days from b to a.
+func fnDateDiff(args []driver.Value) (driver.Value, error) {
+	a, ok1 := toStringTime(args[0])
+	b, ok2 := toStringTime(args[1])
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+	da := time.Date(a.Year(), a.Month(), a.Day(), 0, 0, 0, 0, time.UTC)
+	db := time.Date(b.Year(), b.Month(), b.Day(), 0, 0, 0, 0, time.UTC)
+	return int64(da.Sub(db).Hours() / 24), nil
+}
+
+// fnDatePart implements DATE_PART(unit, date), returning the requested field as
+// an integer. It also backs the MySQL YEAR/MONTH/... helpers and the EXTRACT
+// rewrite.
+func fnDatePart(args []driver.Value) (driver.Value, error) {
+	unit, ok := toString(args[0])
+	if !ok {
+		return nil, nil
+	}
+	tm, ok := toStringTime(args[1])
+	if !ok {
+		return nil, nil
+	}
+	return datePartValue(strings.ToLower(strings.TrimSpace(unit)), tm)
+}
+
+func datePartValue(unit string, tm time.Time) (driver.Value, error) {
+	switch unit {
+	case unitYear:
+		return int64(tm.Year()), nil
+	case unitMonth:
+		return int64(tm.Month()), nil
+	case unitDay:
+		return int64(tm.Day()), nil
+	case unitHour:
+		return int64(tm.Hour()), nil
+	case unitMinute:
+		return int64(tm.Minute()), nil
+	case unitSecond:
+		return int64(tm.Second()), nil
+	case "dow", unitDayOfWeek:
+		// MySQL DAYOFWEEK: Sunday=1..Saturday=7.
+		return int64(tm.Weekday()) + 1, nil
+	case unitWeekday:
+		// MySQL WEEKDAY: Monday=0..Sunday=6.
+		return int64((int(tm.Weekday()) + 6) % 7), nil
+	case "doy", unitDayOfYear:
+		return int64(tm.YearDay()), nil
+	case "quarter":
+		return int64((int(tm.Month())-1)/3 + 1), nil
+	case "week":
+		_, wk := tm.ISOWeek()
+		return int64(wk), nil
+	case "epoch":
+		return tm.Unix(), nil
+	default:
+		return nil, fmt.Errorf("dialect: unsupported date part %q", unit)
+	}
+}
+
+// unaryDatePart builds a one-argument function (YEAR, MONTH, ...) from a fixed
+// date part.
+func unaryDatePart(unit string) scalarFn {
+	return func(args []driver.Value) (driver.Value, error) {
+		tm, ok := toStringTime(args[0])
+		if !ok {
+			return nil, nil
+		}
+		return datePartValue(unit, tm)
+	}
+}
+
+// fnLocate implements MySQL LOCATE(substr, str[, pos]) returning a 1-based
+// index, or 0 when not found.
+func fnLocate(args []driver.Value) (driver.Value, error) {
+	if len(args) < 2 || len(args) > 3 {
+		return nil, fmt.Errorf("dialect: LOCATE expects 2 or 3 arguments, got %d", len(args))
+	}
+	substr, ok1 := toString(args[0])
+	str, ok2 := toString(args[1])
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+	start := 0
+	if len(args) == 3 {
+		pos, ok := toInt(args[2])
+		if !ok || pos < 1 {
+			return int64(0), nil
+		}
+		start = int(pos) - 1
+		if start > len(str) {
+			return int64(0), nil
+		}
+	}
+	idx := strings.Index(str[start:], substr)
+	if idx < 0 {
+		return int64(0), nil
+	}
+	return int64(start + idx + 1), nil
+}
+
+func fnLpad(args []driver.Value) (driver.Value, error) { return pad(args, true) }
+func fnRpad(args []driver.Value) (driver.Value, error) { return pad(args, false) }
+
+func pad(args []driver.Value, left bool) (driver.Value, error) {
+	s, ok1 := toString(args[0])
+	n, ok2 := toInt(args[1])
+	padStr, ok3 := toString(args[2])
+	if !ok1 || !ok2 || !ok3 {
+		return nil, nil
+	}
+	if n < 0 {
+		return nil, nil
+	}
+	length := int(n)
+	if len(s) >= length {
+		return s[:length], nil
+	}
+	if padStr == "" {
+		return s, nil
+	}
+	needed := length - len(s)
+	var fill strings.Builder
+	for fill.Len() < needed {
+		fill.WriteString(padStr)
+	}
+	filler := fill.String()[:needed]
+	if left {
+		return filler + s, nil
+	}
+	return s + filler, nil
+}
+
+// fnSubstringIndex implements MySQL SUBSTRING_INDEX(str, delim, count).
+func fnSubstringIndex(args []driver.Value) (driver.Value, error) {
+	s, ok1 := toString(args[0])
+	delim, ok2 := toString(args[1])
+	count, ok3 := toInt(args[2])
+	if !ok1 || !ok2 || !ok3 {
+		return nil, nil
+	}
+	if delim == "" || count == 0 {
+		return "", nil
+	}
+	parts := strings.Split(s, delim)
+	if count > 0 {
+		if int(count) >= len(parts) {
+			return s, nil
+		}
+		return strings.Join(parts[:count], delim), nil
+	}
+	c := int(-count)
+	if c >= len(parts) {
+		return s, nil
+	}
+	return strings.Join(parts[len(parts)-c:], delim), nil
+}
+
+// fnRepeat implements MySQL REPEAT(str, count).
+func fnRepeat(args []driver.Value) (driver.Value, error) {
+	s, ok1 := toString(args[0])
+	count, ok2 := toInt(args[1])
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+	if count <= 0 {
+		return "", nil
+	}
+	return strings.Repeat(s, int(count)), nil
+}
+
+// fnSpace implements MySQL SPACE(n).
+func fnSpace(args []driver.Value) (driver.Value, error) {
+	n, ok := toInt(args[0])
+	if !ok {
+		return nil, nil
+	}
+	if n <= 0 {
+		return "", nil
+	}
+	return strings.Repeat(" ", int(n)), nil
+}
+
+// fnTruncate implements MySQL TRUNCATE(x, d): truncate x to d decimal places
+// toward zero.
+func fnTruncate(args []driver.Value) (driver.Value, error) {
+	x, ok1 := toFloat(args[0])
+	d, ok2 := toInt(args[1])
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+	factor := math.Pow(10, float64(d))
+	return math.Trunc(x*factor) / factor, nil
+}
+
+// --- time parsing ---
+
+// timeLayouts are tried in order by parseTime, covering the common SQL date and
+// datetime shapes.
+var timeLayouts = []string{
+	"2006-01-02 15:04:05.999999999",
+	"2006-01-02 15:04:05",
+	"2006-01-02T15:04:05",
+	"2006-01-02 15:04",
+	"2006-01-02",
+	"2006/01/02 15:04:05",
+	"2006/01/02",
+	"15:04:05",
+}
+
+// parseTime parses a date/time string against the supported layouts.
+func parseTime(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	for _, layout := range timeLayouts {
+		if tm, err := time.Parse(layout, s); err == nil {
+			return tm, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// toStringTime coerces a value to a time, accepting both strings and time.Time.
+func toStringTime(v driver.Value) (time.Time, bool) {
+	if tm, ok := v.(time.Time); ok {
+		return tm, true
+	}
+	s, ok := toString(v)
+	if !ok {
+		return time.Time{}, false
+	}
+	return parseTime(s)
+}

--- a/dialect/functions_test.go
+++ b/dialect/functions_test.go
@@ -1,0 +1,318 @@
+package dialect
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"regexp"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestRegisterFunctionsIdempotent(t *testing.T) {
+	// Not parallel: touches the process-global driver registration.
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() second call error: %v", err)
+	}
+}
+
+// TestUDFExecution runs each registered UDF through a real SQLite connection so
+// the registration wiring and argument coercion are exercised end to end.
+func TestUDFExecution(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{"regexp match", `SELECT 'abc123' REGEXP '[0-9]+'`, "1"},
+		{"regexp no match", `SELECT 'abc' REGEXP '[0-9]+'`, "0"},
+		{"regexp func form", `SELECT REGEXP('^a', 'abc')`, "1"},
+		{"if true", `SELECT IF(1, 'yes', 'no')`, "yes"},
+		{"if false", `SELECT IF(0, 'yes', 'no')`, "no"},
+		{"if null cond", `SELECT IF(NULL, 'yes', 'no')`, "no"},
+		{"date_format", `SELECT DATE_FORMAT('2026-07-28 13:05:09', '%Y/%m/%d %H:%i')`, "2026/07/28 13:05"},
+		{"date_format month name", `SELECT DATE_FORMAT('2026-07-28', '%M %e, %Y')`, "July 28, 2026"},
+		{"str_to_date", `SELECT STR_TO_DATE('2026-07-28', '%Y-%m-%d')`, "2026-07-28 00:00:00"},
+		{"datediff", `SELECT DATEDIFF('2026-07-28', '2026-07-25')`, "3"},
+		{"date_part year", `SELECT DATE_PART('year', '2026-07-28')`, "2026"},
+		{"year", `SELECT YEAR('2026-07-28')`, "2026"},
+		{"month", `SELECT MONTH('2026-07-28')`, "7"},
+		{"day", `SELECT DAY('2026-07-28')`, "28"},
+		{"hour", `SELECT HOUR('2026-07-28 13:05:09')`, "13"},
+		{"dayofweek", `SELECT DAYOFWEEK('2026-07-28')`, "3"}, // Tuesday -> 3
+		{"weekday", `SELECT WEEKDAY('2026-07-28')`, "1"},     // Tuesday -> 1
+		{"dayofyear", `SELECT DAYOFYEAR('2026-01-10')`, "10"},
+		{"locate", `SELECT LOCATE('b', 'abcabc')`, "2"},
+		{"locate with pos", `SELECT LOCATE('b', 'abcabc', 3)`, "5"},
+		{"locate not found", `SELECT LOCATE('z', 'abc')`, "0"},
+		{"lpad", `SELECT LPAD('7', 3, '0')`, "007"},
+		{"rpad", `SELECT RPAD('7', 3, '-')`, "7--"},
+		{"lpad truncates", `SELECT LPAD('abcdef', 3, 'x')`, "abc"},
+		{"substring_index pos", `SELECT SUBSTRING_INDEX('a.b.c.d', '.', 2)`, "a.b"},
+		{"substring_index neg", `SELECT SUBSTRING_INDEX('a.b.c.d', '.', -2)`, "c.d"},
+		{"repeat", `SELECT REPEAT('ab', 3)`, "ababab"},
+		{"space", `SELECT '[' || SPACE(3) || ']'`, "[   ]"},
+		{"truncate", `SELECT TRUNCATE(3.14159, 2)`, "3.14"},
+		{"truncate negative digits", `SELECT TRUNCATE(1234.5, -2)`, "1200"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got sql.NullString
+			if err := db.QueryRowContext(context.Background(), tt.sql).Scan(&got); err != nil {
+				t.Fatalf("%s: query error: %v", tt.sql, err)
+			}
+			if got.String != tt.want {
+				t.Fatalf("%s = %q, want %q", tt.sql, got.String, tt.want)
+			}
+		})
+	}
+}
+
+// TestUDFNullHandling verifies that NULL arguments propagate to NULL for the
+// string/number helpers.
+func TestUDFNullHandling(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	for _, q := range []string{
+		`SELECT DATE_FORMAT(NULL, '%Y')`,
+		`SELECT LPAD(NULL, 3, '0')`,
+		`SELECT REPEAT(NULL, 2)`,
+		`SELECT YEAR(NULL)`,
+		`SELECT TRUNCATE(NULL, 2)`,
+		`SELECT DATEDIFF('2026-01-01', NULL)`,
+	} {
+		var got sql.NullString
+		if err := db.QueryRowContext(context.Background(), q).Scan(&got); err != nil {
+			t.Fatalf("%s: query error: %v", q, err)
+		}
+		if got.Valid {
+			t.Fatalf("%s = %q, want NULL", q, got.String)
+		}
+	}
+}
+
+// TestNonDeterministicUDFs checks the shape of the non-deterministic helpers
+// through a real connection.
+func TestNonDeterministicUDFs(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tests := []struct {
+		sql     string
+		pattern string
+	}{
+		{`SELECT NOW()`, `^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$`},
+		{`SELECT CURDATE()`, `^\d{4}-\d{2}-\d{2}$`},
+		{`SELECT CURTIME()`, `^\d{2}:\d{2}:\d{2}$`},
+		{`SELECT CAST(RAND() < 1 AS INTEGER)`, `^1$`},
+	}
+	for _, tt := range tests {
+		var got string
+		if err := db.QueryRowContext(context.Background(), tt.sql).Scan(&got); err != nil {
+			t.Fatalf("%s: %v", tt.sql, err)
+		}
+		if !regexp.MustCompile(tt.pattern).MatchString(got) {
+			t.Fatalf("%s = %q, want match %s", tt.sql, got, tt.pattern)
+		}
+	}
+}
+
+// TestDateFormatSpecialAndParts covers the DATE_FORMAT specifiers without a
+// direct Go layout and the extra DATE_PART units.
+func TestDateFormatSpecialAndParts(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tests := []struct {
+		sql  string
+		want string
+	}{
+		{`SELECT DATE_FORMAT('2026-03-10', '%j')`, "069"},
+		{`SELECT DATE_FORMAT('2026-07-28', '%w')`, "2"},
+		{`SELECT DATE_FORMAT('2026-07-28', '100%%')`, "100%"},
+		{`SELECT DATE_FORMAT('2026-07-28', '%Z')`, "Z"},
+		{`SELECT DATE_PART('quarter', '2026-07-28')`, "3"},
+		{`SELECT DATE_PART('week', '2026-01-05')`, "2"},
+		{`SELECT DATE_PART('epoch', '1970-01-01 00:00:01')`, "1"},
+		{`SELECT DATE_PART('dow', '2026-07-28')`, "3"},
+		{`SELECT DATE_PART('doy', '2026-01-10')`, "10"},
+	}
+	for _, tt := range tests {
+		var got sql.NullString
+		if err := db.QueryRowContext(context.Background(), tt.sql).Scan(&got); err != nil {
+			t.Fatalf("%s: %v", tt.sql, err)
+		}
+		if got.String != tt.want {
+			t.Fatalf("%s = %q, want %q", tt.sql, got.String, tt.want)
+		}
+	}
+}
+
+func TestDatePartUnsupported(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	var got sql.NullString
+	err = db.QueryRowContext(context.Background(), `SELECT DATE_PART('century', '2026-07-28')`).Scan(&got)
+	if err == nil {
+		t.Fatal("DATE_PART('century', ...) should error")
+	}
+}
+
+// TestEdgeCaseUDFs covers boundary branches: zero/empty inputs and truthiness of
+// several value types.
+func TestEdgeCaseUDFs(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tests := []struct {
+		sql  string
+		want string
+	}{
+		{`SELECT SPACE(0)`, ""},
+		{`SELECT SPACE(-1)`, ""},
+		{`SELECT REPEAT('x', 0)`, ""},
+		{`SELECT SUBSTRING_INDEX('a.b.c', '.', 0)`, ""},
+		{`SELECT SUBSTRING_INDEX('a.b', '', 1)`, ""},
+		{`SELECT SUBSTRING_INDEX('a.b.c', '.', 9)`, "a.b.c"},
+		{`SELECT LPAD('x', 5, '')`, "x"},
+		{`SELECT IF(2.5, 'y', 'n')`, "y"},
+		{`SELECT IF('0', 'y', 'n')`, "n"},
+		{`SELECT IF('text', 'y', 'n')`, "y"},
+		{`SELECT IF(CAST('' AS BLOB), 'y', 'n')`, "n"},
+	}
+	for _, tt := range tests {
+		var got sql.NullString
+		if err := db.QueryRowContext(context.Background(), tt.sql).Scan(&got); err != nil {
+			t.Fatalf("%s: %v", tt.sql, err)
+		}
+		if got.String != tt.want {
+			t.Fatalf("%s = %q, want %q", tt.sql, got.String, tt.want)
+		}
+	}
+}
+
+func TestRegexpInvalidPattern(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	var got sql.NullString
+	err = db.QueryRowContext(context.Background(), `SELECT 'x' REGEXP '('`).Scan(&got)
+	if err == nil {
+		t.Fatal("REGEXP with an invalid pattern should error")
+	}
+}
+
+func TestRandInRange(t *testing.T) {
+	t.Parallel()
+	for range 1000 {
+		v := randFloat()
+		if v < 0 || v >= 1 {
+			t.Fatalf("randFloat() = %v, want [0,1)", v)
+		}
+	}
+}
+
+// TestToStringCoercions exercises the driver.Value coercion helpers directly for
+// the types the SQLite driver can hand a UDF.
+func TestValueCoercions(t *testing.T) {
+	t.Parallel()
+	if s, ok := toString(driver.Value(int64(42))); !ok || s != "42" {
+		t.Fatalf("toString(int64) = %q, %v", s, ok)
+	}
+	if s, ok := toString(driver.Value([]byte("hi"))); !ok || s != "hi" {
+		t.Fatalf("toString([]byte) = %q, %v", s, ok)
+	}
+	if _, ok := toString(driver.Value(nil)); ok {
+		t.Fatal("toString(nil) should report false")
+	}
+	if n, ok := toInt(driver.Value("15")); !ok || n != 15 {
+		t.Fatalf("toInt(string) = %d, %v", n, ok)
+	}
+	if _, ok := toInt(driver.Value("nope")); ok {
+		t.Fatal("toInt(non-numeric) should report false")
+	}
+	if f, ok := toFloat(driver.Value(int64(3))); !ok || f != 3 {
+		t.Fatalf("toFloat(int64) = %v, %v", f, ok)
+	}
+
+	// Remaining type branches.
+	if s, ok := toString(driver.Value(3.5)); !ok || s != "3.5" {
+		t.Fatalf("toString(float64) = %q, %v", s, ok)
+	}
+	if s, ok := toString(driver.Value(true)); !ok || s != "1" {
+		t.Fatalf("toString(bool) = %q, %v", s, ok)
+	}
+	if s, ok := toString(driver.Value(time.Date(2026, 7, 28, 1, 2, 3, 0, time.UTC))); !ok || s != "2026-07-28 01:02:03" {
+		t.Fatalf("toString(time.Time) = %q, %v", s, ok)
+	}
+	if n, ok := toInt(driver.Value(4.9)); !ok || n != 4 {
+		t.Fatalf("toInt(float64) = %d, %v", n, ok)
+	}
+	if n, ok := toInt(driver.Value(true)); !ok || n != 1 {
+		t.Fatalf("toInt(bool) = %d, %v", n, ok)
+	}
+	if _, ok := toInt(driver.Value(nil)); ok {
+		t.Fatal("toInt(nil) should report false")
+	}
+	if f, ok := toFloat(driver.Value("2.5")); !ok || f != 2.5 {
+		t.Fatalf("toFloat(string) = %v, %v", f, ok)
+	}
+	if f, ok := toFloat(driver.Value([]byte("6"))); !ok || f != 6 {
+		t.Fatalf("toFloat([]byte) = %v, %v", f, ok)
+	}
+	if _, ok := toFloat(driver.Value(nil)); ok {
+		t.Fatal("toFloat(nil) should report false")
+	}
+}

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -1,0 +1,265 @@
+package dialect
+
+import (
+	"fmt"
+	"strings"
+)
+
+// rewriteMySQL applies the MySQL token rewrite rules. The lexical rules (M-1
+// backtick identifiers, M-2 double-quoted strings, M-3 # comments, M-4
+// backslash escapes) are handled by the tokenizer and renderer; this pass
+// handles the structural rules:
+//
+//	C-1  EXTRACT(part FROM x)            -> DATE_PART('part', x)
+//	M-5  DATE_ADD/DATE_SUB(x, INTERVAL n unit) -> datetime(x, '±n unit')
+//	M-6  GROUP_CONCAT(x SEPARATOR s)     -> group_concat(x, s)
+//	M-7  a DIV b                         -> CAST(a / b AS INTEGER)
+//	M-8  CAST(x AS mysql_type)           -> CAST(x AS sqlite_type)
+//	M-9  x RLIKE p                       -> x REGEXP p
+//
+// M-10 (LIMIT n, m) needs no rewrite: SQLite accepts it natively.
+func rewriteMySQL(tokens []token) ([]token, error) {
+	out, err := mysqlCallPass(tokens)
+	if err != nil {
+		return nil, err
+	}
+	out, err = divPass(out)
+	if err != nil {
+		return nil, err
+	}
+	return renameWordPass(out, "RLIKE", "REGEXP"), nil
+}
+
+// mysqlCallPass rewrites the MySQL function-call rules (C-1, M-5, M-6, M-8),
+// recursing into the arguments of recognized calls so nested calls are handled
+// in one pass.
+func mysqlCallPass(tokens []token) ([]token, error) {
+	out := make([]token, 0, len(tokens))
+	i := 0
+	for i < len(tokens) {
+		t := tokens[i]
+		if t.kind == tokWord {
+			open := nextSig(tokens, i+1)
+			if open >= 0 && isOpEq(tokens[open], "(") {
+				closeIdx := matchParen(tokens, open)
+				if closeIdx < 0 {
+					return nil, fmt.Errorf("%w: unbalanced parentheses after %s", ErrInvalidSyntax, t.text)
+				}
+				repl, handled, err := mysqlRewriteCall(tokens, i, open, closeIdx)
+				if err != nil {
+					return nil, err
+				}
+				if handled {
+					out = append(out, repl...)
+					i = closeIdx + 1
+					continue
+				}
+			}
+		}
+		out = append(out, t)
+		i++
+	}
+	return out, nil
+}
+
+// mysqlRewriteCall rewrites the recognized MySQL call that starts with the word
+// at nameIdx and spans open..close. It returns the replacement tokens and
+// whether the call was rewritten. When it is not (handled is false), the caller
+// keeps scanning into the call's tokens, so nested recognized calls are still
+// rewritten by the main pass.
+func mysqlRewriteCall(tokens []token, nameIdx, open, closeIdx int) ([]token, bool, error) {
+	switch strings.ToUpper(tokens[nameIdx].text) {
+	case "EXTRACT":
+		return rewriteExtract(tokens, open, closeIdx)
+	case "DATE_ADD":
+		return rewriteDateArith(tokens, open, closeIdx, "+")
+	case "DATE_SUB":
+		return rewriteDateArith(tokens, open, closeIdx, "-")
+	case "GROUP_CONCAT":
+		return rewriteGroupConcat(tokens, nameIdx, open, closeIdx)
+	case "CAST":
+		return rewriteCast(tokens, nameIdx, open, closeIdx, mysqlCastTypes)
+	default:
+		return nil, false, nil
+	}
+}
+
+// rewriteExtract implements C-1: EXTRACT(part FROM x) -> DATE_PART('part', x).
+func rewriteExtract(tokens []token, open, closeIdx int) ([]token, bool, error) {
+	part := nextSig(tokens, open+1)
+	if part < 0 || tokens[part].kind != tokWord {
+		return nil, false, nil
+	}
+	from := nextSig(tokens, part+1)
+	if from < 0 || !isWordEq(tokens[from], "FROM") {
+		return nil, false, nil
+	}
+	expr, err := mysqlCallPass(tokens[from+1 : closeIdx])
+	if err != nil {
+		return nil, false, err
+	}
+	expr = trimSpaceTokens(expr)
+	repl := make([]token, 0, len(expr)+6)
+	repl = append(repl, wordToken("DATE_PART"), opToken("("))
+	repl = append(repl, stringToken(strings.ToLower(tokens[part].text)))
+	repl = append(repl, opToken(","), spaceToken())
+	repl = append(repl, expr...)
+	repl = append(repl, opToken(")"))
+	return repl, true, nil
+}
+
+// mysqlIntervalUnits maps the INTERVAL units supported by M-5 to the SQLite
+// datetime modifier unit.
+var mysqlIntervalUnits = map[string]string{
+	"SECOND": unitSecond,
+	"MINUTE": unitMinute,
+	"HOUR":   unitHour,
+	"DAY":    unitDay,
+	"MONTH":  unitMonth,
+	"YEAR":   unitYear,
+}
+
+// rewriteDateArith implements M-5: DATE_ADD/DATE_SUB(x, INTERVAL n unit) ->
+// datetime(x, '±n unit'). sign is "+" for DATE_ADD and "-" for DATE_SUB.
+func rewriteDateArith(tokens []token, open, closeIdx int, sign string) ([]token, bool, error) {
+	comma := topLevelComma(tokens, open, closeIdx)
+	if comma < 0 {
+		return nil, false, nil
+	}
+	interval := nextSig(tokens, comma+1)
+	if interval < 0 || !isWordEq(tokens[interval], "INTERVAL") {
+		return nil, false, nil
+	}
+	value := nextSig(tokens, interval+1)
+	if value < 0 || tokens[value].kind != tokNumber {
+		return nil, false, fmt.Errorf("%w: DATE_ADD/DATE_SUB INTERVAL value must be a numeric literal", ErrUnsupportedSyntax)
+	}
+	unitTok := nextSig(tokens, value+1)
+	if unitTok < 0 || tokens[unitTok].kind != tokWord {
+		return nil, false, fmt.Errorf("%w: DATE_ADD/DATE_SUB INTERVAL is missing a unit", ErrUnsupportedSyntax)
+	}
+	unit, ok := mysqlIntervalUnits[strings.ToUpper(tokens[unitTok].text)]
+	if !ok {
+		return nil, false, fmt.Errorf("%w: unsupported INTERVAL unit %q", ErrUnsupportedSyntax, tokens[unitTok].text)
+	}
+	if after := nextSig(tokens, unitTok+1); after != closeIdx {
+		return nil, false, fmt.Errorf("%w: unsupported INTERVAL expression", ErrUnsupportedSyntax)
+	}
+
+	expr, err := mysqlCallPass(tokens[open+1 : comma])
+	if err != nil {
+		return nil, false, err
+	}
+	expr = trimSpaceTokens(expr)
+	modifier := sign + tokens[value].text + " " + unit
+	repl := make([]token, 0, len(expr)+6)
+	repl = append(repl, wordToken("datetime"), opToken("("))
+	repl = append(repl, expr...)
+	repl = append(repl, opToken(","), spaceToken(), stringToken(modifier), opToken(")"))
+	return repl, true, nil
+}
+
+// rewriteGroupConcat implements M-6: GROUP_CONCAT(x SEPARATOR s) ->
+// group_concat(x, s). A leading DISTINCT is preserved.
+func rewriteGroupConcat(tokens []token, nameIdx, open, closeIdx int) ([]token, bool, error) {
+	sep := topLevelWord(tokens, open, closeIdx, "SEPARATOR")
+	inner, err := mysqlCallPass(tokens[open+1 : closeIdx])
+	if err != nil {
+		return nil, false, err
+	}
+	repl := []token{tokens[nameIdx], opToken("(")}
+	if sep < 0 {
+		repl = append(repl, inner...)
+		repl = append(repl, opToken(")"))
+		return repl, true, nil
+	}
+	// Replace the SEPARATOR keyword (offset-shifted into inner) with a comma,
+	// dropping any whitespace that immediately precedes it so the result reads
+	// "x, s" rather than "x , s".
+	sepInner := sep - (open + 1)
+	for j := range inner {
+		if j == sepInner {
+			for len(repl) > 2 && repl[len(repl)-1].kind == tokWhitespace {
+				repl = repl[:len(repl)-1]
+			}
+			repl = append(repl, opToken(","))
+			continue
+		}
+		repl = append(repl, inner[j])
+	}
+	repl = append(repl, opToken(")"))
+	return repl, true, nil
+}
+
+// rewriteCast implements M-8: CAST(x AS type) with the source type mapped to a
+// SQLite type via types. An unmapped type is left unchanged.
+func rewriteCast(tokens []token, nameIdx, open, closeIdx int, types map[string]string) ([]token, bool, error) {
+	as := topLevelWord(tokens, open, closeIdx, "AS")
+	if as < 0 {
+		return nil, false, nil
+	}
+	typeName := nextSig(tokens, as+1)
+	if typeName < 0 || tokens[typeName].kind != tokWord {
+		return nil, false, nil
+	}
+	mapped, ok := lookupCastType(types, tokens[typeName].text)
+	if !ok {
+		return nil, false, nil
+	}
+	expr, err := mysqlCallPass(tokens[open+1 : as])
+	if err != nil {
+		return nil, false, err
+	}
+	expr = trimSpaceTokens(expr)
+	repl := make([]token, 0, len(expr)+6)
+	repl = append(repl, tokens[nameIdx], opToken("("))
+	repl = append(repl, expr...)
+	repl = append(repl, spaceToken(), wordToken("AS"), spaceToken(), wordToken(mapped), opToken(")"))
+	return repl, true, nil
+}
+
+// divPass implements M-7: a DIV b -> CAST(a / b AS INTEGER). The operands must
+// be primary expressions.
+func divPass(tokens []token) ([]token, error) {
+	out := make([]token, 0, len(tokens))
+	i := 0
+	for i < len(tokens) {
+		if isWordEq(tokens[i], "DIV") {
+			start, ok := primaryStartBack(out)
+			if !ok {
+				return nil, fmt.Errorf("%w: left operand of DIV is not a primary expression", ErrUnsupportedSyntax)
+			}
+			rightStart := nextSig(tokens, i+1)
+			rightEnd, ok := primaryEndForward(tokens, i+1)
+			if !ok {
+				return nil, fmt.Errorf("%w: right operand of DIV is not a primary expression", ErrUnsupportedSyntax)
+			}
+			left := append([]token{}, trimSpaceTokens(out[start:])...)
+			out = out[:start]
+			out = append(out, wordToken("CAST"), opToken("("))
+			out = append(out, left...)
+			out = append(out, spaceToken(), opToken("/"), spaceToken())
+			out = append(out, tokens[rightStart:rightEnd+1]...)
+			out = append(out, spaceToken(), wordToken("AS"), spaceToken(), wordToken(sqliteInteger), opToken(")"))
+			i = rightEnd + 1
+			continue
+		}
+		out = append(out, tokens[i])
+		i++
+	}
+	return out, nil
+}
+
+// renameWordPass renames every unquoted word equal to from (case-insensitive)
+// to the given replacement, preserving all other tokens. It implements the
+// operator-keyword renames such as M-9 (RLIKE -> REGEXP).
+func renameWordPass(tokens []token, from, to string) []token {
+	out := make([]token, len(tokens))
+	copy(out, tokens)
+	for i := range out {
+		if isWordEq(out[i], from) {
+			out[i] = wordToken(to)
+		}
+	}
+	return out
+}

--- a/dialect/mysql_test.go
+++ b/dialect/mysql_test.go
@@ -1,0 +1,93 @@
+package dialect
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestMySQLTranslate covers the MySQL rewrite rules by rule ID. Lexical rules
+// (M-1..M-4) are exercised in TestTranslateLexical; this file covers the
+// structural rules and their error cases.
+func TestMySQLTranslate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"C-1_extract", "SELECT EXTRACT(YEAR FROM d) FROM t", "SELECT DATE_PART('year', d) FROM t"},
+		{"C-1_extract_expr", "SELECT EXTRACT(MONTH FROM o.created) FROM t", "SELECT DATE_PART('month', o.created) FROM t"},
+
+		{"M-5_date_add", "SELECT DATE_ADD(d, INTERVAL 3 DAY) FROM t", "SELECT datetime(d, '+3 day') FROM t"},
+		{"M-5_date_sub", "SELECT DATE_SUB(d, INTERVAL 2 MONTH) FROM t", "SELECT datetime(d, '-2 month') FROM t"},
+		{"M-5_date_add_hour", "SELECT DATE_ADD(ts, INTERVAL 5 HOUR)", "SELECT datetime(ts, '+5 hour')"},
+		{"M-5_date_add_string_arg", "SELECT DATE_ADD('2020-01-01', INTERVAL 1 YEAR)", "SELECT datetime('2020-01-01', '+1 year')"},
+
+		{"M-6_group_concat_separator", "SELECT GROUP_CONCAT(name SEPARATOR ', ') FROM t", "SELECT GROUP_CONCAT(name, ', ') FROM t"},
+		{"M-6_group_concat_plain", "SELECT GROUP_CONCAT(name) FROM t", "SELECT GROUP_CONCAT(name) FROM t"},
+		{"M-6_group_concat_distinct", "SELECT GROUP_CONCAT(DISTINCT name) FROM t", "SELECT GROUP_CONCAT(DISTINCT name) FROM t"},
+
+		{"M-7_div", "SELECT a DIV b FROM t", "SELECT CAST(a / b AS INTEGER) FROM t"},
+		{"M-7_div_literals", "SELECT 7 DIV 2", "SELECT CAST(7 / 2 AS INTEGER)"},
+		{"M-7_div_qualified", "SELECT t.a DIV t.b FROM t", "SELECT CAST(t.a / t.b AS INTEGER) FROM t"},
+		{"M-7_div_paren_left", "SELECT (a + b) DIV c", "SELECT CAST((a + b) / c AS INTEGER)"},
+		{"M-7_div_call_right", "SELECT x DIV ABS(y)", "SELECT CAST(x / ABS(y) AS INTEGER)"},
+		{"M-7_div_call_left", "SELECT ABS(x) DIV y", "SELECT CAST(ABS(x) / y AS INTEGER)"},
+
+		{"M-8_cast_signed", "SELECT CAST(x AS SIGNED) FROM t", "SELECT CAST(x AS INTEGER) FROM t"},
+		{"M-8_cast_unsigned_integer", "SELECT CAST(x AS UNSIGNED INTEGER)", "SELECT CAST(x AS INTEGER)"},
+		{"M-8_cast_char", "SELECT CAST(x AS CHAR)", "SELECT CAST(x AS TEXT)"},
+		{"M-8_cast_decimal", "SELECT CAST(x AS DECIMAL(10,2))", "SELECT CAST(x AS REAL)"},
+		{"M-8_cast_datetime", "SELECT CAST(x AS DATETIME)", "SELECT CAST(x AS TEXT)"},
+		{"M-8_cast_binary", "SELECT CAST(x AS BINARY)", "SELECT CAST(x AS BLOB)"},
+		{"M-8_cast_unknown_passthrough", "SELECT CAST(x AS GEOMETRY)", "SELECT CAST(x AS GEOMETRY)"},
+
+		{"M-9_rlike", "SELECT * FROM t WHERE name RLIKE '^a'", "SELECT * FROM t WHERE name REGEXP '^a'"},
+		{"M-9_not_rlike", "SELECT * FROM t WHERE name NOT RLIKE '^a'", "SELECT * FROM t WHERE name NOT REGEXP '^a'"},
+
+		{"M-10_limit_offset", "SELECT * FROM t LIMIT 5, 10", "SELECT * FROM t LIMIT 5, 10"},
+
+		{"nested_date_add_in_extract", "SELECT EXTRACT(DAY FROM DATE_ADD(d, INTERVAL 1 DAY))", "SELECT DATE_PART('day', datetime(d, '+1 day'))"},
+		{"unrelated_function_untouched", "SELECT COALESCE(a, b), SUM(c) FROM t", "SELECT COALESCE(a, b), SUM(c) FROM t"},
+		{"extract_without_from_passthrough", "SELECT EXTRACT(x) FROM t", "SELECT EXTRACT(x) FROM t"},
+		{"cast_without_as_passthrough", "SELECT CAST(x) FROM t", "SELECT CAST(x) FROM t"},
+		{"date_add_without_interval_passthrough", "SELECT DATE_ADD(a, b) FROM t", "SELECT DATE_ADD(a, b) FROM t"},
+		{"nested_cast_in_unrecognized_call", "SELECT COALESCE(CAST(x AS SIGNED), 0) FROM t", "SELECT COALESCE(CAST(x AS INTEGER), 0) FROM t"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Translate(MySQL, tt.input)
+			if err != nil {
+				t.Fatalf("Translate(MySQL, %q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("Translate(MySQL, %q)\n  = %q\nwant %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMySQLTranslateUnsupported(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"M-5_unsupported_unit", "SELECT DATE_ADD(d, INTERVAL 1 WEEK)"},
+		{"M-5_non_literal_interval", "SELECT DATE_ADD(d, INTERVAL n DAY)"},
+		{"M-5_compound_interval", "SELECT DATE_ADD(d, INTERVAL '1:1' MINUTE_SECOND)"},
+		{"M-5_missing_unit", "SELECT DATE_ADD(d, INTERVAL 3)"},
+		{"M-7_div_left_not_primary", "SELECT a, DIV b"},
+		{"M-7_div_right_missing", "SELECT a DIV"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Translate(MySQL, tt.input)
+			if !errors.Is(err, ErrUnsupportedSyntax) {
+				t.Fatalf("Translate(MySQL, %q) error = %v, want ErrUnsupportedSyntax", tt.input, err)
+			}
+		})
+	}
+}

--- a/dialect/rewrite.go
+++ b/dialect/rewrite.go
@@ -1,0 +1,290 @@
+package dialect
+
+import "strings"
+
+// This file holds the shared machinery the per-dialect rewrite passes use to
+// recognize and rewrite patterns in a token stream: token constructors,
+// significance helpers, parenthesis matching, and "primary expression"
+// boundary detection. The stream keeps whitespace and comment tokens so
+// rendering preserves the original adjacency; rewrite rules therefore work in
+// terms of "significant" tokens (everything except whitespace and comments).
+
+// trimSpaceTokens returns toks without leading or trailing whitespace tokens.
+func trimSpaceTokens(toks []token) []token {
+	lo, hi := 0, len(toks)
+	for lo < hi && toks[lo].kind == tokWhitespace {
+		lo++
+	}
+	for hi > lo && toks[hi-1].kind == tokWhitespace {
+		hi--
+	}
+	return toks[lo:hi]
+}
+
+func wordToken(s string) token   { return token{kind: tokWord, text: s} }
+func opToken(s string) token     { return token{kind: tokOp, text: s} }
+func stringToken(s string) token { return token{kind: tokString, text: s} }
+func spaceToken() token          { return token{kind: tokWhitespace, text: " "} }
+
+// isSignificant reports whether t participates in the grammar (i.e. is not
+// whitespace or a comment).
+func isSignificant(t token) bool {
+	switch t.kind {
+	case tokWhitespace, tokLineComment, tokBlockComment:
+		return false
+	default:
+		return true
+	}
+}
+
+// isWordEq reports whether t is an unquoted word equal to kw, ignoring case.
+func isWordEq(t token, kw string) bool {
+	return t.kind == tokWord && strings.EqualFold(t.text, kw)
+}
+
+// isOpEq reports whether t is the operator/punctuation op.
+func isOpEq(t token, op string) bool {
+	return t.kind == tokOp && t.text == op
+}
+
+// isName reports whether t can name a column or table (an unquoted word or a
+// quoted identifier).
+func isName(t token) bool {
+	return t.kind == tokWord || t.kind == tokQuotedIdent
+}
+
+// isLiteral reports whether t is a value literal.
+func isLiteral(t token) bool {
+	switch t.kind {
+	case tokNumber, tokString, tokBlob, tokPlaceholder:
+		return true
+	default:
+		return false
+	}
+}
+
+// nextSig returns the index of the first significant token at or after from, or
+// -1 if there is none.
+func nextSig(toks []token, from int) int {
+	for j := from; j < len(toks); j++ {
+		if isSignificant(toks[j]) {
+			return j
+		}
+	}
+	return -1
+}
+
+// prevSig returns the index of the last significant token before before, or -1.
+func prevSig(toks []token, before int) int {
+	for j := before - 1; j >= 0; j-- {
+		if isSignificant(toks[j]) {
+			return j
+		}
+	}
+	return -1
+}
+
+// lastSig returns the index of the last significant token in toks, or -1.
+func lastSig(toks []token) int {
+	return prevSig(toks, len(toks))
+}
+
+// matchParen returns the index of the ")" that closes the "(" at open, or -1 if
+// the parentheses are unbalanced.
+func matchParen(toks []token, open int) int {
+	depth := 0
+	for j := open; j < len(toks); j++ {
+		if !isSignificant(toks[j]) {
+			continue
+		}
+		if toks[j].kind == tokOp {
+			switch toks[j].text {
+			case "(":
+				depth++
+			case ")":
+				depth--
+				if depth == 0 {
+					return j
+				}
+			}
+		}
+	}
+	return -1
+}
+
+// matchOpenParen returns the index of the "(" that the ")" at closeIdx closes,
+// scanning backward, or -1 if unbalanced.
+func matchOpenParen(toks []token, closeIdx int) int {
+	depth := 0
+	for j := closeIdx; j >= 0; j-- {
+		if !isSignificant(toks[j]) {
+			continue
+		}
+		if toks[j].kind == tokOp {
+			switch toks[j].text {
+			case ")":
+				depth++
+			case "(":
+				depth--
+				if depth == 0 {
+					return j
+				}
+			}
+		}
+	}
+	return -1
+}
+
+// topLevelComma returns the index of the first "," at depth 1 inside the call
+// whose parentheses are open..close, or -1 if there is none.
+func topLevelComma(toks []token, open, closeIdx int) int {
+	depth := 0
+	for j := open; j < closeIdx; j++ {
+		if !isSignificant(toks[j]) {
+			continue
+		}
+		if toks[j].kind != tokOp {
+			continue
+		}
+		switch toks[j].text {
+		case "(":
+			depth++
+		case ")":
+			depth--
+		case ",":
+			if depth == 1 {
+				return j
+			}
+		}
+	}
+	return -1
+}
+
+// topLevelWord returns the index of the first word equal to kw at depth 1 inside
+// the call whose parentheses are open..close, or -1 if there is none.
+func topLevelWord(toks []token, open, closeIdx int, kw string) int {
+	depth := 0
+	for j := open; j < closeIdx; j++ {
+		if !isSignificant(toks[j]) {
+			continue
+		}
+		if toks[j].kind == tokOp {
+			switch toks[j].text {
+			case "(":
+				depth++
+			case ")":
+				depth--
+			}
+			continue
+		}
+		if depth == 1 && isWordEq(toks[j], kw) {
+			return j
+		}
+	}
+	return -1
+}
+
+// chainStartBack extends idx backward across "name . name" chains and returns the
+// index where the chain begins. idx must already be the last name of the chain.
+func chainStartBack(toks []token, idx int) int {
+	for {
+		dot := prevSig(toks, idx)
+		if dot < 0 || !isOpEq(toks[dot], ".") {
+			return idx
+		}
+		name := prevSig(toks, dot)
+		if name < 0 || !isName(toks[name]) {
+			return idx
+		}
+		idx = name
+	}
+}
+
+// primaryStartBack returns the start index of the primary expression that ends
+// at the last significant token of toks. A primary is a literal, an identifier
+// chain (a, a.b.c), a function call, or a parenthesized expression. It reports
+// false when the trailing tokens are not a primary expression.
+func primaryStartBack(toks []token) (int, bool) {
+	end := lastSig(toks)
+	if end < 0 {
+		return 0, false
+	}
+	switch {
+	case isOpEq(toks[end], ")"):
+		open := matchOpenParen(toks, end)
+		if open < 0 {
+			return 0, false
+		}
+		// A "(" is a function call only when a name sits immediately before it
+		// (as in count(*)); a name separated by whitespace (as in the keyword of
+		// "SELECT (a + b)") is not part of the parenthesized primary.
+		if open > 0 && isName(toks[open-1]) {
+			return chainStartBack(toks, open-1), true
+		}
+		return open, true
+	case isName(toks[end]) || isLiteral(toks[end]):
+		return chainStartBack(toks, end), true
+	default:
+		return 0, false
+	}
+}
+
+// primaryEndForward returns the index of the last token of the primary
+// expression that begins at or after from. It reports false when there is no
+// primary expression there.
+func primaryEndForward(toks []token, from int) (int, bool) {
+	s0 := nextSig(toks, from)
+	if s0 < 0 {
+		return 0, false
+	}
+	var end int
+	switch {
+	case isOpEq(toks[s0], "("):
+		e := matchParen(toks, s0)
+		if e < 0 {
+			return 0, false
+		}
+		end = e
+	case isName(toks[s0]):
+		end = s0
+		if e, ok := adjacentCallEnd(toks, end); ok {
+			if e < 0 {
+				return 0, false
+			}
+			end = e
+		}
+	case isLiteral(toks[s0]):
+		end = s0
+	default:
+		return 0, false
+	}
+	// Extend over ".name" chains and any call parentheses that follow them.
+	for {
+		dot := nextSig(toks, end+1)
+		if dot < 0 || !isOpEq(toks[dot], ".") {
+			return end, true
+		}
+		name := nextSig(toks, dot+1)
+		if name < 0 || !isName(toks[name]) {
+			return end, true
+		}
+		end = name
+		if e, ok := adjacentCallEnd(toks, end); ok {
+			if e < 0 {
+				return 0, false
+			}
+			end = e
+		}
+	}
+}
+
+// adjacentCallEnd reports whether the name at nameIdx is immediately followed by
+// a "(" (a function call, as in count(*), not a name separated from a
+// parenthesized expression by whitespace) and, if so, returns the index of the
+// matching ")". A returned index of -1 means the parentheses are unbalanced.
+func adjacentCallEnd(toks []token, nameIdx int) (int, bool) {
+	if nameIdx+1 < len(toks) && isOpEq(toks[nameIdx+1], "(") {
+		return matchParen(toks, nameIdx+1), true
+	}
+	return 0, false
+}

--- a/dialect/token_test.go
+++ b/dialect/token_test.go
@@ -24,6 +24,8 @@ func TestTranslateLexical(t *testing.T) {
 		{"mysql hash comment", MySQL, "SELECT 1 # note", "SELECT 1 -- note\n"},
 		{"mysql backslash escape", MySQL, `SELECT 'It\'s'`, `SELECT 'It''s'`},
 		{"mysql doubled quote", MySQL, `SELECT 'a''b'`, `SELECT 'a''b'`},
+		{"mysql backslash escapes", MySQL, `SELECT 'a\nb\tc\\d\0e'`, "SELECT 'a\nb\tc\\d\x00e'"},
+		{"mysql backslash unknown", MySQL, `SELECT 'a\qb'`, `SELECT 'aqb'`},
 		{"mysql blob passthrough", MySQL, `SELECT x'4142'`, `SELECT x'4142'`},
 
 		// PostgreSQL lexical rules.
@@ -86,6 +88,35 @@ func TestTranslateInvalidSyntax(t *testing.T) {
 				t.Fatalf("Translate(%s, %q) error = %v, want ErrInvalidSyntax", tt.dialect, tt.input, err)
 			}
 		})
+	}
+}
+
+func TestDecodeBackslash(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want string
+		adv  int
+	}{
+		{`\n`, "\n", 2},
+		{`\t`, "\t", 2},
+		{`\r`, "\r", 2},
+		{`\0`, "\x00", 2},
+		{`\b`, "\b", 2},
+		{`\f`, "\f", 2},
+		{`\v`, "\v", 2},
+		{`\\`, "\\", 2},
+		{`\'`, "'", 2},
+		{`\"`, "\"", 2},
+		{"\\`", "`", 2},
+		{`\q`, "q", 2}, // unknown escape drops the backslash
+		{`\`, "\\", 1}, // trailing backslash with nothing after it
+	}
+	for _, c := range cases {
+		got, adv := decodeBackslash(c.in, 0)
+		if got != c.want || adv != c.adv {
+			t.Fatalf("decodeBackslash(%q) = (%q, %d), want (%q, %d)", c.in, got, adv, c.want, c.adv)
+		}
 	}
 }
 

--- a/dialect/typemap.go
+++ b/dialect/typemap.go
@@ -1,0 +1,56 @@
+package dialect
+
+import "strings"
+
+// SQLite storage-class-ish type names used as CAST targets. SQLite applies type
+// affinity from these, which is the closest equivalent to the source dialects'
+// richer type systems.
+const (
+	sqliteInteger = "INTEGER"
+	sqliteReal    = "REAL"
+	sqliteText    = "TEXT"
+	sqliteBlob    = "BLOB"
+)
+
+// mysqlCastTypes maps a MySQL CAST/CONVERT target type (its leading keyword,
+// uppercased) to the SQLite type used in the rewritten CAST. A type not present
+// here is left unchanged so SQLite can interpret it.
+var mysqlCastTypes = map[string]string{
+	"SIGNED":    sqliteInteger,
+	"UNSIGNED":  sqliteInteger,
+	"INT":       sqliteInteger,
+	"INTEGER":   sqliteInteger,
+	"BIGINT":    sqliteInteger,
+	"SMALLINT":  sqliteInteger,
+	"TINYINT":   sqliteInteger,
+	"MEDIUMINT": sqliteInteger,
+	"BOOL":      sqliteInteger,
+	"BOOLEAN":   sqliteInteger,
+	"CHAR":      sqliteText,
+	"NCHAR":     sqliteText,
+	"VARCHAR":   sqliteText,
+	"NVARCHAR":  sqliteText,
+	"TEXT":      sqliteText,
+	"JSON":      sqliteText,
+	"DECIMAL":   sqliteReal,
+	"DEC":       sqliteReal,
+	"NUMERIC":   sqliteReal,
+	"FLOAT":     sqliteReal,
+	"DOUBLE":    sqliteReal,
+	"REAL":      sqliteReal,
+	"DATE":      sqliteText,
+	"DATETIME":  sqliteText,
+	"TIME":      sqliteText,
+	"TIMESTAMP": sqliteText,
+	"YEAR":      sqliteText,
+	"BINARY":    sqliteBlob,
+	"VARBINARY": sqliteBlob,
+	"BLOB":      sqliteBlob,
+}
+
+// lookupCastType returns the SQLite CAST target for a source-dialect type name
+// and whether a mapping exists.
+func lookupCastType(m map[string]string, name string) (string, bool) {
+	mapped, ok := m[strings.ToUpper(name)]
+	return mapped, ok
+}


### PR DESCRIPTION
## What

Second PR of the multi-dialect series (stacked on #168). Adds the **MySQL** translator and the **dialect helper UDFs**.

> Base is `feat/dialect-core` (#168), so this PR's diff is only the MySQL/UDF work. Please merge #168 first.

## MySQL rewrite rules

Translation now runs a per-dialect token rewrite between tokenizing and rendering. MySQL structural rules (rule IDs match the design doc):

| ID | From | To |
|----|------|----|
| C-1 | `EXTRACT(part FROM x)` | `DATE_PART('part', x)` |
| M-5 | `DATE_ADD/DATE_SUB(x, INTERVAL n unit)` | `datetime(x, '±n unit')` |
| M-6 | `GROUP_CONCAT(x SEPARATOR s)` | `group_concat(x, s)` |
| M-7 | `a DIV b` | `CAST(a / b AS INTEGER)` |
| M-8 | `CAST(x AS mysql_type)` | `CAST(x AS sqlite_type)` |
| M-9 | `x RLIKE p` | `x REGEXP p` |

- M-1..M-4 (backtick identifiers, double-quoted strings, `#` comments, backslash escapes) are already handled by the tokenizer/renderer from #168.
- M-10 (`LIMIT n, m`) is native to SQLite; no rewrite.
- Unsupported INTERVAL units and non-primary `DIV` operands return `ErrUnsupportedSyntax`.

## Helper functions

`RegisterFunctions()` installs UDFs into `modernc.org/sqlite` via `sync.Once` (process-global, applies to connections opened afterward) so translated queries resolve: REGEXP, IF, NOW, DATE_FORMAT, STR_TO_DATE, DATEDIFF, DATE_PART, YEAR/MONTH/DAY/HOUR/MINUTE/SECOND/DAYOFWEEK/DAYOFYEAR/WEEKDAY, LOCATE, LPAD/RPAD, SUBSTRING_INDEX, REPEAT, SPACE, TRUNCATE, CURDATE/CURTIME, RAND. Registered as one set regardless of the active dialect. `RAND` uses `crypto/rand` (no seeded global PRNG).

Shared token-rewrite machinery (parenthesis matching, primary-expression boundary detection, token constructors) is in `rewrite.go`; the CAST type map is in `typemap.go`.

## Tests

- Rule-ID golden tests (`TestMySQLTranslate/M-5_date_add`, etc.) and unsupported-syntax cases.
- UDF execution tests through a real SQLite connection, plus NULL-propagation and boundary cases.
- `decodeBackslash` unit test; extended fuzz corpus (runs across all dialects, idempotency invariant).

Dialect package coverage **91.6%**; module total **89.5%**. `golangci-lint` clean.