### PR TITLE
feat: add WithDialect to query in MySQL, PostgreSQL, or GoogleSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ filesql is for cases where the data is already in a file and the fastest useful 
 ## Features
 
 - Query file data with standard SQLite syntax, including joins, CTEs, and `json_extract()`.
+- Optionally query with MySQL, PostgreSQL, or GoogleSQL syntax via `WithDialect` (translated to SQLite).
 - Read from file paths, directories, `io.Reader`, and `embed.FS`.
 - Handle compressed CSV, TSV, LTSV, JSON, JSONL, Parquet, and XLSX files transparently.
 - Load into a new in-memory database or into a `*sql.DB` you already manage.
@@ -120,6 +121,64 @@ func main() {
 	}
 }
 ```
+
+### Query with another SQL dialect
+
+By default queries use SQLite syntax. `WithDialect` lets you write queries in
+MySQL, PostgreSQL, or GoogleSQL (BigQuery / Cloud Spanner) instead; filesql
+translates them to SQLite before running. Loading files always uses SQLite, so
+only the queries you write are affected.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/nao1215/filesql"
+	"github.com/nao1215/filesql/dialect"
+)
+
+func main() {
+	ctx := context.Background()
+
+	builder, err := filesql.NewBuilder().
+		AddPath("users.csv").
+		WithDialect(dialect.PostgreSQL).
+		Build(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db, err := builder.Open(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	// PostgreSQL syntax: "::" cast and ILIKE.
+	rows, err := db.QueryContext(ctx,
+		"SELECT name, age::text FROM users WHERE name ILIKE 'a%'")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+	// ...
+	if err := rows.Err(); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("ok")
+}
+```
+
+Translation is best-effort compatibility, not a full emulator: common
+incompatibilities (identifier quoting, `DATE_ADD`, `SPLIT_PART`, `SAFE_DIVIDE`,
+`EXTRACT`, casts, …) are rewritten or backed by helper functions, constructs
+with no SQLite equivalent (for example `QUALIFY` or `DISTINCT ON`) return a
+clear error, and anything else is passed through to SQLite. A non-SQLite dialect
+cannot be combined with auto-save. See the [`dialect`](./dialect) package for the
+full list of supported translations.
 
 ### Load into a database you already own
 

--- a/builder.go
+++ b/builder.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/nao1215/filesql/dialect"
 	"github.com/xuri/excelize/v2"
 	"modernc.org/sqlite" // Direct SQLite driver usage
 )
@@ -52,6 +53,13 @@ type DBBuilder struct {
 	parsedTables []*table
 	// autoSaveConfig contains auto-save settings
 	autoSaveConfig *autoSaveConfig
+	// sqlDialect is the SQL dialect accepted for queries against the opened
+	// database. Loading always uses SQLite regardless of this setting. The zero
+	// value ("") is treated as dialect.SQLite (no translation).
+	sqlDialect dialect.Dialect
+	// memDSN is the shared-cache in-memory DSN of the database created by
+	// createInMemoryDatabase, used by the dialect connector.
+	memDSN string
 	// defaultChunkSize is the default chunk size for reading large files (10MB)
 	defaultChunkSize int
 	// logger is the logger instance for internal logging
@@ -298,6 +306,40 @@ func (b *DBBuilder) DisableAutoSave() *DBBuilder {
 	return b
 }
 
+// WithDialect sets the SQL dialect accepted by the database returned from Open
+// and OpenReadOnly. Queries are translated from the given dialect to SQLite
+// before execution; see the dialect package for the supported translations and
+// their limitations.
+//
+// Loading data (CSV/TSV/Parquet/... ingestion) always uses SQLite internally
+// regardless of this setting, so only the queries a caller runs are affected.
+// The default is dialect.SQLite, which performs no translation.
+//
+// Constraints (enforced by Build):
+//   - The dialect must be a built-in dialect or one registered with
+//     dialect.RegisterTranslator.
+//   - A non-SQLite dialect cannot be combined with auto-save; the two connector
+//     wrappers are not composed in this version.
+//
+// Example:
+//
+//	db, err := filesql.NewBuilder().
+//		AddPath("users.csv").
+//		WithDialect(dialect.PostgreSQL).
+//		Build(ctx)
+//	// ... db.Query("SELECT name::text FROM users WHERE name ILIKE 'a%'")
+//
+// Returns the builder for method chaining.
+func (b *DBBuilder) WithDialect(d dialect.Dialect) *DBBuilder {
+	b.sqlDialect = d
+	return b
+}
+
+// usesDialectTranslation reports whether a non-SQLite dialect is configured.
+func (b *DBBuilder) usesDialectTranslation() bool {
+	return b.sqlDialect != "" && b.sqlDialect != dialect.SQLite
+}
+
 // Build validates all configured inputs and prepares the builder for opening a database.
 // This method must be called before Open(). It performs the following operations:
 //
@@ -324,6 +366,11 @@ func (b *DBBuilder) Build(ctx context.Context) (*DBBuilder, error) {
 
 	// Use validator to validate auto-save config
 	if err := b.validator.validateAutoSaveConfig(b.autoSaveConfig); err != nil {
+		return nil, err
+	}
+
+	// Validate the SQL dialect and its constraints.
+	if err := b.validateDialect(); err != nil {
 		return nil, err
 	}
 
@@ -423,8 +470,34 @@ func (b *DBBuilder) Open(ctx context.Context) (*sql.DB, error) {
 		return nil, err
 	}
 
+	db, err = b.setupDialectIfNeeded(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
 	b.logger.Info("database opened successfully")
 	return db, nil
+}
+
+// validateDialect checks the configured SQL dialect and rejects unsupported
+// combinations. It is a no-op for the default (SQLite) dialect.
+func (b *DBBuilder) validateDialect() error {
+	if !b.usesDialectTranslation() {
+		return nil
+	}
+	// The dialect must be translatable: either a probe translation succeeds or a
+	// custom translator is registered. Translate of a trivial query surfaces
+	// dialect.ErrUnknownDialect for an unrecognized dialect.
+	if _, err := dialect.Translate(b.sqlDialect, "SELECT 1"); err != nil {
+		if errors.Is(err, dialect.ErrUnknownDialect) {
+			return fmt.Errorf("%w: unknown SQL dialect %q", ErrDatabaseOperation, b.sqlDialect)
+		}
+		return fmt.Errorf("%w: dialect %q is not usable: %s", ErrDatabaseOperation, b.sqlDialect, err.Error())
+	}
+	if b.autoSaveConfig != nil && b.autoSaveConfig.enabled {
+		return fmt.Errorf("%w: WithDialect(%s) cannot be combined with auto-save", ErrDatabaseOperation, b.sqlDialect)
+	}
+	return nil
 }
 
 // OpenReadOnly creates a read-only database connection.
@@ -546,6 +619,10 @@ func (b *DBBuilder) createInMemoryDatabase() (*sql.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to create in-memory database: %s", ErrDatabaseOperation, err.Error())
 	}
+	// Remember the DSN so a dialect-translating connector can open its own
+	// connections to the same shared-cache in-memory database (see
+	// setupDialectIfNeeded).
+	b.memDSN = dsn
 	// A shared-cache in-memory database is discarded once its last connection
 	// closes. Disable idle timeouts so the pool keeps at least one connection
 	// (and therefore the data) alive until the caller closes the *sql.DB.
@@ -616,6 +693,50 @@ func (b *DBBuilder) setupAutoSaveIfNeeded(ctx context.Context, db *sql.DB) (*sql
 	}
 
 	return db, nil
+}
+
+// setupDialectIfNeeded swaps the plain loader database for one whose queries are
+// translated from the configured dialect to SQLite. It is a no-op for the
+// default (SQLite) dialect.
+//
+// The loaded data lives in a shared-cache in-memory database, so the translating
+// database can open its own connection to the same DSN. A live connection is
+// established (via Ping) before the loader database is closed, so the shared
+// cache—and the data—survives the swap.
+func (b *DBBuilder) setupDialectIfNeeded(ctx context.Context, db *sql.DB) (*sql.DB, error) {
+	if !b.usesDialectTranslation() {
+		return db, nil
+	}
+	if b.memDSN == "" {
+		_ = db.Close()
+		return nil, fmt.Errorf("%w: dialect translation requires the in-memory database DSN", ErrDatabaseOperation)
+	}
+
+	// Register the dialect helper UDFs before opening the connection that runs
+	// translated queries; modernc exposes functions only to connections opened
+	// afterward.
+	if err := dialect.RegisterFunctions(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("%w: failed to register dialect functions: %s", ErrDatabaseOperation, err.Error())
+	}
+
+	// Open translated connections through the same driver instance the loader
+	// used, so the dialect helper functions registered above are visible.
+	tdb := sql.OpenDB(&dialectConnector{drv: db.Driver(), dsn: b.memDSN, sqlDialect: b.sqlDialect})
+	tdb.SetConnMaxIdleTime(0)
+	tdb.SetConnMaxLifetime(0)
+
+	if err := tdb.PingContext(ctx); err != nil {
+		_ = tdb.Close()
+		_ = db.Close()
+		return nil, fmt.Errorf("%w: failed to open dialect database: %s", ErrDatabaseOperation, err.Error())
+	}
+
+	if err := db.Close(); err != nil {
+		_ = tdb.Close()
+		return nil, fmt.Errorf("%w: failed to close loader database: %s", ErrDatabaseOperation, err.Error())
+	}
+	return tdb, nil
 }
 
 // streamXLSXFileToSQLite handles XLSX files by creating separate tables for each sheet

--- a/dialect_bridge.go
+++ b/dialect_bridge.go
@@ -1,0 +1,111 @@
+package filesql
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+
+	"github.com/nao1215/filesql/dialect"
+	"modernc.org/sqlite"
+)
+
+// dialectConnector is a driver.Connector that opens connections to a
+// shared-cache in-memory SQLite database and wraps each so queries written in a
+// non-SQLite dialect are translated to SQLite before execution.
+//
+// drv is the SQLite driver instance the dialect helper functions were registered
+// on (the driver registered under the "sqlite" name). Using it — rather than a
+// fresh &sqlite.Driver{} — is what makes the registered UDFs visible on the
+// connections opened here.
+type dialectConnector struct {
+	drv        driver.Driver
+	dsn        string
+	sqlDialect dialect.Dialect
+}
+
+// Connect opens a new connection to the shared-cache database and wraps it with
+// dialect translation.
+func (c *dialectConnector) Connect(_ context.Context) (driver.Conn, error) {
+	conn, err := c.driver().Open(c.dsn)
+	if err != nil {
+		return nil, err
+	}
+	return &dialectConnection{conn: conn, sqlDialect: c.sqlDialect}, nil
+}
+
+// Driver returns the underlying SQLite driver.
+func (c *dialectConnector) Driver() driver.Driver {
+	return c.driver()
+}
+
+// driver returns the configured driver, falling back to a fresh SQLite driver if
+// none was supplied.
+func (c *dialectConnector) driver() driver.Driver {
+	if c.drv != nil {
+		return c.drv
+	}
+	return &sqlite.Driver{}
+}
+
+// dialectConnection wraps a SQLite driver connection and translates query text
+// from the configured dialect to SQLite at prepare time.
+//
+// It deliberately implements only Prepare/PrepareContext (plus transaction and
+// close plumbing) and not the Execer/Queryer fast paths, so every statement is
+// translated exactly once as it is prepared. Translation output is already
+// SQLite, so translating it a second time (as an Execer fallback could) must not
+// happen.
+type dialectConnection struct {
+	conn       driver.Conn
+	sqlDialect dialect.Dialect
+}
+
+// translate converts a query from the connection's dialect into SQLite.
+func (c *dialectConnection) translate(query string) (string, error) {
+	translated, err := dialect.Translate(c.sqlDialect, query)
+	if err != nil {
+		return "", fmt.Errorf("filesql: translate %s query: %w", c.sqlDialect, err)
+	}
+	return translated, nil
+}
+
+// Prepare translates query and prepares it on the underlying connection.
+func (c *dialectConnection) Prepare(query string) (driver.Stmt, error) {
+	translated, err := c.translate(query)
+	if err != nil {
+		return nil, err
+	}
+	return c.conn.Prepare(translated)
+}
+
+// PrepareContext translates query and prepares it with context support.
+func (c *dialectConnection) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	translated, err := c.translate(query)
+	if err != nil {
+		return nil, err
+	}
+	if p, ok := c.conn.(driver.ConnPrepareContext); ok {
+		return p.PrepareContext(ctx, translated)
+	}
+	return c.conn.Prepare(translated)
+}
+
+// Begin starts a transaction on the underlying connection.
+func (c *dialectConnection) Begin() (driver.Tx, error) {
+	//nolint:staticcheck // Backward compatibility with the legacy driver interface.
+	return c.conn.Begin()
+}
+
+// BeginTx starts a transaction with options on the underlying connection.
+func (c *dialectConnection) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if b, ok := c.conn.(driver.ConnBeginTx); ok {
+		return b.BeginTx(ctx, opts)
+	}
+	//nolint:staticcheck // Backward compatibility with the legacy driver interface.
+	return c.conn.Begin()
+}
+
+// Close closes the underlying connection.
+func (c *dialectConnection) Close() error {
+	return c.conn.Close()
+}

--- a/dialect_bridge_test.go
+++ b/dialect_bridge_test.go
@@ -1,0 +1,333 @@
+package filesql
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/nao1215/filesql/dialect"
+)
+
+// sample.csv has columns id,name,age,email with three rows (John/30, Jane/25,
+// Bob/35), used by the dialect bridge tests below.
+
+func TestOpenWithDialectMySQL(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.MySQL).Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	db, err := builder.Open(ctx)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	// Backtick identifiers (M-2) and the IF UDF.
+	rows, err := db.QueryContext(ctx,
+		"SELECT `name`, IF(`age` >= 30, 'senior', 'junior') AS tier FROM `sample` ORDER BY `id`")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	var got []string
+	for rows.Next() {
+		var name, tier string
+		if err := rows.Scan(&name, &tier); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, name+":"+tier)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	want := []string{"John Doe:senior", "Jane Smith:junior", "Bob Johnson:senior"}
+	assertStrings(t, got, want)
+}
+
+func TestOpenWithDialectPostgreSQL(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.PostgreSQL).Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	db, err := builder.Open(ctx)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	// :: cast (P-1) and ILIKE (P-2).
+	rows, err := db.QueryContext(ctx,
+		"SELECT name, age::text AS a FROM sample WHERE name ILIKE 'j%' ORDER BY id")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	var got []string
+	for rows.Next() {
+		var name, a string
+		if err := rows.Scan(&name, &a); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, name+"="+a)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	want := []string{"John Doe=30", "Jane Smith=25"}
+	assertStrings(t, got, want)
+}
+
+func TestOpenWithDialectGoogleSQL(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.GoogleSQL).Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	db, err := builder.Open(ctx)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	// SAFE_CAST (G-2) and SAFE_DIVIDE UDF.
+	var half float64
+	if err := db.QueryRowContext(ctx,
+		"SELECT SAFE_DIVIDE(SAFE_CAST(age AS INT64), 2) FROM `sample` WHERE id = 1").Scan(&half); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if half != 15 {
+		t.Fatalf("SAFE_DIVIDE = %v, want 15", half)
+	}
+}
+
+func TestOpenWithDialectDefaultIsSQLite(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	// Without WithDialect, the database is plain SQLite: a MySQL-only construct
+	// like backtick strings is not translated, but standard SQL still works.
+	builder, err := NewBuilder().AddPath("testdata/sample.csv").Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	db, err := builder.Open(ctx)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sample").Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("count = %d, want 3", count)
+	}
+}
+
+// TestWithDialectLoadIsSQLite verifies loading is unaffected by the dialect: the
+// table is created and populated even though queries run as MySQL.
+func TestWithDialectLoadIsSQLite(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.MySQL).Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	db, err := builder.Open(ctx)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM `sample`").Scan(&count); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("count = %d, want 3", count)
+	}
+}
+
+func TestOpenReadOnlyWithDialect(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.PostgreSQL).Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	rodb, err := builder.OpenReadOnly(ctx)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer rodb.Close()
+
+	// A translated read works.
+	var n int
+	if err := rodb.QueryRowContext(ctx, "SELECT COUNT(*) FROM sample WHERE name ILIKE 'j%'").Scan(&n); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("count = %d, want 2", n)
+	}
+
+	// A write is rejected before translation.
+	if _, err := rodb.ExecContext(ctx, "DELETE FROM sample"); !errors.Is(err, ErrReadOnly) {
+		t.Fatalf("ExecContext(DELETE) error = %v, want ErrReadOnly", err)
+	}
+}
+
+func TestWithDialectAutoSaveConflict(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	_, err := NewBuilder().
+		AddPath("testdata/sample.csv").
+		WithDialect(dialect.MySQL).
+		EnableAutoSave(t.TempDir()).
+		Build(ctx)
+	if err == nil {
+		t.Fatal("Build should reject WithDialect + auto-save")
+	}
+	if !errors.Is(err, ErrDatabaseOperation) {
+		t.Fatalf("error = %v, want ErrDatabaseOperation", err)
+	}
+}
+
+func TestWithDialectUnknown(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	_, err := NewBuilder().
+		AddPath("testdata/sample.csv").
+		WithDialect(dialect.Dialect("oracle")).
+		Build(ctx)
+	if err == nil {
+		t.Fatal("Build should reject an unknown dialect")
+	}
+	if !errors.Is(err, ErrDatabaseOperation) {
+		t.Fatalf("error = %v, want ErrDatabaseOperation", err)
+	}
+}
+
+// TestWithDialectTranslationError verifies an unsupported construct surfaces as a
+// query error rather than a silent wrong result.
+func TestWithDialectTranslationError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.PostgreSQL).Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	db, err := builder.Open(ctx)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	var name string
+	err = db.QueryRowContext(ctx, "SELECT DISTINCT ON (name) name FROM sample").Scan(&name)
+	if err == nil {
+		t.Fatal("query with DISTINCT ON should error")
+	}
+}
+
+// TestWithDialectTransaction exercises the transaction path (BeginTx) through a
+// dialect-translating database.
+func TestWithDialectTransaction(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.MySQL).Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	db, err := builder.Open(ctx)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer db.Close()
+
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var n int
+	if err := tx.QueryRowContext(ctx, "SELECT COUNT(*) FROM `sample`").Scan(&n); err != nil {
+		t.Fatalf("query in tx: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("count = %d, want 3", n)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+}
+
+// TestDialectConnectorMethods unit-tests the connector and connection wrapper
+// directly, covering the legacy Prepare/Begin methods and the driver accessor
+// that the database/sql fast paths do not exercise.
+func TestDialectConnectorMethods(t *testing.T) {
+	t.Parallel()
+	connector := &dialectConnector{dsn: ":memory:", sqlDialect: dialect.MySQL}
+	if connector.Driver() == nil {
+		t.Fatal("Driver() returned nil")
+	}
+	conn, err := connector.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	dc, ok := conn.(*dialectConnection)
+	if !ok {
+		t.Fatalf("Connect returned %T, want *dialectConnection", conn)
+	}
+
+	// Prepare translates the backtick identifier to a double-quoted one before
+	// preparing on the underlying connection.
+	stmt, err := dc.Prepare("SELECT `x` FROM (SELECT 1 AS `x`)")
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	if err := stmt.Close(); err != nil {
+		t.Fatalf("stmt close: %v", err)
+	}
+
+	// A translation failure surfaces from Prepare.
+	if _, err := dc.Prepare("SELECT `x` DIV"); err == nil {
+		t.Fatal("Prepare of an untranslatable query should error")
+	}
+
+	// Legacy Begin and BeginTx both start a transaction on the underlying conn.
+	tx, err := dc.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	tx2, err := dc.BeginTx(context.Background(), driver.TxOptions{})
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	if err := tx2.Rollback(); err != nil {
+		t.Fatalf("rollback2: %v", err)
+	}
+}
+
+func assertStrings(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("row %d = %q, want %q (all: %v)", i, got[i], want[i], got)
+		}
+	}
+}

--- a/doc.go
+++ b/doc.go
@@ -14,6 +14,8 @@
 //   - Efficient streaming for large files with configurable chunk sizes
 //   - Cross-platform compatibility (Linux, macOS, Windows)
 //   - Optional auto-save functionality to persist changes
+//   - Optional MySQL, PostgreSQL, and GoogleSQL query dialects (queries are
+//     translated to SQLite; see WithDialect and the dialect subpackage)
 //
 // # Basic Usage
 //
@@ -83,4 +85,22 @@
 // result in an error.
 //
 // For complete SQL syntax documentation, see: https://www.sqlite.org/lang.html
+//
+// # Query Dialects
+//
+// By default queries use SQLite3 syntax. To accept a different dialect, configure
+// the builder with WithDialect:
+//
+//	db, err := filesql.NewBuilder().
+//	    AddPath("users.csv").
+//	    WithDialect(dialect.PostgreSQL).
+//	    Build(ctx)
+//	// db.Query("SELECT name::text FROM users WHERE name ILIKE 'a%'")
+//
+// The supported dialects are MySQL, PostgreSQL, and GoogleSQL (BigQuery / Cloud
+// Spanner). Queries are translated to SQLite before execution on a best-effort
+// basis: common incompatibilities are rewritten, constructs with no SQLite
+// equivalent are rejected with a clear error, and everything else is passed
+// through. Loading files always uses SQLite regardless of the dialect. See the
+// dialect subpackage for the full list of translations and their limitations.
 package filesql


### PR DESCRIPTION
## What

Final PR of the multi-dialect series (#168, #169, #172, #171 landed the `dialect` package). This wires it into the builder so callers can run queries in a non-SQLite dialect.

```go
db, err := filesql.NewBuilder().
    AddPath("users.csv").
    WithDialect(dialect.PostgreSQL).
    Build(ctx)
// db.Query("SELECT name::text FROM users WHERE name ILIKE 'a%'")
```

Queries are translated to SQLite before execution; **loading always uses SQLite** regardless of the dialect, so only the queries you write are affected.

## Implementation

- `DBBuilder.WithDialect(d)` stores the dialect; `Build` validates it — unknown dialects and the `WithDialect` + auto-save combination are rejected with `ErrDatabaseOperation`.
- When a non-SQLite dialect is set, `Open` registers the dialect helper UDFs and swaps the loader database for one whose connections translate queries:
  - It opens those connections on the **same shared-cache in-memory DSN**, through the **same driver instance** the helper functions were registered on (a fresh `&sqlite.Driver{}` would not see the registered UDFs), and pings to establish a live connection **before** closing the loader, so the shared cache (and the data) survives the swap.
  - `dialectConnection` translates **only at prepare time** (it deliberately does not implement the Execer/Queryer fast paths), so already-SQLite output is never translated a second time.
- `ReadOnlyDB` works over a dialect database: writes are still rejected before translation.

## Constraints

- A non-SQLite dialect cannot be combined with auto-save (the two connector wrappers are not composed in this version; documented on `WithDialect`).

## Tests & docs

Execution tests for each dialect against `testdata/sample.csv` (backtick identifiers + `IF`, `::` cast + `ILIKE`, `SAFE_CAST` + `SAFE_DIVIDE`), read-only-over-dialect, transaction path, connector unit tests, unknown-dialect and auto-save-conflict errors, and an unsupported-syntax query error. README and package docs updated.

Module coverage stays at **89.5%**. `golangci-lint` clean on the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional MySQL, PostgreSQL, and GoogleSQL syntax support for queries.
  * Queries are translated to SQLite automatically when a dialect is selected.
  * Added clear errors for unsupported SQL constructs.
  * Loading data continues to use SQLite syntax.
  * Added transaction and read-only query support with alternate dialects.

* **Documentation**
  * Added configuration guidance and examples for querying with alternate SQL dialects.
  * Documented limitations, including incompatibility with auto-save.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->