### PR TITLE
fix(table): keep non-Latin file names as table names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A file name written in a non-Latin script keeps its table name.** Table names were sanitized against the ASCII letter range, so every other letter was deleted: `売上.csv` became `sheet`, `Данные.csv` became `sheet`, and `café.csv` became `caf`. Two such files in one database therefore collided on the same fallback name and only one of them loaded. A table name is always emitted double-quoted, so the restriction bought nothing; the sanitizer now judges letters and digits by Unicode category and keeps combining marks, so `SELECT * FROM "売上"` works. Excel sheet names, which go through the same sanitizer, are fixed with it. A name whose characters are all dropped still falls back to `sheet`, and punctuation, symbols, and quotes are still removed.
+
 ## [0.21.0] - 2026-07-29
 
 ### Added

--- a/filesql_test.go
+++ b/filesql_test.go
@@ -1387,8 +1387,8 @@ func Test_TableNameSecurity(t *testing.T) {
 		{
 			name:         "Unicode characters",
 			filePath:     "データ.csv",
-			expectedName: "sheet",
-			description:  "Should sanitize Unicode characters to fallback name",
+			expectedName: "データ",
+			description:  "Should keep a name written in a non-Latin script; the table name is quoted",
 		},
 		{
 			name:         "Special characters",
@@ -4795,4 +4795,54 @@ func TestOpenCompressedJSON(t *testing.T) {
 
 		assert.Equal(t, []string{"Alice", "Bob", "Charlie"}, names)
 	})
+}
+
+// Test_NonLatinFileNameBecomesQueryableTable pins the whole path from a file
+// name written in a non-Latin script to a query: the table keeps the name, and
+// two such files in one database stay distinct instead of both collapsing onto
+// the "sheet" fallback.
+func Test_NonLatinFileNameBecomesQueryableTable(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	dir := t.TempDir()
+	files := map[string]string{
+		"売上.csv":     "id,amount\n1,100\n2,200\n",
+		"顧客.csv":     "id,name\n1,alice\n",
+		"Данные.csv": "id\n7\n",
+		"café.csv":   "id\n9\n",
+	}
+	paths := make([]string, 0, len(files))
+	for name, body := range files {
+		path := filepath.Join(dir, name)
+		require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+		paths = append(paths, path)
+	}
+
+	db, err := OpenContext(ctx, paths...)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Each file keeps its own table, so a query naming the file finds it.
+	var amount int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT amount FROM "売上" WHERE id = '2'`).Scan(&amount))
+	assert.Equal(t, 200, amount)
+
+	var name string
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT name FROM "顧客" WHERE id = '1'`).Scan(&name))
+	assert.Equal(t, "alice", name)
+
+	var id int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT id FROM "Данные"`).Scan(&id))
+	assert.Equal(t, 7, id)
+
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT id FROM "café"`).Scan(&id))
+	assert.Equal(t, 9, id)
+
+	// None of them fell back to the shared "sheet" name.
+	rows, err := db.QueryContext(ctx, `SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'sheet'`)
+	require.NoError(t, err)
+	defer rows.Close()
+	assert.False(t, rows.Next(), `no table should have collapsed onto the "sheet" fallback`)
+	require.NoError(t, rows.Err())
 }

--- a/table.go
+++ b/table.go
@@ -3,6 +3,8 @@ package filesql
 import (
 	"path/filepath"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // sheetFallbackName is the table name used when a sheet name sanitizes to empty.
@@ -92,33 +94,27 @@ func tableFromFilePath(filePath string) string {
 //
 // Transformations applied:
 //   - Replaces spaces, hyphens (-), and dots (.) with underscores (_)
-//   - Removes any non-alphanumeric characters except underscores
-//   - Adds "sheet_" prefix if the name starts with a number
+//   - Removes any character that is not a letter, a digit, a combining mark, or an underscore
+//   - Adds "sheet_" prefix if the name starts with a digit
 //   - Returns "sheet" as fallback for empty names
+//
+// Letters and digits are judged by Unicode category, not by the ASCII range: a
+// table name is always emitted double-quoted, so every letter SQLite accepts
+// inside quotes is kept. Restricting the set to ASCII erased a Japanese,
+// Chinese, Korean, Cyrillic, or accented-Latin file name down to the fallback,
+// which also made two such files collide on one table name.
 //
 // Example:
 //
 //	sanitizeTableName("with-hyphens") // returns "with_hyphens"
 //	sanitizeTableName("data.backup")  // returns "data_backup"
-//	sanitizeTableName("test@#$%")     // returns "test_"
+//	sanitizeTableName("test@#$%")     // returns "test"
+//	sanitizeTableName("売上")          // returns "売上"
 func sanitizeTableName(name string) string {
-	// Replace spaces and invalid characters with underscores
-	result := strings.ReplaceAll(name, " ", "_")
-	result = strings.ReplaceAll(result, "-", "_")
-	result = strings.ReplaceAll(result, ".", "_")
+	finalResult := identifierRunes(name)
 
-	// Remove any non-alphanumeric characters except underscore
-	var sanitized strings.Builder
-	for _, r := range result {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
-			sanitized.WriteRune(r)
-		}
-	}
-
-	finalResult := sanitized.String()
-
-	// Ensure it doesn't start with a number
-	if len(finalResult) > 0 && finalResult[0] >= '0' && finalResult[0] <= '9' {
+	// Ensure it doesn't start with a digit
+	if first, _ := utf8.DecodeRuneInString(finalResult); unicode.IsDigit(first) {
 		finalResult = "sheet_" + finalResult
 	}
 
@@ -128,4 +124,27 @@ func sanitizeTableName(name string) string {
 	}
 
 	return finalResult
+}
+
+// identifierRunes maps a derived name onto the characters an identifier may
+// carry: spaces, hyphens, and dots become underscores, and every remaining
+// character that is not a letter, a digit, a combining mark, or an underscore is
+// dropped. Letters and digits are judged by Unicode category so a name written
+// in any script survives; a combining mark is kept so a decomposed accent stays
+// with its base letter. Underscore is punctuation category-wise, so it is kept
+// by name. This is the one place both table-name sanitizers agree on the
+// character set, so a name derived from a file path and one built through
+// TableName cannot disagree.
+func identifierRunes(name string) string {
+	result := strings.ReplaceAll(name, " ", "_")
+	result = strings.ReplaceAll(result, "-", "_")
+	result = strings.ReplaceAll(result, ".", "_")
+
+	var sanitized strings.Builder
+	for _, r := range result {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r) || r == '_' {
+			sanitized.WriteRune(r)
+		}
+	}
+	return sanitized.String()
 }

--- a/table_test.go
+++ b/table_test.go
@@ -226,3 +226,44 @@ func TestTableFromFilePath_Additional(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeTableName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain name", "users", "users"},
+		{"hyphen becomes underscore", "user-data", "user_data"},
+		{"space becomes underscore", "user data", "user_data"},
+		{"dot becomes underscore", "data.backup", "data_backup"},
+		{"punctuation is dropped", "user@#$data", "userdata"},
+		{"leading digit is prefixed", "123table", "sheet_123table"},
+		{"only punctuation falls back", "@#$%", "sheet"},
+		{"empty falls back", "", "sheet"},
+		{"uppercase is preserved", "UserData", "UserData"},
+		// A table name is always emitted double-quoted, so any letter SQLite
+		// accepts inside quotes survives. Dropping non-ASCII letters used to
+		// erase a Japanese, Chinese, Korean, Cyrillic, or accented-Latin file
+		// name down to the fallback, making two such files collide.
+		{"japanese is preserved", "売上", "売上"},
+		{"japanese kana is preserved", "テーブル", "テーブル"},
+		{"cyrillic is preserved", "Данные", "Данные"},
+		{"accented latin is preserved", "café", "café"},
+		{"decomposed accent is preserved", "café", "café"},
+		{"mixed script keeps both", "売上-2026", "売上_2026"},
+		{"non-ascii digit leads", "١٢", "sheet_١٢"},
+		{"emoji is dropped", "data\U0001F600", "data"},
+		{"quote is dropped", `a"b`, "ab"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, sanitizeTableName(tt.input), "sanitizeTableName(%q)", tt.input)
+		})
+	}
+}

--- a/types.go
+++ b/types.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 )
 
 // defaultTableName is the table name used when a derived name is empty.
@@ -21,24 +23,6 @@ const (
 	MinChunkSize = 1
 	// ValidationPeekSize is the size used for validation peek operations
 	ValidationPeekSize = 1
-)
-
-// Character validation constants
-const (
-	// firstDigitChar represents the first numeric character
-	firstDigitChar = '0'
-	// lastDigitChar represents the last numeric character
-	lastDigitChar = '9'
-	// firstLowerChar represents the first lowercase letter
-	firstLowerChar = 'a'
-	// lastLowerChar represents the last lowercase letter
-	lastLowerChar = 'z'
-	// firstUpperChar represents the first uppercase letter
-	firstUpperChar = 'A'
-	// lastUpperChar represents the last uppercase letter
-	lastUpperChar = 'Z'
-	// underscoreChar represents the underscore character
-	underscoreChar = '_'
 )
 
 // File format delimiters
@@ -78,28 +62,15 @@ func (tn TableName) Sanitize() TableName {
 	return TableName{value: tn.sanitizeString()}
 }
 
-// sanitizeString removes invalid characters from table names
+// sanitizeString removes invalid characters from table names. It keeps the same
+// characters as the file-path sanitizer (see identifierRunes), so a name written
+// in a non-Latin script survives here too, and differs only in the fallback and
+// prefix it uses when the result is empty or starts with a digit.
 func (tn TableName) sanitizeString() string {
-	// Replace spaces and invalid characters with underscores
-	result := strings.ReplaceAll(tn.value, " ", "_")
-	result = strings.ReplaceAll(result, "-", "_")
-	result = strings.ReplaceAll(result, ".", "_")
+	finalResult := identifierRunes(tn.value)
 
-	// Remove any non-alphanumeric characters except underscore
-	var sanitized strings.Builder
-	for _, r := range result {
-		if (r >= firstLowerChar && r <= lastLowerChar) ||
-			(r >= firstUpperChar && r <= lastUpperChar) ||
-			(r >= firstDigitChar && r <= lastDigitChar) ||
-			r == underscoreChar {
-			sanitized.WriteRune(r)
-		}
-	}
-
-	finalResult := sanitized.String()
-
-	// Ensure it doesn't start with a number
-	if len(finalResult) > 0 && finalResult[0] >= firstDigitChar && finalResult[0] <= lastDigitChar {
+	// Ensure it doesn't start with a digit
+	if first, _ := utf8.DecodeRuneInString(finalResult); unicode.IsDigit(first) {
 		finalResult = "table_" + finalResult
 	}
 

--- a/types_test.go
+++ b/types_test.go
@@ -105,6 +105,12 @@ func TestTableName_Sanitize(t *testing.T) {
 		{"empty after sanitize", "", "table"},
 		{"mixed invalid chars", "test-data.v2@new", "test_data_v2new"}, // only -, space, . are replaced with _
 		{"uppercase preserved", "UserData", "UserData"},
+		// The character set matches the file-path sanitizer, so a name in any
+		// script survives here too; only the fallback and prefix differ.
+		{"japanese preserved", "売上", "売上"},
+		{"cyrillic preserved", "Данные", "Данные"},
+		{"accented latin preserved", "café", "café"},
+		{"non-ascii digit leads", "١٢", "table_١٢"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

A table name derived from a file path was sanitized against the ASCII letter range, so every letter outside it was deleted. `売上.csv` became `sheet`, `Данные.csv` became `sheet`, and `café.csv` became `caf`. Two files whose names are written in a non-Latin script therefore collided on the same fallback name, and only one of them loaded. Table names are always emitted double-quoted, so the ASCII restriction bought no safety; the sanitizer now judges letters and digits by Unicode category.

## Changes

- `table.go`: `sanitizeTableName` keeps any Unicode letter, digit, or combining mark plus underscore, and the leading-digit check decodes the first rune instead of the first byte. The character filter moved into a new `identifierRunes` helper so both table-name sanitizers agree on the set.
- `types.go`: `TableName.sanitizeString` delegates to `identifierRunes`, differing from the file-path sanitizer only in the fallback (`table`) and prefix (`table_`) it uses. The now-unused ASCII range constants are removed.
- `table_test.go`: `TestSanitizeTableName` covers the live sanitizer directly for the first time, across Japanese, Cyrillic, accented Latin in both precomposed and decomposed form, a non-ASCII leading digit, and the cases that must keep being dropped (emoji, quotes, punctuation).
- `types_test.go`: `TestTableName_Sanitize` gains the same non-Latin cases so the twin cannot drift back.
- `filesql_test.go`: `Test_NonLatinFileNameBecomesQueryableTable` opens a database over four non-Latin file names and queries each by name, asserting none collapsed onto the shared `sheet` fallback. `Test_TableNameSecurity` expects `データ.csv` to yield `データ`.

## Design Decisions

Combining marks are kept so a decomposed accent stays attached to its base letter; dropping them would turn NFD `café` into `cafe` while NFC `café` stayed intact, which is a difference the file system does not make visible. Underscore is punctuation by Unicode category, so it is kept by name rather than by category. Everything else that used to be dropped is still dropped, including the double quote that would otherwise break the quoted identifier.

`TableName.Sanitize` is exported but unused inside the package. It keeps its own `table` fallback and `table_` prefix rather than being folded into `sanitizeTableName`, so its documented output does not change beyond the character set.

## Limitations

This changes the table name a non-Latin input maps to, so a caller that had adapted to querying `sheet` needs to use the real name. That path could only ever address one such file per database, which is the bug being fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table names generated from non-Latin filenames so they preserve Unicode letters and remain independently queryable.
  * Prevented distinct non-Latin filenames and Excel sheet names from incorrectly collapsing into the same fallback name.
  * Improved handling of combining marks, leading digits, punctuation, and empty names during sanitization.
* **Tests**
  * Added coverage for Unicode filenames, scripts, accented characters, and edge-case table names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->