### PR TITLE
chore: prepare v0.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-29
+
 ### Added
 - Dialect queries can now call the scalar functions that were previously missing. Shared: `LEAST` and `GREATEST`. MySQL: `REVERSE`, `FIND_IN_SET`, `FIELD`, `ELT`, `MONTHNAME`, `DAYNAME`, `LAST_DAY`, `UNIX_TIMESTAMP`, `FROM_UNIXTIME`. PostgreSQL: `MD5`, `ASCII`, `CHR`, `TRANSLATE`. GoogleSQL: `FORMAT_DATE`, `FORMAT_DATETIME`, `FORMAT_TIMESTAMP`, `PARSE_DATE`, `PARSE_DATETIME`, `PARSE_TIMESTAMP`, `UNIX_SECONDS`, `UNIX_MILLIS`, `UNIX_MICROS`, `TIMESTAMP_SECONDS`, `TIMESTAMP_MILLIS`, `TIMESTAMP_MICROS`, `TO_HEX`, `IS_NAN`, `SAFE_ADD`, `SAFE_SUBTRACT`, `SAFE_MULTIPLY`, `SAFE_NEGATE`. Each previously failed with `no such function`.
 - `REGEXP_REPLACE` accepts PostgreSQL's fourth flags argument: `g` replaces every match, its absence replaces only the first, and `i` matches case insensitively. The three-argument form keeps replacing every match.
@@ -790,7 +792,8 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/nao1215/filesql/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/nao1215/filesql/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/nao1215/filesql/compare/v0.17.2...v0.18.0
 [0.17.2]: https://github.com/nao1215/filesql/compare/v0.17.1...v0.17.2


### PR DESCRIPTION
Roll the Unreleased entries into v0.20.0 and add the compare link.

The release is the dialect layer catching up with the dialects it claims to translate. It adds the scalar functions that were missing outright, and fixes four classes of silent divergence found by probing sqly's CLI: casts that applied SQLite's type affinity instead of the dialect's conversion rules, operators (`/`, `LIKE`, `||`, `<=>`, `^`) that meant something else in SQLite, date arithmetic that rolled a month-end overflow forward instead of clamping it, and the aggregates SQLite has no equivalent for.

No code change; CHANGELOG only.