### PR TITLE
feat(dialect): fill the scalar function gaps in the dialect layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Dialect queries can now call the scalar functions that were previously missing. Shared: `LEAST` and `GREATEST`. MySQL: `REVERSE`, `FIND_IN_SET`, `FIELD`, `ELT`, `MONTHNAME`, `DAYNAME`, `LAST_DAY`, `UNIX_TIMESTAMP`, `FROM_UNIXTIME`. PostgreSQL: `MD5`, `ASCII`, `CHR`, `TRANSLATE`. GoogleSQL: `FORMAT_DATE`, `FORMAT_DATETIME`, `FORMAT_TIMESTAMP`, `PARSE_DATE`, `PARSE_DATETIME`, `PARSE_TIMESTAMP`, `UNIX_SECONDS`, `UNIX_MILLIS`, `UNIX_MICROS`, `TIMESTAMP_SECONDS`, `TIMESTAMP_MILLIS`, `TIMESTAMP_MICROS`, `TO_HEX`, `IS_NAN`, `SAFE_ADD`, `SAFE_SUBTRACT`, `SAFE_MULTIPLY`, `SAFE_NEGATE`. Each previously failed with `no such function`.
+- `REGEXP_REPLACE` accepts PostgreSQL's fourth flags argument: `g` replaces every match, its absence replaces only the first, and `i` matches case insensitively. The three-argument form keeps replacing every match.
+
 ## [0.19.0] - 2026-07-29
 
 ### Added

--- a/dialect/functions.go
+++ b/dialect/functions.go
@@ -1,9 +1,12 @@
 package dialect
 
 import (
+	"crypto/md5" //nolint:gosec // MD5 backs PostgreSQL's MD5() function, not a security control
 	"crypto/rand"
 	"database/sql/driver"
 	"encoding/binary"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
@@ -11,6 +14,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	sqlite "modernc.org/sqlite"
 )
@@ -108,6 +112,19 @@ func registerAll() error {
 		"repeat":          {2, fnRepeat},
 		"space":           {1, fnSpace},
 		"truncate":        {2, fnTruncate},
+		"reverse":         {1, fnReverse},
+		"find_in_set":     {2, fnFindInSet},
+		"field":           {-1, fnField},
+		"elt":             {-1, fnElt},
+		"monthname":       {1, fnMonthName},
+		"dayname":         {1, fnDayName},
+		"last_day":        {1, fnLastDay},
+		"from_unixtime":   {-1, fnFromUnixtime},
+
+		// Shared by every dialect; SQLite spells them min/max with several
+		// arguments, which collides with the aggregate forms.
+		"least":    {-1, fnLeast},
+		"greatest": {-1, fnGreatest},
 
 		// PostgreSQL helpers.
 		"to_char":        {2, fnToChar},
@@ -118,16 +135,38 @@ func registerAll() error {
 		"strpos":         {2, fnStrpos},
 		"left":           {2, fnLeft},
 		"right":          {2, fnRight},
-		"regexp_replace": {3, fnRegexpReplace},
+		"regexp_replace": {-1, fnRegexpReplace},
+		"md5":            {1, fnMD5},
+		"ascii":          {1, fnASCII},
+		"chr":            {1, fnChr},
+		"translate":      {3, fnTranslate},
 
 		// GoogleSQL helpers.
-		"safe_divide":     {2, fnSafeDivide},
-		"starts_with":     {2, fnStartsWith},
-		"ends_with":       {2, fnEndsWith},
-		"regexp_contains": {2, fnRegexpContains},
-		"regexp_extract":  {2, fnRegexpExtract},
-		"date_diff":       {3, fnDateDiff3},
-		"timestamp_diff":  {3, fnDateDiff3},
+		"safe_divide":       {2, fnSafeDivide},
+		"starts_with":       {2, fnStartsWith},
+		"ends_with":         {2, fnEndsWith},
+		"regexp_contains":   {2, fnRegexpContains},
+		"regexp_extract":    {2, fnRegexpExtract},
+		"date_diff":         {3, fnDateDiff3},
+		"timestamp_diff":    {3, fnDateDiff3},
+		"format_date":       {2, fnFormatDate},
+		"format_datetime":   {2, fnFormatDate},
+		"format_timestamp":  {2, fnFormatDate},
+		"parse_date":        {2, fnParseDate},
+		"parse_datetime":    {2, fnParseTimestamp},
+		"parse_timestamp":   {2, fnParseTimestamp},
+		"unix_seconds":      {1, unixScale(1)},
+		"unix_millis":       {1, unixScale(1000)},
+		"unix_micros":       {1, unixScale(1000000)},
+		"timestamp_seconds": {1, fromUnixScale(1)},
+		"timestamp_millis":  {1, fromUnixScale(1000)},
+		"timestamp_micros":  {1, fromUnixScale(1000000)},
+		"to_hex":            {1, fnToHex},
+		"is_nan":            {1, fnIsNaN},
+		"safe_add":          {2, safeArith(safeAddInt, func(a, b float64) float64 { return a + b })},
+		"safe_subtract":     {2, safeArith(safeSubInt, func(a, b float64) float64 { return a - b })},
+		"safe_multiply":     {2, safeArith(safeMulInt, func(a, b float64) float64 { return a * b })},
+		"safe_negate":       {1, fnSafeNegate},
 	}
 	for name, spec := range det {
 		if err := sqlite.RegisterDeterministicScalarFunction(name, spec.nArg, wrapScalar(spec.fn)); err != nil {
@@ -140,11 +179,15 @@ func registerAll() error {
 		nArg int32
 		fn   scalarFn
 	}{
-		"now":           {0, fnNow},
-		"curdate":       {0, fnCurdate},
-		"curtime":       {0, fnCurtime},
-		"rand":          {0, fnRand},
-		"generate_uuid": {0, fnGenerateUUID},
+		"now":     {0, fnNow},
+		"curdate": {0, fnCurdate},
+		"curtime": {0, fnCurtime},
+		"rand":    {0, fnRand},
+		// UNIX_TIMESTAMP() with no argument reads the clock, so the whole
+		// function has to be registered as non-deterministic even though the
+		// one-argument form is pure.
+		"unix_timestamp": {-1, fnUnixTimestamp},
+		"generate_uuid":  {0, fnGenerateUUID},
 	}
 	for name, spec := range nondet {
 		if err := sqlite.RegisterScalarFunction(name, spec.nArg, wrapScalar(spec.fn)); err != nil {
@@ -624,6 +667,174 @@ func fnTruncate(args []driver.Value) (driver.Value, error) {
 	return math.Trunc(x*factor) / factor, nil
 }
 
+// fnLeast implements LEAST(a, b, ...) and fnGreatest GREATEST(a, b, ...).
+// Values are compared numerically when every argument parses as a number and
+// lexicographically otherwise, matching how the source dialects coerce a mixed
+// list. A NULL argument makes the whole call NULL, which is MySQL and GoogleSQL
+// behavior; PostgreSQL instead skips NULLs, a difference callers should know
+// about.
+func fnLeast(args []driver.Value) (driver.Value, error) { return extremum(args, true) }
+
+func fnGreatest(args []driver.Value) (driver.Value, error) { return extremum(args, false) }
+
+func extremum(args []driver.Value, wantSmaller bool) (driver.Value, error) {
+	if len(args) == 0 {
+		return nil, errors.New("dialect: LEAST/GREATEST expects at least one argument")
+	}
+	strs := make([]string, len(args))
+	nums := make([]float64, len(args))
+	allNumeric := true
+	for i, a := range args {
+		s, ok := toString(a)
+		if !ok {
+			return nil, nil
+		}
+		strs[i] = s
+		if f, isNum := toFloat(a); isNum {
+			nums[i] = f
+		} else {
+			allNumeric = false
+		}
+	}
+	best := 0
+	for i := 1; i < len(args); i++ {
+		var smaller bool
+		if allNumeric {
+			smaller = nums[i] < nums[best]
+		} else {
+			smaller = strs[i] < strs[best]
+		}
+		if smaller == wantSmaller {
+			best = i
+		}
+	}
+	return args[best], nil
+}
+
+// fnReverse implements MySQL REVERSE, reversing runes rather than bytes so
+// multi-byte text survives.
+func fnReverse(args []driver.Value) (driver.Value, error) {
+	s, ok := toString(args[0])
+	if !ok {
+		return nil, nil
+	}
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes), nil
+}
+
+// fnFindInSet implements MySQL FIND_IN_SET(needle, "a,b,c"): the 1-based
+// position of needle in the comma-separated list, or 0 when it is absent.
+func fnFindInSet(args []driver.Value) (driver.Value, error) {
+	needle, ok1 := toString(args[0])
+	set, ok2 := toString(args[1])
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+	for i, part := range strings.Split(set, ",") {
+		if part == needle {
+			return int64(i + 1), nil
+		}
+	}
+	return int64(0), nil
+}
+
+// fnField implements MySQL FIELD(x, a, b, ...): the 1-based position of the
+// first argument that equals x, or 0 when none does.
+func fnField(args []driver.Value) (driver.Value, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("dialect: FIELD expects at least 2 arguments, got %d", len(args))
+	}
+	needle, ok := toString(args[0])
+	if !ok {
+		return int64(0), nil
+	}
+	for i, a := range args[1:] {
+		if s, ok := toString(a); ok && s == needle {
+			return int64(i + 1), nil
+		}
+	}
+	return int64(0), nil
+}
+
+// fnElt implements MySQL ELT(n, a, b, ...): the nth argument, or NULL when n is
+// out of range.
+func fnElt(args []driver.Value) (driver.Value, error) {
+	if len(args) < 2 {
+		return nil, fmt.Errorf("dialect: ELT expects at least 2 arguments, got %d", len(args))
+	}
+	n, ok := toInt(args[0])
+	if !ok || n < 1 || int(n) > len(args)-1 {
+		return nil, nil
+	}
+	return args[n], nil
+}
+
+// fnMonthName and fnDayName implement the MySQL MONTHNAME/DAYNAME helpers.
+func fnMonthName(args []driver.Value) (driver.Value, error) {
+	return namedTimePart(args[0], layoutMonthLong)
+}
+
+func fnDayName(args []driver.Value) (driver.Value, error) {
+	return namedTimePart(args[0], layoutWeekdayLong)
+}
+
+func namedTimePart(v driver.Value, layout string) (driver.Value, error) {
+	tm, ok := toStringTime(v)
+	if !ok {
+		return nil, nil
+	}
+	return tm.Format(layout), nil
+}
+
+// fnLastDay implements MySQL LAST_DAY(date): the last day of that month. It is
+// computed as "the day before the first of the next month" so leap years need
+// no special case.
+func fnLastDay(args []driver.Value) (driver.Value, error) {
+	tm, ok := toStringTime(args[0])
+	if !ok {
+		return nil, nil
+	}
+	firstOfNext := time.Date(tm.Year(), tm.Month(), 1, 0, 0, 0, 0, time.UTC).AddDate(0, 1, 0)
+	return firstOfNext.AddDate(0, 0, -1).Format("2006-01-02"), nil
+}
+
+// fnUnixTimestamp implements MySQL UNIX_TIMESTAMP([date]): the current epoch
+// second with no argument, or the epoch second of the given datetime. Values are
+// read as UTC, as everywhere else in this package.
+func fnUnixTimestamp(args []driver.Value) (driver.Value, error) {
+	if len(args) == 0 {
+		return time.Now().Unix(), nil
+	}
+	if len(args) > 1 {
+		return nil, fmt.Errorf("dialect: UNIX_TIMESTAMP expects 0 or 1 arguments, got %d", len(args))
+	}
+	tm, ok := toStringTime(args[0])
+	if !ok {
+		return nil, nil
+	}
+	return tm.Unix(), nil
+}
+
+// fnFromUnixtime implements MySQL FROM_UNIXTIME(seconds[, format]), the inverse
+// of UNIX_TIMESTAMP.
+func fnFromUnixtime(args []driver.Value) (driver.Value, error) {
+	if len(args) < 1 || len(args) > 2 {
+		return nil, fmt.Errorf("dialect: FROM_UNIXTIME expects 1 or 2 arguments, got %d", len(args))
+	}
+	sec, ok := toInt(args[0])
+	if !ok {
+		return nil, nil
+	}
+	tm := time.Unix(sec, 0).UTC()
+	if len(args) == 1 {
+		return tm.Format(layoutDateTime), nil
+	}
+	return fnDateFormat([]driver.Value{tm.Format(layoutDateTime), args[1]})
+}
+
 // --- PostgreSQL scalar functions ---
 
 // pgToCharTokens maps TO_CHAR template patterns to Go reference-time layout
@@ -838,21 +1049,121 @@ func leftRight(args []driver.Value, left bool) (driver.Value, error) {
 	return string(runes[len(runes)-count:]), nil
 }
 
-// fnRegexpReplace implements REGEXP_REPLACE(source, pattern, replacement),
-// replacing every match. PostgreSQL back-references (\1) are translated to Go's
-// ${1} expansion form.
+// fnRegexpReplace implements REGEXP_REPLACE(source, pattern, replacement
+// [, flags]). PostgreSQL back-references (\1) are translated to Go's ${1}
+// expansion form.
+//
+// The three-argument form replaces every match, which is GoogleSQL semantics.
+// PostgreSQL's three-argument form replaces only the first match and needs the
+// "g" flag for the rest; that difference is left in place because the same
+// function is shared by all dialects and replace-all is the behavior callers
+// expect. With an explicit flags argument the flags win: "g" replaces every
+// match and its absence replaces only the first, and "i" matches case
+// insensitively.
 func fnRegexpReplace(args []driver.Value) (driver.Value, error) {
+	if len(args) < 3 || len(args) > 4 {
+		return nil, fmt.Errorf("dialect: REGEXP_REPLACE expects 3 or 4 arguments, got %d", len(args))
+	}
 	src, ok1 := toString(args[0])
 	pattern, ok2 := toString(args[1])
 	repl, ok3 := toString(args[2])
 	if !ok1 || !ok2 || !ok3 {
 		return nil, nil
 	}
+	global := true
+	if len(args) == 4 {
+		flags, ok := toString(args[3])
+		if !ok {
+			return nil, nil
+		}
+		global = strings.Contains(flags, "g")
+		if strings.Contains(flags, "i") {
+			pattern = "(?i)" + pattern
+		}
+	}
 	re, err := compileRegexp(pattern)
 	if err != nil {
 		return nil, err
 	}
-	return re.ReplaceAllString(src, pgReplacement(repl)), nil
+	expansion := pgReplacement(repl)
+	if global {
+		return re.ReplaceAllString(src, expansion), nil
+	}
+	replaced := false
+	return re.ReplaceAllStringFunc(src, func(match string) string {
+		if replaced {
+			return match
+		}
+		replaced = true
+		return string(re.ExpandString(nil, expansion, match, re.FindStringSubmatchIndex(match)))
+	}), nil
+}
+
+// fnMD5 implements PostgreSQL MD5(text). MD5 is used here as a content
+// fingerprint compatible with the source dialect, never for security.
+func fnMD5(args []driver.Value) (driver.Value, error) {
+	s, ok := toString(args[0])
+	if !ok {
+		return nil, nil
+	}
+	sum := md5.Sum([]byte(s)) //nolint:gosec // required for PostgreSQL MD5() compatibility, not a security control
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// fnASCII implements ASCII(text): the code point of the first character, or 0
+// for an empty string.
+func fnASCII(args []driver.Value) (driver.Value, error) {
+	s, ok := toString(args[0])
+	if !ok {
+		return nil, nil
+	}
+	for _, r := range s {
+		return int64(r), nil
+	}
+	return int64(0), nil
+}
+
+// fnChr implements CHR(code): the character for a code point.
+func fnChr(args []driver.Value) (driver.Value, error) {
+	n, ok := toInt(args[0])
+	if !ok {
+		return nil, nil
+	}
+	if n < 0 || n > utf8.MaxRune {
+		return nil, fmt.Errorf("dialect: CHR: code point %d is out of range", n)
+	}
+	return string(rune(n)), nil
+}
+
+// fnTranslate implements PostgreSQL TRANSLATE(string, from, to): each character
+// of from is replaced by the character at the same position in to, and a
+// character whose position has no counterpart in to is dropped.
+func fnTranslate(args []driver.Value) (driver.Value, error) {
+	s, ok1 := toString(args[0])
+	from, ok2 := toString(args[1])
+	to, ok3 := toString(args[2])
+	if !ok1 || !ok2 || !ok3 {
+		return nil, nil
+	}
+	fromRunes := []rune(from)
+	toRunes := []rune(to)
+	var b strings.Builder
+	for _, r := range s {
+		idx := -1
+		for i, f := range fromRunes {
+			if f == r {
+				idx = i
+				break
+			}
+		}
+		switch {
+		case idx < 0:
+			b.WriteRune(r)
+		case idx < len(toRunes):
+			b.WriteRune(toRunes[idx])
+		}
+	}
+	return b.String(), nil
 }
 
 // pgReplacement translates PostgreSQL replacement back-references (\1..\9, \&) to
@@ -996,6 +1307,220 @@ func fnDateDiff3(args []driver.Value) (driver.Value, error) {
 
 func truncDay(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// strftimeToGoLayout maps the strftime-style specifiers GoogleSQL uses in
+// FORMAT_DATE and PARSE_DATE to Go reference-time layout fragments. They differ
+// from the MySQL DATE_FORMAT set: %M is the minute here but the month name
+// there, and the month and weekday names are %B and %A.
+var strftimeToGoLayout = map[byte]string{
+	'Y': "2006",
+	'y': "06",
+	'm': "01",
+	'd': "02",
+	'e': "_2",
+	'H': "15",
+	'I': "03",
+	'M': "04",
+	'S': "05",
+	'p': "PM",
+	'B': layoutMonthLong,
+	'b': layoutMonthShort,
+	'A': layoutWeekdayLong,
+	'a': layoutWeekdayShort,
+	'F': "2006-01-02",
+	'T': "15:04:05",
+	'R': "15:04",
+}
+
+// strftimeLayout converts a GoogleSQL format string into a Go layout. An
+// unknown specifier contributes its own letter, mirroring how DATE_FORMAT
+// handles the same case.
+func strftimeLayout(format string) string {
+	var b strings.Builder
+	for i := 0; i < len(format); i++ {
+		if format[i] == '%' && i+1 < len(format) {
+			if layout, ok := strftimeToGoLayout[format[i+1]]; ok {
+				b.WriteString(layout)
+			} else if format[i+1] == '%' {
+				b.WriteByte('%')
+			} else {
+				b.WriteByte(format[i+1])
+			}
+			i++
+			continue
+		}
+		b.WriteByte(format[i])
+	}
+	return b.String()
+}
+
+// fnFormatDate implements GoogleSQL FORMAT_DATE/FORMAT_DATETIME/
+// FORMAT_TIMESTAMP(format, value). The format comes first, the reverse of MySQL
+// DATE_FORMAT.
+func fnFormatDate(args []driver.Value) (driver.Value, error) {
+	format, ok := toString(args[0])
+	if !ok {
+		return nil, nil
+	}
+	tm, ok := toStringTime(args[1])
+	if !ok {
+		return nil, nil
+	}
+	return tm.Format(strftimeLayout(format)), nil
+}
+
+// fnParseDate implements GoogleSQL PARSE_DATE(format, text) and fnParseTimestamp
+// its datetime counterparts, returning NULL when the text does not match.
+func fnParseDate(args []driver.Value) (driver.Value, error) {
+	return parseWithStrftime(args, "2006-01-02")
+}
+
+func fnParseTimestamp(args []driver.Value) (driver.Value, error) {
+	return parseWithStrftime(args, layoutDateTime)
+}
+
+func parseWithStrftime(args []driver.Value, out string) (driver.Value, error) {
+	format, ok1 := toString(args[0])
+	s, ok2 := toString(args[1])
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+	tm, ok := parseLayout(strftimeLayout(format), s)
+	if !ok {
+		return nil, nil
+	}
+	return tm.Format(out), nil
+}
+
+// unixScale builds UNIX_SECONDS/UNIX_MILLIS/UNIX_MICROS, which differ only in
+// how many sub-second units they report.
+func unixScale(perSecond int64) scalarFn {
+	return func(args []driver.Value) (driver.Value, error) {
+		tm, ok := toStringTime(args[0])
+		if !ok {
+			return nil, nil
+		}
+		return tm.Unix()*perSecond + int64(tm.Nanosecond())/(1000000000/perSecond), nil
+	}
+}
+
+// fromUnixScale builds TIMESTAMP_SECONDS/TIMESTAMP_MILLIS/TIMESTAMP_MICROS, the
+// inverses of unixScale.
+func fromUnixScale(perSecond int64) scalarFn {
+	return func(args []driver.Value) (driver.Value, error) {
+		n, ok := toInt(args[0])
+		if !ok {
+			return nil, nil
+		}
+		nanos := (n % perSecond) * (1000000000 / perSecond)
+		return time.Unix(n/perSecond, nanos).UTC().Format(layoutDateTime), nil
+	}
+}
+
+// fnToHex implements GoogleSQL TO_HEX(bytes): the lowercase hexadecimal form of
+// the value's bytes.
+func fnToHex(args []driver.Value) (driver.Value, error) {
+	switch x := args[0].(type) {
+	case nil:
+		return nil, nil
+	case []byte:
+		return hex.EncodeToString(x), nil
+	default:
+		s, ok := toString(args[0])
+		if !ok {
+			return nil, nil
+		}
+		return hex.EncodeToString([]byte(s)), nil
+	}
+}
+
+// fnIsNaN implements GoogleSQL IS_NAN(x).
+func fnIsNaN(args []driver.Value) (driver.Value, error) {
+	f, ok := toFloat(args[0])
+	if !ok {
+		// A NULL argument is NULL; a non-numeric one is simply not NaN.
+		if _, present := toString(args[0]); !present {
+			return nil, nil
+		}
+		return int64(0), nil
+	}
+	return boolToInt(math.IsNaN(f)), nil
+}
+
+// safeArith builds the GoogleSQL SAFE_ADD/SAFE_SUBTRACT/SAFE_MULTIPLY family:
+// the operation, or NULL where the source dialect would raise an overflow. Two
+// integer arguments stay in int64 so overflow is detectable; anything else falls
+// back to float64, where the result is already an infinity rather than an error.
+func safeArith(intOp func(a, b int64) (int64, bool), floatOp func(a, b float64) float64) scalarFn {
+	return func(args []driver.Value) (driver.Value, error) {
+		if ai, ok := args[0].(int64); ok {
+			if bi, ok := args[1].(int64); ok {
+				res, fine := intOp(ai, bi)
+				if !fine {
+					return nil, nil
+				}
+				return res, nil
+			}
+		}
+		a, ok1 := toFloat(args[0])
+		b, ok2 := toFloat(args[1])
+		if !ok1 || !ok2 {
+			return nil, nil
+		}
+		res := floatOp(a, b)
+		if math.IsInf(res, 0) || math.IsNaN(res) {
+			return nil, nil
+		}
+		return res, nil
+	}
+}
+
+func safeAddInt(a, b int64) (int64, bool) {
+	sum := a + b
+	// The sum overflowed when both operands share a sign that the result lost.
+	if (a > 0 && b > 0 && sum < 0) || (a < 0 && b < 0 && sum >= 0) {
+		return 0, false
+	}
+	return sum, true
+}
+
+func safeSubInt(a, b int64) (int64, bool) {
+	if b == math.MinInt64 {
+		// Negating the minimum has no int64 representation, so handle it as an
+		// addition that cannot be expressed either.
+		if a >= 0 {
+			return 0, false
+		}
+		return a - b, true
+	}
+	return safeAddInt(a, -b)
+}
+
+func safeMulInt(a, b int64) (int64, bool) {
+	if a == 0 || b == 0 {
+		return 0, true
+	}
+	product := a * b
+	if product/b != a || (a == -1 && b == math.MinInt64) || (b == -1 && a == math.MinInt64) {
+		return 0, false
+	}
+	return product, true
+}
+
+// fnSafeNegate implements GoogleSQL SAFE_NEGATE(x).
+func fnSafeNegate(args []driver.Value) (driver.Value, error) {
+	if n, ok := args[0].(int64); ok {
+		if n == math.MinInt64 {
+			return nil, nil
+		}
+		return -n, nil
+	}
+	f, ok := toFloat(args[0])
+	if !ok {
+		return nil, nil
+	}
+	return -f, nil
 }
 
 // fnGenerateUUID implements GoogleSQL GENERATE_UUID: a random RFC 4122 v4 UUID.

--- a/dialect/functions.go
+++ b/dialect/functions.go
@@ -766,7 +766,7 @@ func fnElt(args []driver.Value) (driver.Value, error) {
 		return nil, fmt.Errorf("dialect: ELT expects at least 2 arguments, got %d", len(args))
 	}
 	n, ok := toInt(args[0])
-	if !ok || n < 1 || int(n) > len(args)-1 {
+	if !ok || n < 1 || n > int64(len(args)-1) {
 		return nil, nil
 	}
 	return args[n], nil
@@ -1089,14 +1089,15 @@ func fnRegexpReplace(args []driver.Value) (driver.Value, error) {
 	if global {
 		return re.ReplaceAllString(src, expansion), nil
 	}
-	replaced := false
-	return re.ReplaceAllStringFunc(src, func(match string) string {
-		if replaced {
-			return match
-		}
-		replaced = true
-		return string(re.ExpandString(nil, expansion, match, re.FindStringSubmatchIndex(match)))
-	}), nil
+	// Expand against the source rather than the matched text on its own: a
+	// boundary-dependent pattern such as `\Bb` matches inside "ab" but not in
+	// the isolated "b", which would leave ExpandString without submatch indices.
+	loc := re.FindStringSubmatchIndex(src)
+	if loc == nil {
+		return src, nil
+	}
+	out := re.ExpandString([]byte(src[:loc[0]]), expansion, src, loc)
+	return string(out) + src[loc[1]:], nil
 }
 
 // fnMD5 implements PostgreSQL MD5(text). MD5 is used here as a content

--- a/dialect/functions_test.go
+++ b/dialect/functions_test.go
@@ -444,6 +444,12 @@ func TestEdgeCaseUDFs(t *testing.T) {
 		{`SELECT SAFE_ADD(1.5, 2.0)`, "3.5"},
 		{`SELECT SAFE_NEGATE(1.5)`, "-1.5"},
 		{`SELECT REGEXP_REPLACE('a1b2', '[0-9]', 'X', '')`, "aXb2"}, // no "g": first match only
+		// A boundary-dependent pattern matches inside the source but not in the
+		// matched text on its own, so the first-match path has to expand against
+		// the source.
+		{`SELECT REGEXP_REPLACE('ab', '\Bb', 'X', '')`, "aX"},
+		{`SELECT REGEXP_REPLACE('ab', 'z', 'X', '')`, "ab"},
+		{`SELECT ELT(4294967298, 'a', 'b')`, ""}, // an index past int32 must stay out of range
 	}
 	for _, tt := range tests {
 		var got sql.NullString

--- a/dialect/functions_test.go
+++ b/dialect/functions_test.go
@@ -68,6 +68,24 @@ func TestUDFExecution(t *testing.T) {
 		{"space", `SELECT '[' || SPACE(3) || ']'`, "[   ]"},
 		{"truncate", `SELECT TRUNCATE(3.14159, 2)`, "3.14"},
 		{"truncate negative digits", `SELECT TRUNCATE(1234.5, -2)`, "1200"},
+		{"least numeric", `SELECT LEAST(3, 1, 2)`, "1"},
+		{"least string", `SELECT LEAST('pear', 'apple')`, "apple"},
+		{"greatest numeric", `SELECT GREATEST(3, 1, 2)`, "3"},
+		{"greatest mixed sign", `SELECT GREATEST(-5, -1)`, "-1"},
+		{"reverse", `SELECT REVERSE('abc')`, "cba"},
+		{"reverse multibyte", `SELECT REVERSE('あいう')`, "ういあ"},
+		{"find_in_set", `SELECT FIND_IN_SET('b', 'a,b,c')`, "2"},
+		{"find_in_set missing", `SELECT FIND_IN_SET('z', 'a,b,c')`, "0"},
+		{"field", `SELECT FIELD('b', 'a', 'b', 'c')`, "2"},
+		{"field missing", `SELECT FIELD('z', 'a', 'b')`, "0"},
+		{"elt", `SELECT ELT(2, 'a', 'b')`, "b"},
+		{"monthname", `SELECT MONTHNAME('2026-02-05')`, "February"},
+		{"dayname", `SELECT DAYNAME('2026-02-05')`, "Thursday"},
+		{"last_day", `SELECT LAST_DAY('2026-02-05')`, "2026-02-28"},
+		{"last_day leap year", `SELECT LAST_DAY('2028-02-05')`, "2028-02-29"},
+		{"unix_timestamp", `SELECT UNIX_TIMESTAMP('2026-01-01 00:00:00')`, "1767225600"},
+		{"from_unixtime", `SELECT FROM_UNIXTIME(0)`, "1970-01-01 00:00:00"},
+		{"from_unixtime with format", `SELECT FROM_UNIXTIME(0, '%Y/%m/%d')`, "1970/01/01"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -118,6 +136,14 @@ func TestPostgreSQLUDFExecution(t *testing.T) {
 		{"right negative", `SELECT RIGHT('abcdef', -2)`, "cdef"},
 		{"regexp_replace", `SELECT REGEXP_REPLACE('foobar', 'o+', 'O')`, "fObar"},
 		{"regexp_replace backref", `SELECT REGEXP_REPLACE('2026-07', '(\d+)-(\d+)', '\2/\1')`, "07/2026"},
+		{"regexp_replace with flags", `SELECT REGEXP_REPLACE('a1b2', '[0-9]', '', 'g')`, "ab"},
+		{"regexp_replace case-insensitive flag", `SELECT REGEXP_REPLACE('ABC', 'b', 'x', 'i')`, "AxC"},
+		{"md5", `SELECT MD5('a')`, "0cc175b9c0f1b6a831c399e269772661"},
+		{"ascii", `SELECT ASCII('A')`, "65"},
+		{"ascii empty", `SELECT ASCII('')`, "0"},
+		{"chr", `SELECT CHR(65)`, "A"},
+		{"translate", `SELECT TRANSLATE('abc', 'ab', 'xy')`, "xyc"},
+		{"translate deletes unmapped", `SELECT TRANSLATE('abcd', 'abc', 'x')`, "xd"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -165,6 +191,25 @@ func TestGoogleSQLUDFExecution(t *testing.T) {
 		{"timestamp_diff hour", `SELECT TIMESTAMP_DIFF('2026-01-01 05:00:00', '2026-01-01 00:00:00', 'hour')`, "5"},
 		{"timestamp_diff minute", `SELECT TIMESTAMP_DIFF('2026-01-01 00:30:00', '2026-01-01 00:00:00', 'minute')`, "30"},
 		{"timestamp_diff second", `SELECT TIMESTAMP_DIFF('2026-01-01 00:00:10', '2026-01-01 00:00:01', 'second')`, "9"},
+		{"format_date", `SELECT FORMAT_DATE('%Y-%m', '2026-03-15')`, "2026-03"},
+		{"format_date month name", `SELECT FORMAT_DATE('%B %d, %Y', '2026-03-15')`, "March 15, 2026"},
+		{"format_timestamp minutes", `SELECT FORMAT_TIMESTAMP('%H:%M:%S', '2026-03-15 10:20:30')`, "10:20:30"},
+		{"parse_date", `SELECT PARSE_DATE('%Y-%m-%d', '2026-03-15')`, "2026-03-15"},
+		{"parse_timestamp", `SELECT PARSE_TIMESTAMP('%Y-%m-%d %H:%M:%S', '2026-03-15 10:20:30')`, "2026-03-15 10:20:30"},
+		{"unix_seconds", `SELECT UNIX_SECONDS('2026-01-01 00:00:00')`, "1767225600"},
+		{"unix_millis", `SELECT UNIX_MILLIS('2026-01-01 00:00:00')`, "1767225600000"},
+		{"timestamp_seconds", `SELECT TIMESTAMP_SECONDS(0)`, "1970-01-01 00:00:00"},
+		{"timestamp_millis", `SELECT TIMESTAMP_MILLIS(1000)`, "1970-01-01 00:00:01"},
+		{"to_hex", `SELECT TO_HEX('ab')`, "6162"},
+		{"is_nan false", `SELECT IS_NAN(1.0)`, "0"},
+		{"is_nan true", `SELECT IS_NAN('nan')`, "1"},
+		{"is_nan non-numeric text", `SELECT IS_NAN('abc')`, "0"},
+		{"safe_add", `SELECT SAFE_ADD(1, 2)`, "3"},
+		{"safe_add overflow", `SELECT IFNULL(CAST(SAFE_ADD(9223372036854775807, 1) AS TEXT), 'null')`, "null"},
+		{"safe_subtract", `SELECT SAFE_SUBTRACT(1, 2)`, "-1"},
+		{"safe_multiply", `SELECT SAFE_MULTIPLY(3, 4)`, "12"},
+		{"safe_multiply overflow", `SELECT IFNULL(CAST(SAFE_MULTIPLY(9223372036854775807, 2) AS TEXT), 'null')`, "null"},
+		{"safe_negate", `SELECT SAFE_NEGATE(5)`, "-5"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -224,6 +269,30 @@ func TestUDFNullHandling(t *testing.T) {
 		`SELECT REGEXP_CONTAINS(NULL, 'a')`,
 		`SELECT REGEXP_EXTRACT('abc', 'z')`,
 		`SELECT DATE_DIFF(NULL, '2026-01-01', 'day')`,
+		`SELECT LEAST(1, NULL)`,
+		`SELECT GREATEST(NULL, 'a')`,
+		`SELECT REVERSE(NULL)`,
+		`SELECT FIND_IN_SET(NULL, 'a,b')`,
+		`SELECT ELT(0, 'a', 'b')`,
+		`SELECT ELT(3, 'a', 'b')`,
+		`SELECT MONTHNAME(NULL)`,
+		`SELECT DAYNAME('not a date')`,
+		`SELECT LAST_DAY(NULL)`,
+		`SELECT UNIX_TIMESTAMP(NULL)`,
+		`SELECT FROM_UNIXTIME(NULL)`,
+		`SELECT MD5(NULL)`,
+		`SELECT ASCII(NULL)`,
+		`SELECT CHR(NULL)`,
+		`SELECT TRANSLATE(NULL, 'a', 'b')`,
+		`SELECT FORMAT_DATE('%Y', NULL)`,
+		`SELECT PARSE_DATE('%Y-%m-%d', 'nope')`,
+		`SELECT UNIX_SECONDS(NULL)`,
+		`SELECT TIMESTAMP_SECONDS(NULL)`,
+		`SELECT TO_HEX(NULL)`,
+		`SELECT IS_NAN(NULL)`,
+		`SELECT SAFE_ADD(NULL, 1)`,
+		`SELECT SAFE_NEGATE(NULL)`,
+		`SELECT REGEXP_REPLACE(NULL, 'a', 'b', 'g')`,
 	} {
 		var got sql.NullString
 		if err := db.QueryRowContext(context.Background(), q).Scan(&got); err != nil {
@@ -318,6 +387,14 @@ func TestDatePartUnsupported(t *testing.T) {
 		`SELECT DATE_PART('century', '2026-07-28')`,
 		`SELECT DATE_TRUNC('decade', '2026-07-28')`,
 		`SELECT DATE_DIFF('2026-01-01', '2020-01-01', 'century')`,
+		`SELECT CHR(-1)`,
+		`SELECT CHR(2000000)`,
+		`SELECT FIELD('a')`,
+		`SELECT ELT(1)`,
+		`SELECT REGEXP_REPLACE('a', 'a')`,
+		`SELECT REGEXP_REPLACE('a', 'a', 'b', 'g', 'extra')`,
+		`SELECT UNIX_TIMESTAMP('2026-01-01', 'extra')`,
+		`SELECT FROM_UNIXTIME(0, '%Y', 'extra')`,
 	} {
 		var got sql.NullString
 		if err := db.QueryRowContext(context.Background(), q).Scan(&got); err == nil {
@@ -353,6 +430,20 @@ func TestEdgeCaseUDFs(t *testing.T) {
 		{`SELECT IF('0', 'y', 'n')`, "n"},
 		{`SELECT IF('text', 'y', 'n')`, "y"},
 		{`SELECT IF(CAST('' AS BLOB), 'y', 'n')`, "n"},
+		{`SELECT LEAST(5)`, "5"},
+		{`SELECT GREATEST('10', '9')`, "10"},        // numeric strings compare numerically
+		{`SELECT GREATEST('b10', 'b9')`, "b9"},      // mixed content falls back to text order
+		{`SELECT FIND_IN_SET('', 'a,,b')`, "2"},     // an empty field is still a field
+		{`SELECT FIELD(1, '1', 'x')`, "1"},          // arguments are compared as text
+		{`SELECT TRANSLATE('abc', '', 'x')`, "abc"}, // an empty from-set changes nothing
+		{`SELECT REVERSE('')`, ""},
+		{`SELECT ASCII('あ')`, "12354"},
+		{`SELECT CHR(12354)`, "あ"},
+		{`SELECT LAST_DAY('2026-12-31')`, "2026-12-31"},
+		{`SELECT FROM_UNIXTIME(-1)`, "1969-12-31 23:59:59"},
+		{`SELECT SAFE_ADD(1.5, 2.0)`, "3.5"},
+		{`SELECT SAFE_NEGATE(1.5)`, "-1.5"},
+		{`SELECT REGEXP_REPLACE('a1b2', '[0-9]', 'X', '')`, "aXb2"}, // no "g": first match only
 	}
 	for _, tt := range tests {
 		var got sql.NullString


### PR DESCRIPTION
## Why

Probing sqly's CLI for SQL-dialect divergences turned up a long list of ordinary scalar functions that failed with `no such function` once a query was written in MySQL, PostgreSQL, or GoogleSQL syntax. None of them are exotic: `LEAST`, `GREATEST`, `MD5`, `LAST_DAY`, and `FORMAT_DATE` all show up in everyday queries, and a user hitting one has no workaround other than rewriting the query in SQLite syntax, which defeats the point of the dialect layer.

## What

Register the missing functions as UDFs.

Shared by every dialect: `LEAST`, `GREATEST`. SQLite spells these `min`/`max` with several arguments, which collides with the aggregate forms, so they need their own implementations. A NULL argument makes the call NULL, which is MySQL and GoogleSQL behavior; PostgreSQL instead skips NULLs, and that difference is documented at the implementation.

MySQL: `REVERSE`, `FIND_IN_SET`, `FIELD`, `ELT`, `MONTHNAME`, `DAYNAME`, `LAST_DAY`, `UNIX_TIMESTAMP`, `FROM_UNIXTIME`.

PostgreSQL: `MD5`, `ASCII`, `CHR`, `TRANSLATE`.

GoogleSQL: `FORMAT_DATE`, `FORMAT_DATETIME`, `FORMAT_TIMESTAMP`, `PARSE_DATE`, `PARSE_DATETIME`, `PARSE_TIMESTAMP`, `UNIX_SECONDS`, `UNIX_MILLIS`, `UNIX_MICROS`, `TIMESTAMP_SECONDS`, `TIMESTAMP_MILLIS`, `TIMESTAMP_MICROS`, `TO_HEX`, `IS_NAN`, `SAFE_ADD`, `SAFE_SUBTRACT`, `SAFE_MULTIPLY`, `SAFE_NEGATE`.

GoogleSQL formats dates with strftime specifiers rather than the MySQL `DATE_FORMAT` set, and the two disagree on `%M` (minute versus month name) and on how month and weekday names are spelled. `FORMAT_DATE` and `PARSE_DATE` therefore get their own specifier table instead of reusing `DATE_FORMAT`'s.

`REGEXP_REPLACE` now also accepts PostgreSQL's fourth flags argument: `g` replaces every match, its absence replaces only the first, and `i` matches case insensitively. The three-argument form keeps replacing every match, which is what GoogleSQL does and what callers of the existing behavior rely on.

`UNIX_TIMESTAMP` is registered as non-deterministic because its zero-argument form reads the clock.

## Testing

Cases were added to the existing `TestUDFExecution`, `TestPostgreSQLUDFExecution`, and `TestGoogleSQLUDFExecution` tables, each running through a real SQLite connection. `TestUDFNullHandling` covers NULL propagation for every new function, `TestEdgeCaseUDFs` covers the boundaries (empty strings, multi-byte runes, negative epochs, numeric-versus-text comparison in `LEAST`/`GREATEST`, integer overflow in the `SAFE_` family, `REGEXP_REPLACE` without `g`), and `TestDatePartUnsupported` covers the argument-count and out-of-range errors.

`go test ./...`, `go vet`, and `golangci-lint run` are clean.

Ref: nao1215/sqly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded SQL-dialect translation with additional MySQL, PostgreSQL, and GoogleSQL scalar functions (including `LEAST`/`GREATEST`, `REGEXP_REPLACE`, and more string/date/time and encoding utilities).
  * Added Unix epoch/time conversion and date/time format/parse helpers.
  * Introduced safe arithmetic functions that return `NULL` on overflow or invalid results.
* **Documentation**
  * Updated the changelog under **Added** with the new dialect capabilities and `REGEXP_REPLACE` flag behavior.
* **Tests**
  * Expanded UDF test coverage for new functions, flags, NULL propagation, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->