### PR TITLE
fix(dialect): keep window clauses attached to their aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A window or filter clause no longer breaks the operator rewrites.** `SUM(x) OVER (ORDER BY id) / 2` failed to parse under MySQL and GoogleSQL, and `x / COUNT(*) OVER ()` attached the `OVER` clause to the division helper instead of the count. The operand scanners walk back from an operator to the primary expression beside it, and a windowed aggregate ends in the clause's own parentheses, which they mistook for the whole operand. `FILTER (WHERE ...)` and `OVER window_name` had the same problem. Introduced in 0.20.0 with the division and `LIKE` rewrites.
+- **The `INTERVAL` amount can be any expression.** `DATE_ADD(d, INTERVAL n DAY)` with a column or an expression as the amount is valid MySQL but was rejected with "INTERVAL value must be a numeric literal".
+
 ## [0.20.0] - 2026-07-29
 
 ### Added

--- a/dialect/datetime_test.go
+++ b/dialect/datetime_test.go
@@ -38,6 +38,10 @@ func TestDateArithmeticSemantics(t *testing.T) {
 		{"mysql quarter", MySQL, `SELECT DATE_ADD('2026-01-01', INTERVAL 1 QUARTER)`, "2026-04-01"},
 		{"mysql negative interval", MySQL, `SELECT DATE_ADD('2026-01-01', INTERVAL -1 DAY)`, "2025-12-31"},
 		{"mysql explicit positive interval", MySQL, `SELECT DATE_ADD('2026-01-01', INTERVAL +1 DAY)`, "2026-01-02"},
+		// MySQL accepts any expression as the amount, not only a literal.
+		{"mysql interval from a column", MySQL, `SELECT DATE_ADD('2026-01-01', INTERVAL n DAY) FROM (SELECT 3 AS n) t`, "2026-01-04"},
+		{"mysql interval from an expression", MySQL, `SELECT DATE_ADD('2026-01-01', INTERVAL (1 + 2) DAY)`, "2026-01-04"},
+		{"mysql date_sub from a column", MySQL, `SELECT DATE_SUB('2026-01-10', INTERVAL n DAY) FROM (SELECT 3 AS n) t`, "2026-01-07"},
 		{"googlesql week", GoogleSQL, `SELECT DATE_ADD(DATE '2026-01-01', INTERVAL 1 WEEK)`, "2026-01-08"},
 
 		// MySQL's TIMESTAMPDIFF counts forward from its second argument, the
@@ -120,7 +124,6 @@ func TestDateArithmeticRejects(t *testing.T) {
 		query   string
 	}{
 		{MySQL, `SELECT DATE_ADD(d, INTERVAL 1 DAY_HOUR)`},
-		{MySQL, `SELECT DATE_ADD('2026-01-01', INTERVAL 'x' DAY)`},
 		{PostgreSQL, `SELECT DATE '2026-01-01' + INTERVAL 'nonsense'`},
 		{PostgreSQL, `SELECT DATE '2026-01-01' + INTERVAL '1 fortnight'`},
 		{PostgreSQL, `SELECT DATE '2026-01-01' + INTERVAL '1.5 days'`},

--- a/dialect/googlesql_test.go
+++ b/dialect/googlesql_test.go
@@ -33,7 +33,7 @@ func TestGoogleSQLTranslate(t *testing.T) {
 		{"G-6_format", "SELECT FORMAT('%d', n) FROM t", "SELECT printf('%d', n) FROM t"},
 
 		{"G-7_date_add", "SELECT DATE_ADD(d, INTERVAL 3 DAY)", "SELECT interval_add(d, 3, 'day')"},
-		{"G-7_timestamp_sub", "SELECT TIMESTAMP_SUB(ts, INTERVAL 2 HOUR)", "SELECT interval_add(ts, -2, 'hour')"},
+		{"G-7_timestamp_sub", "SELECT TIMESTAMP_SUB(ts, INTERVAL 2 HOUR)", "SELECT interval_add(ts, -(2), 'hour')"},
 
 		{"G-8_date_diff", "SELECT DATE_DIFF(a, b, DAY) FROM t", "SELECT DATE_DIFF(a, b, 'day') FROM t"},
 		{"G-8_timestamp_diff", "SELECT TIMESTAMP_DIFF(a, b, SECOND)", "SELECT TIMESTAMP_DIFF(a, b, 'second')"},

--- a/dialect/mysql_test.go
+++ b/dialect/mysql_test.go
@@ -19,7 +19,7 @@ func TestMySQLTranslate(t *testing.T) {
 		{"C-1_extract_expr", "SELECT EXTRACT(MONTH FROM o.created) FROM t", "SELECT DATE_PART('month', o.created) FROM t"},
 
 		{"M-5_date_add", "SELECT DATE_ADD(d, INTERVAL 3 DAY) FROM t", "SELECT interval_add(d, 3, 'day') FROM t"},
-		{"M-5_date_sub", "SELECT DATE_SUB(d, INTERVAL 2 MONTH) FROM t", "SELECT interval_add(d, -2, 'month') FROM t"},
+		{"M-5_date_sub", "SELECT DATE_SUB(d, INTERVAL 2 MONTH) FROM t", "SELECT interval_add(d, -(2), 'month') FROM t"},
 		{"M-5_date_add_hour", "SELECT DATE_ADD(ts, INTERVAL 5 HOUR)", "SELECT interval_add(ts, 5, 'hour')"},
 		{"M-5_date_add_string_arg", "SELECT DATE_ADD('2020-01-01', INTERVAL 1 YEAR)", "SELECT interval_add('2020-01-01', 1, 'year')"},
 
@@ -75,7 +75,7 @@ func TestMySQLTranslateUnsupported(t *testing.T) {
 		input string
 	}{
 		{"M-5_unsupported_unit", "SELECT DATE_ADD(d, INTERVAL 1 DAY_HOUR)"},
-		{"M-5_non_literal_interval", "SELECT DATE_ADD(d, INTERVAL n DAY)"},
+		{"M-5_missing_interval_value", "SELECT DATE_ADD(d, INTERVAL DAY)"},
 		{"M-5_compound_interval", "SELECT DATE_ADD(d, INTERVAL '1:1' MINUTE_SECOND)"},
 		{"M-5_missing_unit", "SELECT DATE_ADD(d, INTERVAL 3)"},
 		{"M-7_div_left_not_primary", "SELECT a, DIV b"},

--- a/dialect/operators_test.go
+++ b/dialect/operators_test.go
@@ -192,3 +192,44 @@ func TestOperandMustBePrimary(t *testing.T) {
 		}
 	}
 }
+
+// TestWindowFunctionOperands keeps a window or filter clause attached to the
+// aggregate it modifies. The operand scanners walk back from an operator to the
+// primary expression beside it, and a bare "SUM(x) OVER (...)" ends in the
+// clause's own parentheses, which is easy to mistake for the whole operand.
+func TestWindowFunctionOperands(t *testing.T) {
+	// Not parallel: castDB touches the process-global driver registration.
+	db := castDB(t)
+
+	if _, err := db.ExecContext(context.Background(), `CREATE TABLE w (id INTEGER, score INTEGER)`); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := db.ExecContext(context.Background(), `INSERT INTO w VALUES (1, 10), (2, 20), (3, 30)`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		dialect Dialect
+		query   string
+		want    string
+	}{
+		{"mysql divides a windowed sum", MySQL, `SELECT SUM(score) OVER (ORDER BY id) / 2 FROM w ORDER BY id LIMIT 1`, "5"},
+		{"mysql divides by a windowed count", MySQL, `SELECT score / COUNT(*) OVER () FROM w ORDER BY id LIMIT 1`, "3.3333333333333335"},
+		{"googlesql divides a windowed sum", GoogleSQL, `SELECT SUM(score) OVER (ORDER BY id) / 2 FROM w ORDER BY id LIMIT 1`, "5"},
+		{"mysql divides a named window", MySQL, `SELECT SUM(score) OVER win / 2 FROM w WINDOW win AS (ORDER BY id) ORDER BY id LIMIT 1`, "5"},
+		{"mysql divides a filtered aggregate", MySQL, `SELECT COUNT(*) FILTER (WHERE id > 1) / 2 FROM w`, "1"},
+		{"postgresql matches a windowed value", PostgreSQL, `SELECT CAST(SUM(score) OVER (ORDER BY id) AS TEXT) LIKE '1%' FROM w ORDER BY id LIMIT 1`, "1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := runDialect(t, db, tt.dialect, tt.query)
+			if err != nil {
+				t.Fatalf("%s: %v", tt.query, err)
+			}
+			if !got.Valid || got.String != tt.want {
+				t.Fatalf("%s = %v, want %q", tt.query, got, tt.want)
+			}
+		})
+	}
+}

--- a/dialect/rewrite.go
+++ b/dialect/rewrite.go
@@ -116,6 +116,9 @@ var intervalUnits = map[string]string{
 // TIMESTAMP_ADD/TIMESTAMP_SUB): f(x, INTERVAL n unit) -> interval_add(x, ±n,
 // 'unit'). sign is "+" for the ADD forms and "-" for the SUB forms.
 //
+// The amount is any expression up to the trailing unit keyword, so a signed
+// literal and a column both work; MySQL accepts either.
+//
 // It goes through the helper rather than SQLite's datetime() modifier because
 // datetime() rolls a month-end overflow forward where every source dialect
 // clamps it, and always renders a time of day.
@@ -128,16 +131,21 @@ func rewriteDateArith(tokens []token, open, closeIdx int, sign string, recurse c
 	if interval < 0 || !isWordEq(tokens[interval], "INTERVAL") {
 		return nil, false, nil
 	}
-	amount, unitTok, err := readIntervalAmount(tokens, interval)
-	if err != nil {
-		return nil, false, err
+	unitTok := prevSig(tokens, closeIdx)
+	if unitTok < 0 || unitTok <= interval || tokens[unitTok].kind != tokWord {
+		return nil, false, fmt.Errorf("%w: INTERVAL is missing a unit", ErrUnsupportedSyntax)
 	}
 	unit, ok := intervalUnits[strings.ToUpper(tokens[unitTok].text)]
 	if !ok {
 		return nil, false, fmt.Errorf("%w: unsupported INTERVAL unit %q", ErrUnsupportedSyntax, tokens[unitTok].text)
 	}
-	if after := nextSig(tokens, unitTok+1); after != closeIdx {
-		return nil, false, fmt.Errorf("%w: unsupported INTERVAL expression", ErrUnsupportedSyntax)
+	amount, err := recurse(tokens[interval+1 : unitTok])
+	if err != nil {
+		return nil, false, err
+	}
+	amount = trimSpaceTokens(amount)
+	if len(amount) == 0 {
+		return nil, false, fmt.Errorf("%w: INTERVAL is missing a value", ErrUnsupportedSyntax)
 	}
 
 	expr, err := recurse(tokens[open+1 : comma])
@@ -145,38 +153,21 @@ func rewriteDateArith(tokens []token, open, closeIdx int, sign string, recurse c
 		return nil, false, err
 	}
 	expr = trimSpaceTokens(expr)
-	if sign == "-" {
-		amount = "-" + amount
-	}
-	repl := make([]token, 0, len(expr)+8)
+	repl := make([]token, 0, len(expr)+len(amount)+10)
 	repl = append(repl, wordToken("interval_add"), opToken("("))
 	repl = append(repl, expr...)
-	repl = append(repl, opToken(","), spaceToken(), wordToken(amount))
+	repl = append(repl, opToken(","), spaceToken())
+	if sign == "-" {
+		// Negate the whole amount, which may be an expression rather than a
+		// literal: MySQL accepts DATE_SUB(d, INTERVAL n DAY) with a column n.
+		repl = append(repl, opToken("-"), opToken("("))
+		repl = append(repl, amount...)
+		repl = append(repl, opToken(")"))
+	} else {
+		repl = append(repl, amount...)
+	}
 	repl = append(repl, opToken(","), spaceToken(), stringToken(unit), opToken(")"))
 	return repl, true, nil
-}
-
-// readIntervalAmount reads the signed numeric literal after an INTERVAL keyword
-// and returns it along with the index of the unit token that follows. A leading
-// "-" arrives as its own operator token, which is why the sign is handled here
-// rather than by requiring a single number token.
-func readIntervalAmount(tokens []token, interval int) (string, int, error) {
-	idx := nextSig(tokens, interval+1)
-	sign := ""
-	if idx >= 0 && (isOpEq(tokens[idx], "-") || isOpEq(tokens[idx], "+")) {
-		if tokens[idx].text == "-" {
-			sign = "-"
-		}
-		idx = nextSig(tokens, idx+1)
-	}
-	if idx < 0 || tokens[idx].kind != tokNumber {
-		return "", 0, fmt.Errorf("%w: INTERVAL value must be a numeric literal", ErrUnsupportedSyntax)
-	}
-	unitTok := nextSig(tokens, idx+1)
-	if unitTok < 0 || tokens[unitTok].kind != tokWord {
-		return "", 0, fmt.Errorf("%w: INTERVAL is missing a unit", ErrUnsupportedSyntax)
-	}
-	return sign + tokens[idx].text, unitTok, nil
 }
 
 // rewriteRenameCall rewrites a call to use newName, recursing into its arguments.
@@ -425,6 +416,12 @@ func primaryStartBack(toks []token) (int, bool) {
 		if open < 0 {
 			return 0, false
 		}
+		// A FILTER or OVER clause modifies the call in front of it, so the
+		// primary is the whole "f(...) FILTER (...) OVER (...)" and not just the
+		// clause's own parentheses.
+		if prev := prevSig(toks, open); prev >= 0 && isWindowClauseKeyword(toks[prev]) {
+			return primaryStartBack(toks[:prev])
+		}
 		// A "(" is a function call only when a name sits immediately before it
 		// (as in count(*)); a name separated by whitespace (as in the keyword of
 		// "SELECT (a + b)") is not part of the parenthesized primary.
@@ -433,9 +430,49 @@ func primaryStartBack(toks []token) (int, bool) {
 		}
 		return open, true
 	case isName(toks[end]) || isLiteral(toks[end]):
-		return chainStartBack(toks, end), true
+		start := chainStartBack(toks, end)
+		// "f(...) OVER w" names a window defined in a WINDOW clause; the name
+		// belongs to the call, not to whatever precedes it.
+		if prev := prevSig(toks, start); prev >= 0 && isWordEq(toks[prev], "OVER") {
+			return primaryStartBack(toks[:prev])
+		}
+		return start, true
 	default:
 		return 0, false
+	}
+}
+
+// isWindowClauseKeyword reports whether t introduces a postfix clause that binds
+// to the aggregate call before it.
+func isWindowClauseKeyword(t token) bool {
+	return isWordEq(t, "OVER") || isWordEq(t, "FILTER")
+}
+
+// extendWindowClauses walks forward across the FILTER and OVER clauses that
+// follow the call ending at end, so a binary-operator rewrite treats
+// "SUM(x) OVER (...)" as one operand rather than splitting it at the clause.
+func extendWindowClauses(toks []token, end int) int {
+	for {
+		next := nextSig(toks, end+1)
+		if next < 0 || !isWindowClauseKeyword(toks[next]) {
+			return end
+		}
+		after := nextSig(toks, next+1)
+		if after < 0 {
+			return end
+		}
+		switch {
+		case isOpEq(toks[after], "("):
+			closeIdx := matchParen(toks, after)
+			if closeIdx < 0 {
+				return end
+			}
+			end = closeIdx
+		case isWordEq(toks[next], "OVER") && isName(toks[after]):
+			end = after
+		default:
+			return end
+		}
 	}
 }
 
@@ -476,6 +513,7 @@ func primaryEndForward(toks []token, from int) (int, bool) {
 	default:
 		return 0, false
 	}
+	end = extendWindowClauses(toks, end)
 	// Extend over ".name" chains and any call parentheses that follow them.
 	for {
 		dot := nextSig(toks, end+1)
@@ -493,6 +531,7 @@ func primaryEndForward(toks []token, from int) (int, bool) {
 			}
 			end = e
 		}
+		end = extendWindowClauses(toks, end)
 	}
 }
 


### PR DESCRIPTION
## Why

A regression from v0.20.0, found by re-probing sqly's CLI after that release.

The binary-operator rewrites (`/`, `LIKE`, `^`, `SIMILAR TO`) walk back from the operator to the primary expression beside it. A windowed aggregate ends in its clause's own parentheses, so `SUM(x) OVER (ORDER BY id)` looked to the scanner like a parenthesized expression preceded by the name `OVER`, and it took `OVER (ORDER BY id)` as the entire left operand.

The result was a query that used to work and now does not:

```
SELECT SUM(score) OVER (ORDER BY id) / 2 FROM t    -- near "(": syntax error
SELECT score / COUNT(*) OVER () FROM t             -- googlesql_divide() may not be used as a window function
```

The second is the more revealing message: the rewrite produced `googlesql_divide(score, COUNT(*)) OVER ()`, moving the window clause onto the helper. `FILTER (WHERE ...)` and the `OVER window_name` form had the same problem, and PostgreSQL's `LIKE` rewrite shared it.

## What

`primaryStartBack` walks back across a `FILTER` or `OVER` clause to the call it modifies, and `primaryEndForward` walks forward across both, so `f(...) FILTER (...) OVER (...)` is treated as one primary expression. The `OVER window_name` form is handled too, since a bare name there belongs to the call rather than to whatever precedes it.

Separately, the `INTERVAL` amount now accepts any expression up to the trailing unit keyword. `DATE_ADD(d, INTERVAL n DAY)` with a column is valid MySQL and was rejected with "INTERVAL value must be a numeric literal". Nothing but the rewrite required a literal: the helper takes the amount as an argument, so a column or an expression works as-is. `DATE_SUB` negates the whole amount rather than prefixing a minus to a number.

## Testing

`TestWindowFunctionOperands` runs each shape through a real table: a windowed sum divided by a constant, a value divided by a windowed count, a named window, a filtered aggregate, and a `LIKE` against a windowed value. `TestDateArithmeticSemantics` gains a column amount, an expression amount, and the `DATE_SUB` form.

`go test ./...`, `go vet`, and `golangci-lint run` are clean.

Ref: nao1215/sqly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL translation for window functions, named windows, and `FILTER` clauses.
  - Fixed MySQL and GoogleSQL date arithmetic rewrites involving window clauses.
  - `INTERVAL` amounts can now use expressions and column references, not only numeric literals.
  - Corrected negative interval expression handling in translated SQL.

- **Documentation**
  - Updated the changelog with the latest translation fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->