### PR TITLE
feat(dialect): add PostgreSQL translator and helper functions

### DIFF
--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -134,6 +134,8 @@ func rewriteTokens(d Dialect, tokens []token) ([]token, error) {
 	switch d {
 	case MySQL:
 		return rewriteMySQL(tokens)
+	case PostgreSQL:
+		return rewritePostgreSQL(tokens)
 	default:
 		return tokens, nil
 	}

--- a/dialect/functions.go
+++ b/dialect/functions.go
@@ -50,6 +50,15 @@ var (
 // layoutDateTime is the canonical datetime string the helpers emit.
 const layoutDateTime = "2006-01-02 15:04:05"
 
+// Go reference-time fragments for month and weekday names, shared by the MySQL
+// and PostgreSQL format mappings.
+const (
+	layoutMonthLong    = "January"
+	layoutMonthShort   = "Jan"
+	layoutWeekdayLong  = "Monday"
+	layoutWeekdayShort = "Mon"
+)
+
 // Date-part / interval unit names shared by the date helpers and the interval
 // rewrite so the same spelling is used for a function name, an INTERVAL unit,
 // and a DATE_PART argument.
@@ -98,6 +107,17 @@ func registerAll() error {
 		"repeat":          {2, fnRepeat},
 		"space":           {1, fnSpace},
 		"truncate":        {2, fnTruncate},
+
+		// PostgreSQL helpers.
+		"to_char":        {2, fnToChar},
+		"to_date":        {2, fnToDate},
+		"date_trunc":     {2, fnDateTrunc},
+		"split_part":     {3, fnSplitPart},
+		"initcap":        {1, fnInitcap},
+		"strpos":         {2, fnStrpos},
+		"left":           {2, fnLeft},
+		"right":          {2, fnRight},
+		"regexp_replace": {3, fnRegexpReplace},
 	}
 	for name, spec := range det {
 		if err := sqlite.RegisterDeterministicScalarFunction(name, spec.nArg, wrapScalar(spec.fn)); err != nil {
@@ -312,10 +332,10 @@ var mysqlToGoLayout = map[byte]string{
 	's': "05",
 	'S': "05",
 	'p': "PM",
-	'M': "January",
-	'b': "Jan",
-	'W': "Monday",
-	'a': "Mon",
+	'M': layoutMonthLong,
+	'b': layoutMonthShort,
+	'W': layoutWeekdayLong,
+	'a': layoutWeekdayShort,
 }
 
 // fnDateFormat implements MySQL DATE_FORMAT(date, format).
@@ -591,6 +611,267 @@ func fnTruncate(args []driver.Value) (driver.Value, error) {
 	}
 	factor := math.Pow(10, float64(d))
 	return math.Trunc(x*factor) / factor, nil
+}
+
+// --- PostgreSQL scalar functions ---
+
+// pgToCharTokens maps TO_CHAR template patterns to Go reference-time layout
+// fragments, longest first so the scanner prefers the longest match.
+var pgToCharTokens = []struct{ pat, layout string }{
+	{"YYYY", "2006"},
+	{"YY", "06"},
+	{"MONTH", layoutMonthLong},
+	{"Month", layoutMonthLong},
+	{"MON", layoutMonthShort},
+	{"Mon", layoutMonthShort},
+	{"MM", "01"},
+	{"DAY", layoutWeekdayLong},
+	{"Day", layoutWeekdayLong},
+	{"DY", layoutWeekdayShort},
+	{"Dy", layoutWeekdayShort},
+	{"DD", "02"},
+	{"HH24", "15"},
+	{"HH12", "03"},
+	{"HH", "03"},
+	{"MI", "04"},
+	{"SS", "05"},
+	{"AM", "PM"},
+	{"PM", "PM"},
+	{"am", "pm"},
+	{"pm", "pm"},
+}
+
+// toCharLayout converts a PostgreSQL TO_CHAR/TO_DATE template into a Go layout,
+// dropping the "FM" fill-mode prefix and passing literal characters through.
+func toCharLayout(format string) string {
+	var b strings.Builder
+	for i := 0; i < len(format); {
+		if strings.HasPrefix(format[i:], "FM") {
+			i += 2
+			continue
+		}
+		matched := false
+		for _, tok := range pgToCharTokens {
+			if strings.HasPrefix(format[i:], tok.pat) {
+				b.WriteString(tok.layout)
+				i += len(tok.pat)
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			b.WriteByte(format[i])
+			i++
+		}
+	}
+	return b.String()
+}
+
+// fnToChar implements PostgreSQL TO_CHAR(value, format) for date/time values.
+func fnToChar(args []driver.Value) (driver.Value, error) {
+	format, ok := toString(args[1])
+	if !ok {
+		return nil, nil
+	}
+	tm, ok := toStringTime(args[0])
+	if !ok {
+		return nil, nil
+	}
+	return tm.Format(toCharLayout(format)), nil
+}
+
+// fnToDate implements PostgreSQL TO_DATE(str, format).
+func fnToDate(args []driver.Value) (driver.Value, error) {
+	s, ok := toString(args[0])
+	format, ok2 := toString(args[1])
+	if !ok || !ok2 {
+		return nil, nil
+	}
+	tm, ok := parseLayout(toCharLayout(format), s)
+	if !ok {
+		return nil, nil
+	}
+	return tm.Format("2006-01-02"), nil
+}
+
+// fnDateTrunc implements PostgreSQL DATE_TRUNC(unit, timestamp).
+func fnDateTrunc(args []driver.Value) (driver.Value, error) {
+	unit, ok := toString(args[0])
+	if !ok {
+		return nil, nil
+	}
+	tm, ok := toStringTime(args[1])
+	if !ok {
+		return nil, nil
+	}
+	y, mo, d := tm.Date()
+	loc := tm.Location()
+	switch strings.ToLower(strings.TrimSpace(unit)) {
+	case unitYear:
+		return time.Date(y, 1, 1, 0, 0, 0, 0, loc).Format(layoutDateTime), nil
+	case "quarter":
+		q := (int(mo)-1)/3*3 + 1
+		return time.Date(y, time.Month(q), 1, 0, 0, 0, 0, loc).Format(layoutDateTime), nil
+	case unitMonth:
+		return time.Date(y, mo, 1, 0, 0, 0, 0, loc).Format(layoutDateTime), nil
+	case "week":
+		offset := (int(tm.Weekday()) + 6) % 7 // days since Monday
+		monday := time.Date(y, mo, d, 0, 0, 0, 0, loc).AddDate(0, 0, -offset)
+		return monday.Format(layoutDateTime), nil
+	case unitDay:
+		return time.Date(y, mo, d, 0, 0, 0, 0, loc).Format(layoutDateTime), nil
+	case unitHour:
+		return time.Date(y, mo, d, tm.Hour(), 0, 0, 0, loc).Format(layoutDateTime), nil
+	case unitMinute:
+		return time.Date(y, mo, d, tm.Hour(), tm.Minute(), 0, 0, loc).Format(layoutDateTime), nil
+	case unitSecond:
+		return time.Date(y, mo, d, tm.Hour(), tm.Minute(), tm.Second(), 0, loc).Format(layoutDateTime), nil
+	default:
+		return nil, fmt.Errorf("dialect: unsupported DATE_TRUNC unit %q", unit)
+	}
+}
+
+// fnSplitPart implements PostgreSQL SPLIT_PART(string, delimiter, n) with a
+// 1-based field index.
+func fnSplitPart(args []driver.Value) (driver.Value, error) {
+	s, ok1 := toString(args[0])
+	delim, ok2 := toString(args[1])
+	n, ok3 := toInt(args[2])
+	if !ok1 || !ok2 || !ok3 {
+		return nil, nil
+	}
+	if delim == "" {
+		if n == 1 || n == -1 {
+			return s, nil
+		}
+		return "", nil
+	}
+	parts := strings.Split(s, delim)
+	idx := int(n)
+	if idx < 0 {
+		idx = len(parts) + idx + 1
+	}
+	if idx < 1 || idx > len(parts) {
+		return "", nil
+	}
+	return parts[idx-1], nil
+}
+
+// fnInitcap implements PostgreSQL INITCAP: uppercase the first letter of each
+// alphanumeric run, lowercase the rest.
+func fnInitcap(args []driver.Value) (driver.Value, error) {
+	s, ok := toString(args[0])
+	if !ok {
+		return nil, nil
+	}
+	var b strings.Builder
+	prevAlnum := false
+	for _, r := range s {
+		alnum := isAlnumRune(r)
+		switch {
+		case alnum && !prevAlnum:
+			b.WriteString(strings.ToUpper(string(r)))
+		case alnum:
+			b.WriteString(strings.ToLower(string(r)))
+		default:
+			b.WriteRune(r)
+		}
+		prevAlnum = alnum
+	}
+	return b.String(), nil
+}
+
+func isAlnumRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}
+
+// fnStrpos implements PostgreSQL STRPOS(string, substring): 1-based index or 0.
+func fnStrpos(args []driver.Value) (driver.Value, error) {
+	s, ok1 := toString(args[0])
+	sub, ok2 := toString(args[1])
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+	idx := strings.Index(s, sub)
+	if idx < 0 {
+		return int64(0), nil
+	}
+	return int64(idx + 1), nil
+}
+
+func fnLeft(args []driver.Value) (driver.Value, error)  { return leftRight(args, true) }
+func fnRight(args []driver.Value) (driver.Value, error) { return leftRight(args, false) }
+
+// leftRight implements LEFT/RIGHT with PostgreSQL's negative-count semantics: a
+// negative n removes |n| characters from the far end.
+func leftRight(args []driver.Value, left bool) (driver.Value, error) {
+	s, ok1 := toString(args[0])
+	n, ok2 := toInt(args[1])
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+	runes := []rune(s)
+	count := int(n)
+	if count < 0 {
+		count = len(runes) + count
+	}
+	if count <= 0 {
+		return "", nil
+	}
+	if count > len(runes) {
+		count = len(runes)
+	}
+	if left {
+		return string(runes[:count]), nil
+	}
+	return string(runes[len(runes)-count:]), nil
+}
+
+// fnRegexpReplace implements REGEXP_REPLACE(source, pattern, replacement),
+// replacing every match. PostgreSQL back-references (\1) are translated to Go's
+// ${1} expansion form.
+func fnRegexpReplace(args []driver.Value) (driver.Value, error) {
+	src, ok1 := toString(args[0])
+	pattern, ok2 := toString(args[1])
+	repl, ok3 := toString(args[2])
+	if !ok1 || !ok2 || !ok3 {
+		return nil, nil
+	}
+	re, err := compileRegexp(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return re.ReplaceAllString(src, pgReplacement(repl)), nil
+}
+
+// pgReplacement translates PostgreSQL replacement back-references (\1..\9, \&) to
+// the ${n} form Go's regexp expansion understands.
+func pgReplacement(repl string) string {
+	var b strings.Builder
+	for i := 0; i < len(repl); i++ {
+		if repl[i] == '\\' && i+1 < len(repl) {
+			c := repl[i+1]
+			switch {
+			case c >= '0' && c <= '9':
+				b.WriteString("${")
+				b.WriteByte(c)
+				b.WriteByte('}')
+			case c == '&':
+				b.WriteString("${0}")
+			default:
+				b.WriteByte(c)
+			}
+			i++
+			continue
+		}
+		if repl[i] == '$' {
+			// Escape a literal '$' so Go does not treat it as an expansion.
+			b.WriteString("$$")
+			continue
+		}
+		b.WriteByte(repl[i])
+	}
+	return b.String()
 }
 
 // --- time parsing ---

--- a/dialect/functions_test.go
+++ b/dialect/functions_test.go
@@ -82,6 +82,56 @@ func TestUDFExecution(t *testing.T) {
 	}
 }
 
+// TestPostgreSQLUDFExecution runs the PostgreSQL helper UDFs through a real
+// SQLite connection.
+func TestPostgreSQLUDFExecution(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{"to_char date", `SELECT TO_CHAR('2026-07-28 13:05:09', 'YYYY-MM-DD HH24:MI:SS')`, "2026-07-28 13:05:09"},
+		{"to_char month name", `SELECT TO_CHAR('2026-07-28', 'FMMonth DD, YYYY')`, "July 28, 2026"},
+		{"to_date", `SELECT TO_DATE('28/07/2026', 'DD/MM/YYYY')`, "2026-07-28"},
+		{"date_trunc month", `SELECT DATE_TRUNC('month', '2026-07-28 13:05:09')`, "2026-07-01 00:00:00"},
+		{"date_trunc year", `SELECT DATE_TRUNC('year', '2026-07-28')`, "2026-01-01 00:00:00"},
+		{"date_trunc quarter", `SELECT DATE_TRUNC('quarter', '2026-07-28')`, "2026-07-01 00:00:00"},
+		{"date_trunc week", `SELECT DATE_TRUNC('week', '2026-07-28')`, "2026-07-27 00:00:00"}, // Monday
+		{"split_part", `SELECT SPLIT_PART('a,b,c', ',', 2)`, "b"},
+		{"split_part neg", `SELECT SPLIT_PART('a,b,c', ',', -1)`, "c"},
+		{"split_part out of range", `SELECT SPLIT_PART('a,b', ',', 5)`, ""},
+		{"initcap", `SELECT INITCAP('hello WORLD_foo')`, "Hello World_Foo"},
+		{"strpos", `SELECT STRPOS('abcabc', 'c')`, "3"},
+		{"strpos not found", `SELECT STRPOS('abc', 'z')`, "0"},
+		{"left", `SELECT LEFT('abcdef', 3)`, "abc"},
+		{"left negative", `SELECT LEFT('abcdef', -2)`, "abcd"},
+		{"right", `SELECT RIGHT('abcdef', 2)`, "ef"},
+		{"right negative", `SELECT RIGHT('abcdef', -2)`, "cdef"},
+		{"regexp_replace", `SELECT REGEXP_REPLACE('foobar', 'o+', 'O')`, "fObar"},
+		{"regexp_replace backref", `SELECT REGEXP_REPLACE('2026-07', '(\d+)-(\d+)', '\2/\1')`, "07/2026"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got sql.NullString
+			if err := db.QueryRowContext(context.Background(), tt.sql).Scan(&got); err != nil {
+				t.Fatalf("%s: query error: %v", tt.sql, err)
+			}
+			if got.String != tt.want {
+				t.Fatalf("%s = %q, want %q", tt.sql, got.String, tt.want)
+			}
+		})
+	}
+}
+
 // TestUDFNullHandling verifies that NULL arguments propagate to NULL for the
 // string/number helpers.
 func TestUDFNullHandling(t *testing.T) {
@@ -101,6 +151,18 @@ func TestUDFNullHandling(t *testing.T) {
 		`SELECT YEAR(NULL)`,
 		`SELECT TRUNCATE(NULL, 2)`,
 		`SELECT DATEDIFF('2026-01-01', NULL)`,
+		`SELECT TO_CHAR(NULL, 'YYYY')`,
+		`SELECT TO_CHAR('2026-01-01', NULL)`,
+		`SELECT TO_DATE(NULL, 'YYYY')`,
+		`SELECT DATE_TRUNC('day', NULL)`,
+		`SELECT DATE_TRUNC(NULL, '2026-01-01')`,
+		`SELECT SPLIT_PART(NULL, ',', 1)`,
+		`SELECT INITCAP(NULL)`,
+		`SELECT STRPOS(NULL, 'a')`,
+		`SELECT LEFT(NULL, 2)`,
+		`SELECT REGEXP_REPLACE(NULL, 'a', 'b')`,
+		`SELECT DATE_PART('year', NULL)`,
+		`SELECT DATE_PART(NULL, '2026-01-01')`,
 	} {
 		var got sql.NullString
 		if err := db.QueryRowContext(context.Background(), q).Scan(&got); err != nil {
@@ -191,10 +253,14 @@ func TestDatePartUnsupported(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = db.Close() })
 
-	var got sql.NullString
-	err = db.QueryRowContext(context.Background(), `SELECT DATE_PART('century', '2026-07-28')`).Scan(&got)
-	if err == nil {
-		t.Fatal("DATE_PART('century', ...) should error")
+	for _, q := range []string{
+		`SELECT DATE_PART('century', '2026-07-28')`,
+		`SELECT DATE_TRUNC('decade', '2026-07-28')`,
+	} {
+		var got sql.NullString
+		if err := db.QueryRowContext(context.Background(), q).Scan(&got); err == nil {
+			t.Fatalf("%s should error", q)
+		}
 	}
 }
 

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -70,7 +70,7 @@ func mysqlCallPass(tokens []token) ([]token, error) {
 func mysqlRewriteCall(tokens []token, nameIdx, open, closeIdx int) ([]token, bool, error) {
 	switch strings.ToUpper(tokens[nameIdx].text) {
 	case "EXTRACT":
-		return rewriteExtract(tokens, open, closeIdx)
+		return rewriteExtractCall(tokens, open, closeIdx, mysqlCallPass)
 	case "DATE_ADD":
 		return rewriteDateArith(tokens, open, closeIdx, "+")
 	case "DATE_SUB":
@@ -78,34 +78,10 @@ func mysqlRewriteCall(tokens []token, nameIdx, open, closeIdx int) ([]token, boo
 	case "GROUP_CONCAT":
 		return rewriteGroupConcat(tokens, nameIdx, open, closeIdx)
 	case "CAST":
-		return rewriteCast(tokens, nameIdx, open, closeIdx, mysqlCastTypes)
+		return rewriteCastCall(tokens, nameIdx, open, closeIdx, mysqlCastTypes, mysqlCallPass)
 	default:
 		return nil, false, nil
 	}
-}
-
-// rewriteExtract implements C-1: EXTRACT(part FROM x) -> DATE_PART('part', x).
-func rewriteExtract(tokens []token, open, closeIdx int) ([]token, bool, error) {
-	part := nextSig(tokens, open+1)
-	if part < 0 || tokens[part].kind != tokWord {
-		return nil, false, nil
-	}
-	from := nextSig(tokens, part+1)
-	if from < 0 || !isWordEq(tokens[from], "FROM") {
-		return nil, false, nil
-	}
-	expr, err := mysqlCallPass(tokens[from+1 : closeIdx])
-	if err != nil {
-		return nil, false, err
-	}
-	expr = trimSpaceTokens(expr)
-	repl := make([]token, 0, len(expr)+6)
-	repl = append(repl, wordToken("DATE_PART"), opToken("("))
-	repl = append(repl, stringToken(strings.ToLower(tokens[part].text)))
-	repl = append(repl, opToken(","), spaceToken())
-	repl = append(repl, expr...)
-	repl = append(repl, opToken(")"))
-	return repl, true, nil
 }
 
 // mysqlIntervalUnits maps the INTERVAL units supported by M-5 to the SQLite
@@ -188,33 +164,6 @@ func rewriteGroupConcat(tokens []token, nameIdx, open, closeIdx int) ([]token, b
 		repl = append(repl, inner[j])
 	}
 	repl = append(repl, opToken(")"))
-	return repl, true, nil
-}
-
-// rewriteCast implements M-8: CAST(x AS type) with the source type mapped to a
-// SQLite type via types. An unmapped type is left unchanged.
-func rewriteCast(tokens []token, nameIdx, open, closeIdx int, types map[string]string) ([]token, bool, error) {
-	as := topLevelWord(tokens, open, closeIdx, "AS")
-	if as < 0 {
-		return nil, false, nil
-	}
-	typeName := nextSig(tokens, as+1)
-	if typeName < 0 || tokens[typeName].kind != tokWord {
-		return nil, false, nil
-	}
-	mapped, ok := lookupCastType(types, tokens[typeName].text)
-	if !ok {
-		return nil, false, nil
-	}
-	expr, err := mysqlCallPass(tokens[open+1 : as])
-	if err != nil {
-		return nil, false, err
-	}
-	expr = trimSpaceTokens(expr)
-	repl := make([]token, 0, len(expr)+6)
-	repl = append(repl, tokens[nameIdx], opToken("("))
-	repl = append(repl, expr...)
-	repl = append(repl, spaceToken(), wordToken("AS"), spaceToken(), wordToken(mapped), opToken(")"))
 	return repl, true, nil
 }
 

--- a/dialect/postgresql.go
+++ b/dialect/postgresql.go
@@ -1,0 +1,296 @@
+package dialect
+
+import (
+	"fmt"
+	"strings"
+)
+
+// rewritePostgreSQL applies the PostgreSQL token rewrite rules. The lexical
+// rules (P-7 E'...'/$$...$$ strings) are handled by the tokenizer; TRUE/FALSE
+// (P-9) are native to SQLite. This pass handles the structural rules:
+//
+//	C-1  EXTRACT(part FROM x)      -> DATE_PART('part', x)
+//	P-1  expr::type                -> CAST(expr AS sqlite_type)
+//	P-2  x ILIKE p / NOT ILIKE     -> x LIKE p / NOT LIKE
+//	P-3  x ~ p / !~ / ~* / !~*     -> x REGEXP p / NOT REGEXP / case-insensitive
+//	P-4  POSITION(x IN y)          -> INSTR(y, x)
+//	P-5  SUBSTRING(x FROM n FOR m) -> SUBSTR(x, n, m)
+//	P-6  STRING_AGG(x, s)          -> group_concat(x, s)
+//	P-8  CAST(x AS pg_type)        -> CAST(x AS sqlite_type)
+//	P-10 DISTINCT ON (...), LATERAL -> ErrUnsupportedSyntax
+func rewritePostgreSQL(tokens []token) ([]token, error) {
+	if err := checkUnsupportedPostgreSQL(tokens); err != nil {
+		return nil, err
+	}
+	out, err := pgCallPass(tokens)
+	if err != nil {
+		return nil, err
+	}
+	out, err = pgCastOperatorPass(out)
+	if err != nil {
+		return nil, err
+	}
+	out, err = pgRegexOperatorPass(out)
+	if err != nil {
+		return nil, err
+	}
+	out = renameWordPass(out, "ILIKE", "LIKE")
+	out = renameWordPass(out, "STRING_AGG", "group_concat")
+	return out, nil
+}
+
+// checkUnsupportedPostgreSQL rejects P-10 constructs that have no SQLite
+// equivalent: "DISTINCT ON (...)" and the LATERAL keyword.
+func checkUnsupportedPostgreSQL(tokens []token) error {
+	for i, t := range tokens {
+		if !isSignificant(t) {
+			continue
+		}
+		if isWordEq(t, "LATERAL") {
+			return fmt.Errorf("%w: LATERAL is not supported", ErrUnsupportedSyntax)
+		}
+		if isWordEq(t, "DISTINCT") {
+			if on := nextSig(tokens, i+1); on >= 0 && isWordEq(tokens[on], "ON") {
+				return fmt.Errorf("%w: DISTINCT ON is not supported", ErrUnsupportedSyntax)
+			}
+		}
+	}
+	return nil
+}
+
+// pgCallPass rewrites the PostgreSQL function-call rules (C-1, P-4, P-5, P-8),
+// recursing into the arguments of recognized calls.
+func pgCallPass(tokens []token) ([]token, error) {
+	out := make([]token, 0, len(tokens))
+	i := 0
+	for i < len(tokens) {
+		t := tokens[i]
+		if t.kind == tokWord {
+			open := nextSig(tokens, i+1)
+			if open >= 0 && isOpEq(tokens[open], "(") {
+				closeIdx := matchParen(tokens, open)
+				if closeIdx < 0 {
+					return nil, fmt.Errorf("%w: unbalanced parentheses after %s", ErrInvalidSyntax, t.text)
+				}
+				repl, handled, err := pgRewriteCall(tokens, i, open, closeIdx)
+				if err != nil {
+					return nil, err
+				}
+				if handled {
+					out = append(out, repl...)
+					i = closeIdx + 1
+					continue
+				}
+			}
+		}
+		out = append(out, t)
+		i++
+	}
+	return out, nil
+}
+
+func pgRewriteCall(tokens []token, nameIdx, open, closeIdx int) ([]token, bool, error) {
+	switch strings.ToUpper(tokens[nameIdx].text) {
+	case "EXTRACT":
+		return rewriteExtractCall(tokens, open, closeIdx, pgCallPass)
+	case "POSITION":
+		return rewritePosition(tokens, open, closeIdx)
+	case "SUBSTRING":
+		return rewriteSubstring(tokens, open, closeIdx)
+	case "CAST":
+		return rewriteCastCall(tokens, nameIdx, open, closeIdx, pgCastTypes, pgCallPass)
+	default:
+		return nil, false, nil
+	}
+}
+
+// rewritePosition implements P-4: POSITION(x IN y) -> INSTR(y, x).
+func rewritePosition(tokens []token, open, closeIdx int) ([]token, bool, error) {
+	in := topLevelWord(tokens, open, closeIdx, "IN")
+	if in < 0 {
+		return nil, false, nil
+	}
+	needle, err := pgCallPass(tokens[open+1 : in])
+	if err != nil {
+		return nil, false, err
+	}
+	haystack, err := pgCallPass(tokens[in+1 : closeIdx])
+	if err != nil {
+		return nil, false, err
+	}
+	needle = trimSpaceTokens(needle)
+	haystack = trimSpaceTokens(haystack)
+	repl := make([]token, 0, len(needle)+len(haystack)+5)
+	repl = append(repl, wordToken("INSTR"), opToken("("))
+	repl = append(repl, haystack...)
+	repl = append(repl, opToken(","), spaceToken())
+	repl = append(repl, needle...)
+	repl = append(repl, opToken(")"))
+	return repl, true, nil
+}
+
+// rewriteSubstring implements P-5: SUBSTRING(x FROM n FOR m) -> SUBSTR(x, n, m).
+// The FROM and FOR parts are each optional; a missing FROM defaults the start to
+// 1. The comma-argument form SUBSTRING(x, n, m) is left unchanged (SQLite accepts
+// it natively).
+func rewriteSubstring(tokens []token, open, closeIdx int) ([]token, bool, error) {
+	from := topLevelWord(tokens, open, closeIdx, "FROM")
+	forKw := topLevelWord(tokens, open, closeIdx, "FOR")
+	if from < 0 && forKw < 0 {
+		return nil, false, nil
+	}
+
+	// The subject ends at whichever of FROM/FOR is present (FROM first when both
+	// are). At least one exists here, since the no-keyword case returned above.
+	subjectEnd := forKw
+	if from >= 0 {
+		subjectEnd = from
+	}
+	subject, err := pgCallPass(tokens[open+1 : subjectEnd])
+	if err != nil {
+		return nil, false, err
+	}
+	subject = trimSpaceTokens(subject)
+
+	var start, length []token
+	if from >= 0 {
+		startEnd := closeIdx
+		if forKw > from {
+			startEnd = forKw
+		}
+		start, err = pgCallPass(tokens[from+1 : startEnd])
+		if err != nil {
+			return nil, false, err
+		}
+		start = trimSpaceTokens(start)
+	}
+	if forKw >= 0 {
+		length, err = pgCallPass(tokens[forKw+1 : closeIdx])
+		if err != nil {
+			return nil, false, err
+		}
+		length = trimSpaceTokens(length)
+	}
+
+	repl := make([]token, 0, len(subject)+len(start)+len(length)+8)
+	repl = append(repl, wordToken("SUBSTR"), opToken("("))
+	repl = append(repl, subject...)
+	repl = append(repl, opToken(","), spaceToken())
+	if len(start) == 0 {
+		repl = append(repl, wordToken("1"))
+	} else {
+		repl = append(repl, start...)
+	}
+	if len(length) > 0 {
+		repl = append(repl, opToken(","), spaceToken())
+		repl = append(repl, length...)
+	}
+	repl = append(repl, opToken(")"))
+	return repl, true, nil
+}
+
+// pgCastOperatorPass implements P-1: expr::type -> CAST(expr AS sqlite_type).
+// It processes "::" left to right, so a chain such as a::int::text nests into
+// CAST(CAST(a AS INTEGER) AS TEXT).
+func pgCastOperatorPass(tokens []token) ([]token, error) {
+	out := make([]token, 0, len(tokens))
+	i := 0
+	for i < len(tokens) {
+		if isOpEq(tokens[i], "::") {
+			start, ok := primaryStartBack(out)
+			if !ok {
+				return nil, fmt.Errorf("%w: left operand of :: is not a primary expression", ErrUnsupportedSyntax)
+			}
+			typeName := nextSig(tokens, i+1)
+			if typeName < 0 || tokens[typeName].kind != tokWord {
+				return nil, fmt.Errorf("%w: :: is missing a type name", ErrUnsupportedSyntax)
+			}
+			typeEnd := typeName
+			if e, ok := adjacentCallEnd(tokens, typeName); ok {
+				if e < 0 {
+					return nil, fmt.Errorf("%w: unbalanced type parameters in :: cast", ErrInvalidSyntax)
+				}
+				typeEnd = e
+			}
+
+			left := append([]token{}, trimSpaceTokens(out[start:])...)
+			out = out[:start]
+			out = append(out, wordToken("CAST"), opToken("("))
+			out = append(out, left...)
+			out = append(out, spaceToken(), wordToken("AS"), spaceToken())
+			if mapped, ok := lookupCastType(pgCastTypes, tokens[typeName].text); ok {
+				out = append(out, wordToken(mapped))
+			} else {
+				out = append(out, tokens[typeName:typeEnd+1]...)
+			}
+			out = append(out, opToken(")"))
+			i = typeEnd + 1
+			continue
+		}
+		out = append(out, tokens[i])
+		i++
+	}
+	return out, nil
+}
+
+// pgRegexOperatorPass implements P-3: the "~" family of regex-match operators.
+//
+//	x ~ p    -> x REGEXP p
+//	x !~ p   -> x NOT REGEXP p
+//	x ~* p   -> x REGEXP '(?i)p'    (p must be a string literal)
+//	x !~* p  -> x NOT REGEXP '(?i)p'
+func pgRegexOperatorPass(tokens []token) ([]token, error) {
+	out := make([]token, 0, len(tokens))
+	caseInsensitivePending := false
+	for i := range tokens {
+		t := tokens[i]
+		if caseInsensitivePending && isSignificant(t) {
+			if t.kind != tokString {
+				return nil, fmt.Errorf("%w: case-insensitive regex operator requires a string-literal pattern", ErrUnsupportedSyntax)
+			}
+			out = append(out, stringToken("(?i)"+t.text))
+			caseInsensitivePending = false
+			continue
+		}
+		if t.kind == tokOp {
+			switch t.text {
+			case "~":
+				out = appendRegexOperator(out, tokens, i, false)
+				continue
+			case "!~":
+				out = appendRegexOperator(out, tokens, i, true)
+				continue
+			case "~*":
+				out = appendRegexOperator(out, tokens, i, false)
+				caseInsensitivePending = true
+				continue
+			case "!~*":
+				out = appendRegexOperator(out, tokens, i, true)
+				caseInsensitivePending = true
+				continue
+			}
+		}
+		out = append(out, t)
+	}
+	if caseInsensitivePending {
+		return nil, fmt.Errorf("%w: case-insensitive regex operator requires a string-literal pattern", ErrUnsupportedSyntax)
+	}
+	return out, nil
+}
+
+// appendRegexOperator appends "REGEXP" (or "NOT REGEXP" when negated) in place of
+// a regex operator token at index i, inserting single spaces only where the
+// original text lacked whitespace so the result reads "x REGEXP p".
+func appendRegexOperator(out, tokens []token, i int, negated bool) []token {
+	if n := len(out); n > 0 && out[n-1].kind != tokWhitespace {
+		out = append(out, spaceToken())
+	}
+	if negated {
+		out = append(out, wordToken("NOT"), spaceToken())
+	}
+	out = append(out, wordToken("REGEXP"))
+	if i+1 < len(tokens) && tokens[i+1].kind != tokWhitespace {
+		out = append(out, spaceToken())
+	}
+	return out
+}

--- a/dialect/postgresql_test.go
+++ b/dialect/postgresql_test.go
@@ -1,0 +1,91 @@
+package dialect
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestPostgreSQLTranslate covers the PostgreSQL rewrite rules by rule ID.
+func TestPostgreSQLTranslate(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"C-1_extract", "SELECT EXTRACT(YEAR FROM d) FROM t", "SELECT DATE_PART('year', d) FROM t"},
+
+		{"P-1_cast", "SELECT a::int FROM t", "SELECT CAST(a AS INTEGER) FROM t"},
+		{"P-1_cast_text", "SELECT a::text", "SELECT CAST(a AS TEXT)"},
+		{"P-1_cast_chain", "SELECT a::int::text", "SELECT CAST(CAST(a AS INTEGER) AS TEXT)"},
+		{"P-1_cast_varchar_param", "SELECT a::varchar(50)", "SELECT CAST(a AS TEXT)"},
+		{"P-1_cast_unknown_type", "SELECT a::inet", "SELECT CAST(a AS inet)"},
+		{"P-1_cast_paren_operand", "SELECT (a + b)::int", "SELECT CAST((a + b) AS INTEGER)"},
+
+		{"P-2_ilike", "SELECT * FROM t WHERE name ILIKE 'a%'", "SELECT * FROM t WHERE name LIKE 'a%'"},
+		{"P-2_not_ilike", "SELECT * FROM t WHERE name NOT ILIKE 'a%'", "SELECT * FROM t WHERE name NOT LIKE 'a%'"},
+
+		{"P-3_match", "SELECT * FROM t WHERE name ~ '^a'", "SELECT * FROM t WHERE name REGEXP '^a'"},
+		{"P-3_not_match", "SELECT * FROM t WHERE name !~ '^a'", "SELECT * FROM t WHERE name NOT REGEXP '^a'"},
+		{"P-3_match_ci", "SELECT * FROM t WHERE name ~* '^a'", "SELECT * FROM t WHERE name REGEXP '(?i)^a'"},
+		{"P-3_not_match_ci", "SELECT * FROM t WHERE name !~* '^a'", "SELECT * FROM t WHERE name NOT REGEXP '(?i)^a'"},
+
+		{"P-4_position", "SELECT POSITION('b' IN name) FROM t", "SELECT INSTR(name, 'b') FROM t"},
+		{"P-4_position_expr", "SELECT POSITION(sub IN col) FROM t", "SELECT INSTR(col, sub) FROM t"},
+
+		{"P-5_substring_from_for", "SELECT SUBSTRING(name FROM 2 FOR 3) FROM t", "SELECT SUBSTR(name, 2, 3) FROM t"},
+		{"P-5_substring_from", "SELECT SUBSTRING(name FROM 2) FROM t", "SELECT SUBSTR(name, 2) FROM t"},
+		{"P-5_substring_for", "SELECT SUBSTRING(name FOR 3) FROM t", "SELECT SUBSTR(name, 1, 3) FROM t"},
+		{"P-5_substring_comma_passthrough", "SELECT SUBSTRING(name, 2, 3) FROM t", "SELECT SUBSTRING(name, 2, 3) FROM t"},
+
+		{"P-6_string_agg", "SELECT STRING_AGG(name, ', ') FROM t", "SELECT group_concat(name, ', ') FROM t"},
+
+		{"P-8_cast_int4", "SELECT CAST(x AS int4) FROM t", "SELECT CAST(x AS INTEGER) FROM t"},
+		{"P-8_cast_boolean", "SELECT CAST(x AS boolean)", "SELECT CAST(x AS INTEGER)"},
+		{"P-8_cast_bytea", "SELECT CAST(x AS bytea)", "SELECT CAST(x AS BLOB)"},
+
+		{"P-9_true_false", "SELECT * FROM t WHERE active = TRUE OR done = FALSE", "SELECT * FROM t WHERE active = TRUE OR done = FALSE"},
+
+		// Lexical rules P-7 handled by the tokenizer.
+		{"P-7_escape_string", `SELECT E'a\tb'`, "SELECT 'a\tb'"},
+		{"P-7_dollar_quote", "SELECT $$hi$$", "SELECT 'hi'"},
+
+		{"double_quoted_identifier_preserved", `SELECT "col" FROM "My Table"`, `SELECT "col" FROM "My Table"`},
+		{"nested_cast_in_position", "SELECT POSITION(x::text IN y) FROM t", "SELECT INSTR(y, CAST(x AS TEXT)) FROM t"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Translate(PostgreSQL, tt.input)
+			if err != nil {
+				t.Fatalf("Translate(PostgreSQL, %q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("Translate(PostgreSQL, %q)\n  = %q\nwant %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPostgreSQLTranslateUnsupported(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"P-10_distinct_on", "SELECT DISTINCT ON (a) a, b FROM t"},
+		{"P-10_lateral", "SELECT * FROM t, LATERAL (SELECT 1) s"},
+		{"P-3_ci_non_literal", "SELECT * FROM t WHERE a ~* b"},
+		{"P-1_missing_type", "SELECT a::"},
+		{"P-1_type_not_word", "SELECT a:: , b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Translate(PostgreSQL, tt.input)
+			if !errors.Is(err, ErrUnsupportedSyntax) {
+				t.Fatalf("Translate(PostgreSQL, %q) error = %v, want ErrUnsupportedSyntax", tt.input, err)
+			}
+		})
+	}
+}

--- a/dialect/rewrite.go
+++ b/dialect/rewrite.go
@@ -9,6 +9,64 @@ import "strings"
 // rendering preserves the original adjacency; rewrite rules therefore work in
 // terms of "significant" tokens (everything except whitespace and comments).
 
+// callRecurser rewrites a slice of argument tokens with a dialect's call pass so
+// nested recognized calls inside a rewritten call are handled too.
+type callRecurser func([]token) ([]token, error)
+
+// rewriteExtractCall implements the C-1 rule shared by every dialect:
+// EXTRACT(part FROM x) -> DATE_PART('part', x). It returns handled=false when the
+// call is not the "part FROM x" form so the caller leaves it untouched.
+func rewriteExtractCall(tokens []token, open, closeIdx int, recurse callRecurser) ([]token, bool, error) {
+	part := nextSig(tokens, open+1)
+	if part < 0 || tokens[part].kind != tokWord {
+		return nil, false, nil
+	}
+	from := nextSig(tokens, part+1)
+	if from < 0 || !isWordEq(tokens[from], "FROM") {
+		return nil, false, nil
+	}
+	expr, err := recurse(tokens[from+1 : closeIdx])
+	if err != nil {
+		return nil, false, err
+	}
+	expr = trimSpaceTokens(expr)
+	repl := make([]token, 0, len(expr)+6)
+	repl = append(repl, wordToken("DATE_PART"), opToken("("))
+	repl = append(repl, stringToken(strings.ToLower(tokens[part].text)))
+	repl = append(repl, opToken(","), spaceToken())
+	repl = append(repl, expr...)
+	repl = append(repl, opToken(")"))
+	return repl, true, nil
+}
+
+// rewriteCastCall maps the target type of a CAST(x AS type) call to a SQLite type
+// via types, shared by the dialects (M-8, P-8, G-4). An unmapped type leaves the
+// call unchanged (handled=false).
+func rewriteCastCall(tokens []token, nameIdx, open, closeIdx int, types map[string]string, recurse callRecurser) ([]token, bool, error) {
+	as := topLevelWord(tokens, open, closeIdx, "AS")
+	if as < 0 {
+		return nil, false, nil
+	}
+	typeName := nextSig(tokens, as+1)
+	if typeName < 0 || tokens[typeName].kind != tokWord {
+		return nil, false, nil
+	}
+	mapped, ok := lookupCastType(types, tokens[typeName].text)
+	if !ok {
+		return nil, false, nil
+	}
+	expr, err := recurse(tokens[open+1 : as])
+	if err != nil {
+		return nil, false, err
+	}
+	expr = trimSpaceTokens(expr)
+	repl := make([]token, 0, len(expr)+6)
+	repl = append(repl, tokens[nameIdx], opToken("("))
+	repl = append(repl, expr...)
+	repl = append(repl, spaceToken(), wordToken("AS"), spaceToken(), wordToken(mapped), opToken(")"))
+	return repl, true, nil
+}
+
 // trimSpaceTokens returns toks without leading or trailing whitespace tokens.
 func trimSpaceTokens(toks []token) []token {
 	lo, hi := 0, len(toks)

--- a/dialect/token_test.go
+++ b/dialect/token_test.go
@@ -34,7 +34,7 @@ func TestTranslateLexical(t *testing.T) {
 		{"postgres dollar quote", PostgreSQL, `SELECT $$hi$$`, `SELECT 'hi'`},
 		{"postgres tagged dollar quote", PostgreSQL, `SELECT $q$a'b$q$`, `SELECT 'a''b'`},
 		{"postgres numbered placeholder", PostgreSQL, `SELECT $1`, `SELECT $1`},
-		{"postgres cast passthrough", PostgreSQL, `SELECT a::int`, `SELECT a::int`},
+		{"postgres arithmetic passthrough", PostgreSQL, `SELECT a + b * c`, `SELECT a + b * c`},
 
 		// GoogleSQL lexical rules.
 		{"googlesql backtick path", GoogleSQL, "SELECT `p.d.t`", `SELECT "p.d.t"`},

--- a/dialect/typemap.go
+++ b/dialect/typemap.go
@@ -48,6 +48,44 @@ var mysqlCastTypes = map[string]string{
 	"BLOB":      sqliteBlob,
 }
 
+// pgCastTypes maps a PostgreSQL type name (uppercased) to the SQLite type used
+// in a rewritten CAST or "::" cast. A type not present here is left unchanged.
+var pgCastTypes = map[string]string{
+	"SMALLINT":    sqliteInteger,
+	"INT2":        sqliteInteger,
+	"INTEGER":     sqliteInteger,
+	"INT":         sqliteInteger,
+	"INT4":        sqliteInteger,
+	"BIGINT":      sqliteInteger,
+	"INT8":        sqliteInteger,
+	"SERIAL":      sqliteInteger,
+	"BIGSERIAL":   sqliteInteger,
+	"BOOLEAN":     sqliteInteger,
+	"BOOL":        sqliteInteger,
+	"REAL":        sqliteReal,
+	"FLOAT4":      sqliteReal,
+	"FLOAT8":      sqliteReal,
+	"DOUBLE":      sqliteReal, // "DOUBLE PRECISION"; leading keyword is DOUBLE
+	"NUMERIC":     sqliteReal,
+	"DECIMAL":     sqliteReal,
+	"MONEY":       sqliteReal,
+	"TEXT":        sqliteText,
+	"VARCHAR":     sqliteText,
+	"CHARACTER":   sqliteText, // "CHARACTER VARYING" / CHARACTER(n)
+	"CHAR":        sqliteText,
+	"BPCHAR":      sqliteText,
+	"NAME":        sqliteText,
+	"UUID":        sqliteText,
+	"JSON":        sqliteText,
+	"JSONB":       sqliteText,
+	"DATE":        sqliteText,
+	"TIME":        sqliteText,
+	"TIMESTAMP":   sqliteText,
+	"TIMESTAMPTZ": sqliteText,
+	"INTERVAL":    sqliteText,
+	"BYTEA":       sqliteBlob,
+}
+
 // lookupCastType returns the SQLite CAST target for a source-dialect type name
 // and whether a mapping exists.
 func lookupCastType(m map[string]string, name string) (string, bool) {


### PR DESCRIPTION
PostgreSQL translator and helper UDFs for the multi-dialect series (supersedes #170, which auto-closed when its stacked base branch was deleted during merge).

## Rules
| ID | From | To |
|----|------|----|
| C-1 | `EXTRACT(part FROM x)` | `DATE_PART('part', x)` |
| P-1 | `expr::type` | `CAST(expr AS sqlite_type)` (chains nest) |
| P-2 | `x ILIKE p` / `NOT ILIKE` | `x LIKE p` / `NOT LIKE` |
| P-3 | `x ~ p` / `!~` / `~*` / `!~*` | `x REGEXP p` / `x NOT REGEXP p` / `(?i)`-prefixed |
| P-4 | `POSITION(x IN y)` | `INSTR(y, x)` |
| P-5 | `SUBSTRING(x FROM n FOR m)` | `SUBSTR(x, n, m)` |
| P-6 | `STRING_AGG(x, s)` | `group_concat(x, s)` |
| P-8 | `CAST(x AS pg_type)` | `CAST(x AS sqlite_type)` |
| P-10 | `DISTINCT ON (...)`, `LATERAL` | `ErrUnsupportedSyntax` |

New UDFs: TO_CHAR, TO_DATE, DATE_TRUNC, SPLIT_PART, INITCAP, STRPOS, LEFT, RIGHT, REGEXP_REPLACE.

Dialect coverage 91.4%; module total 89.6%. golangci-lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL SQL translation support, including casts, `ILIKE`, regex operators, `EXTRACT`, `POSITION`, `SUBSTRING`, and `STRING_AGG`.
  * Added PostgreSQL-compatible date, string, formatting, and regular-expression functions.
  * Added PostgreSQL type mappings for SQLite-compatible casts.

* **Bug Fixes**
  * Improved nested expression handling when translating MySQL `EXTRACT` and `CAST` expressions.
  * Added clear errors for unsupported PostgreSQL syntax and invalid expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->