### PR TITLE
fix(ach,wire): stage the write so a rejected save cannot destroy the source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A rejected ACH or Fedwire write destroyed the file it was overwriting.** Both encoders validate while they encode, so a value the format cannot hold — an amount wider than its field, a malformed amount string — is rejected partway through the write. The destination was opened with `os.Create` first, which truncates, and for an in-place save that destination is the caller's own source file: an 891-byte ACH file came back 0 bytes, and Fedwire went further and deleted the file outright, because its failure path removed the output path as a "partial file". The write is now staged in a temporary file next to the destination and renamed over it only after the encoder and the close both succeed, so a rejected write costs nothing. An existing destination keeps its permissions; a new file is created 0644.
+
 ## [0.22.0] - 2026-07-29
 
 ### Fixed

--- a/ach.go
+++ b/ach.go
@@ -122,7 +122,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"sync"
 
@@ -547,22 +546,16 @@ func DumpACHWithTableSet(ctx context.Context, db *sql.DB, baseTableName, outputP
 		return fmt.Errorf("%w: failed to read updated data from database: %s", ErrACH, err.Error())
 	}
 
-	// Write the ACH file using WriteToWriter (encapsulates moov-io/ach)
-	file, err := os.Create(outputPath) //nolint:gosec // Output path is user-specified
-	if err != nil {
-		return fmt.Errorf("%w: failed to create output file: %s", ErrIOOperation, err.Error())
-	}
-
-	if err := tableSet.WriteToWriter(file); err != nil {
-		_ = file.Close() // Ignore close error as we're already returning an error
-		return fmt.Errorf("%w: failed to write ACH file: %s", ErrACH, err.Error())
-	}
-
-	if err := file.Close(); err != nil {
-		return fmt.Errorf("%w: failed to close output file: %s", ErrIOOperation, err.Error())
-	}
-
-	return nil
+	// Write the ACH file using WriteToWriter (encapsulates moov-io/ach). The
+	// writer validates while it encodes, so it can reject the data after the
+	// output has been opened; staging the write keeps a rejection from destroying
+	// the destination, which for an in-place save is the source file itself.
+	return writeFileAtomically(outputPath, func(w io.Writer) error {
+		if err := tableSet.WriteToWriter(w); err != nil {
+			return fmt.Errorf("%w: failed to write ACH file: %s", ErrACH, err.Error())
+		}
+		return nil
+	})
 }
 
 // updateTableSetFromDB reads updated data from the database and updates the TableSet.

--- a/ach_test.go
+++ b/ach_test.go
@@ -408,3 +408,48 @@ func TestGetACHTableInfos_Empty(t *testing.T) {
 	assert.NotNil(t, infos)
 	assert.Empty(t, infos)
 }
+
+// TestDumpACH_FailedWriteLeavesDestinationIntact pins that a rejected ACH write
+// does not damage the file it was going to overwrite. The moov-io writer
+// validates while encoding, so a value the format cannot hold (an amount wider
+// than its field) fails after the destination has been opened. Opening it with
+// os.Create truncated the caller's own source file to zero bytes before the
+// validation ran, so a rejected save destroyed the data it was saving.
+func TestDumpACH_FailedWriteLeavesDestinationIntact(t *testing.T) {
+	testFile := findTestACHFile(t)
+	if testFile == "" {
+		t.Skip("No test ACH file found")
+	}
+
+	ctx := context.Background()
+	ClearACHTableSetRegistry()
+	defer ClearACHTableSetRegistry()
+
+	// Copy the fixture so the test writes back over its own file, which is what
+	// an in-place save does.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "ppd-debit.ach")
+	original, err := os.ReadFile(testFile) //nolint:gosec // Test fixture path
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(target, original, 0o600)) //nolint:gosec // Test path is constructed from t.TempDir()
+
+	db, err := OpenContext(ctx, target)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// An amount of twelve digits cannot fit the ten-digit ACH field, so the
+	// writer rejects it partway through encoding.
+	_, err = db.ExecContext(ctx, "UPDATE ppd_debit_entries SET amount = 999999999999")
+	require.NoError(t, err)
+
+	err = DumpACH(ctx, db, "ppd_debit", target)
+	require.Error(t, err, "DumpACH should reject an amount wider than the ACH field")
+
+	after, err := os.ReadFile(target) //nolint:gosec // Test fixture path
+	require.NoError(t, err)
+	assert.Equal(t, original, after, "a rejected write must leave the destination byte-for-byte unchanged")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "a rejected write must not leave a temporary file behind: %v", entries)
+}

--- a/atomic_write.go
+++ b/atomic_write.go
@@ -1,0 +1,64 @@
+package filesql
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// defaultOutputFileMode is the permission given to a file this package creates.
+// An existing destination keeps its own mode instead.
+const defaultOutputFileMode os.FileMode = 0o644
+
+// writeFileAtomically hands write a writer for a temporary file in dest's
+// directory and renames it over dest only after write and the close both
+// succeed. When either fails, dest is left exactly as it was and the temporary
+// file is removed.
+//
+// Why this matters: the ACH and Fedwire encoders validate while they encode, so
+// a value the format cannot represent is rejected partway through the write.
+// Opening dest directly with os.Create truncated it first, which for an in-place
+// save is the caller's own source file — a rejected save destroyed the data it
+// was saving. Staging the write means a failure costs nothing.
+//
+// The temporary file is created in dest's directory so the rename stays within
+// one filesystem, where it is atomic. An existing dest keeps its permissions; a
+// new file is created 0644.
+func writeFileAtomically(dest string, write func(io.Writer) error) error {
+	dir := filepath.Dir(dest)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(dest)+".tmp*")
+	if err != nil {
+		return fmt.Errorf("%w: failed to create a temporary file next to %s: %s", ErrIOOperation, dest, err.Error())
+	}
+	tmpName := tmp.Name()
+	// Remove the staged file unless the rename below claimed it. Both calls are
+	// no-ops after a successful rename.
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName) //nolint:errcheck // Best-effort cleanup; the file is gone after a successful rename
+	}()
+
+	if err := write(tmp); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("%w: failed to close the temporary file for %s: %s", ErrIOOperation, dest, err.Error())
+	}
+
+	mode := defaultOutputFileMode
+	if info, statErr := os.Stat(dest); statErr == nil {
+		mode = info.Mode().Perm()
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return fmt.Errorf("%w: failed to inspect %s: %s", ErrIOOperation, dest, statErr.Error())
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return fmt.Errorf("%w: failed to set permissions on the temporary file for %s: %s", ErrIOOperation, dest, err.Error())
+	}
+
+	if err := os.Rename(tmpName, dest); err != nil {
+		return fmt.Errorf("%w: failed to replace %s: %s", ErrIOOperation, dest, err.Error())
+	}
+	return nil
+}

--- a/atomic_write_test.go
+++ b/atomic_write_test.go
@@ -1,0 +1,143 @@
+package filesql
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteFileAtomically(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates a new file", func(t *testing.T) {
+		t.Parallel()
+
+		dest := filepath.Join(t.TempDir(), "out.txt")
+		err := writeFileAtomically(dest, func(w io.Writer) error {
+			_, err := io.WriteString(w, "hello")
+			return err
+		})
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(dest) //nolint:gosec // Test path from t.TempDir()
+		require.NoError(t, err)
+		assert.Equal(t, "hello", string(got))
+	})
+
+	t.Run("replaces an existing file", func(t *testing.T) {
+		t.Parallel()
+
+		dest := filepath.Join(t.TempDir(), "out.txt")
+		require.NoError(t, os.WriteFile(dest, []byte("old content that is longer"), 0o600))
+
+		err := writeFileAtomically(dest, func(w io.Writer) error {
+			_, err := io.WriteString(w, "new")
+			return err
+		})
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(dest) //nolint:gosec // Test path from t.TempDir()
+		require.NoError(t, err)
+		assert.Equal(t, "new", string(got), "the old content must not survive as a tail")
+	})
+
+	t.Run("a failed write leaves the destination and the directory untouched", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		dest := filepath.Join(dir, "out.txt")
+		require.NoError(t, os.WriteFile(dest, []byte("original"), 0o600))
+
+		sentinel := errors.New("encoder rejected the data")
+		err := writeFileAtomically(dest, func(w io.Writer) error {
+			// Write some bytes first, the way an encoder that validates midway does.
+			if _, err := io.WriteString(w, "partial"); err != nil {
+				return err
+			}
+			return sentinel
+		})
+		require.ErrorIs(t, err, sentinel, "the writer's own error must reach the caller unwrapped")
+
+		got, err := os.ReadFile(dest) //nolint:gosec // Test path from t.TempDir()
+		require.NoError(t, err)
+		assert.Equal(t, "original", string(got))
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Len(t, entries, 1, "the staged file must be removed: %v", entries)
+	})
+
+	t.Run("a failed write does not create a destination that was absent", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		dest := filepath.Join(dir, "out.txt")
+
+		err := writeFileAtomically(dest, func(io.Writer) error {
+			return errors.New("nope")
+		})
+		require.Error(t, err)
+
+		_, statErr := os.Stat(dest)
+		assert.ErrorIs(t, statErr, os.ErrNotExist)
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Empty(t, entries, "the staged file must be removed: %v", entries)
+	})
+
+	t.Run("an existing file keeps its permissions", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Windows does not model Unix permission bits")
+		}
+		t.Parallel()
+
+		dest := filepath.Join(t.TempDir(), "out.txt")
+		require.NoError(t, os.WriteFile(dest, []byte("old"), 0o640)) //nolint:gosec // The 0640 mode is the subject of this test
+
+		err := writeFileAtomically(dest, func(w io.Writer) error {
+			_, err := io.WriteString(w, "new")
+			return err
+		})
+		require.NoError(t, err)
+
+		info, err := os.Stat(dest)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0o640), info.Mode().Perm())
+	})
+
+	t.Run("a new file is readable, not the 0600 of a temp file", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Windows does not model Unix permission bits")
+		}
+		t.Parallel()
+
+		dest := filepath.Join(t.TempDir(), "out.txt")
+		require.NoError(t, writeFileAtomically(dest, func(w io.Writer) error {
+			_, err := io.WriteString(w, "new")
+			return err
+		}))
+
+		info, err := os.Stat(dest)
+		require.NoError(t, err)
+		assert.Equal(t, defaultOutputFileMode, info.Mode().Perm())
+	})
+
+	t.Run("reports a destination directory that does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		dest := filepath.Join(t.TempDir(), "missing", "out.txt")
+		err := writeFileAtomically(dest, func(w io.Writer) error {
+			_, err := io.WriteString(w, "hello")
+			return err
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrIOOperation)
+	})
+}

--- a/wire.go
+++ b/wire.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"sync"
 
@@ -253,23 +252,17 @@ func DumpFedWireWithTableSet(ctx context.Context, db *sql.DB, baseTableName, out
 		return fmt.Errorf("%w: failed to read updated data from database: %s", ErrWire, err.Error())
 	}
 
-	// Write the Fedwire file using WriteToWriter
-	file, err := os.Create(outputPath) //nolint:gosec // Output path is user-specified
-	if err != nil {
-		return fmt.Errorf("%w: failed to create output file: %s", ErrIOOperation, err.Error())
-	}
-
-	if err := tableSet.WriteToWriter(file); err != nil {
-		_ = file.Close()
-		_ = os.Remove(outputPath) //nolint:errcheck // Best-effort cleanup of partial file
-		return fmt.Errorf("%w: failed to write Fedwire file: %s", ErrWire, err.Error())
-	}
-
-	if err := file.Close(); err != nil {
-		return fmt.Errorf("%w: failed to close output file: %s", ErrIOOperation, err.Error())
-	}
-
-	return nil
+	// Write the Fedwire file using WriteToWriter. The writer validates while it
+	// encodes, so it can reject the data after the output has been opened.
+	// Staging the write keeps a rejection from destroying the destination; the
+	// previous failure path removed the output path as a "partial file", which
+	// for an in-place save deleted the source it was saving.
+	return writeFileAtomically(outputPath, func(w io.Writer) error {
+		if err := tableSet.WriteToWriter(w); err != nil {
+			return fmt.Errorf("%w: failed to write Fedwire file: %s", ErrWire, err.Error())
+		}
+		return nil
+	})
 }
 
 // updateWireTableSetFromDB reads updated data from the database and updates the TableSet.

--- a/wire_test.go
+++ b/wire_test.go
@@ -352,3 +352,42 @@ func findWireTestFile(t *testing.T) string {
 
 	return ""
 }
+
+// TestDumpFedWire_FailedWriteLeavesDestinationIntact pins that a rejected
+// Fedwire write does not damage the file it was going to overwrite. The writer
+// validates while encoding, and the failure path used to remove the output path
+// as a "partial file" — which, for an in-place save, is the caller's source.
+func TestDumpFedWire_FailedWriteLeavesDestinationIntact(t *testing.T) {
+	testFile := findWireTestFile(t)
+	if testFile == "" {
+		t.Skip("No test Fedwire file found")
+	}
+
+	ctx := context.Background()
+	ClearWireTableSetRegistry()
+	defer ClearWireTableSetRegistry()
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "customer-transfer.fed")
+	original, err := os.ReadFile(testFile) //nolint:gosec // Test fixture path
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(target, original, 0o600)) //nolint:gosec // Test path is constructed from t.TempDir()
+
+	db, err := OpenContext(ctx, target)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.ExecContext(ctx, "UPDATE customer_transfer_message SET amount = 'BADAMOUNT'")
+	require.NoError(t, err)
+
+	err = DumpFedWire(ctx, db, "customer_transfer", target)
+	require.Error(t, err, "DumpFedWire should reject a malformed amount")
+
+	after, err := os.ReadFile(target) //nolint:gosec // Test fixture path
+	require.NoError(t, err)
+	assert.Equal(t, original, after, "a rejected write must leave the destination byte-for-byte unchanged")
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "a rejected write must not leave a temporary file behind: %v", entries)
+}


### PR DESCRIPTION
## Summary

The ACH and Fedwire encoders validate while they encode, so a value the format cannot hold is rejected partway through the write — after the destination has already been opened. `os.Create` truncates on open, and for an in-place save that destination is the caller's own source file, so a rejected save destroyed the data it was saving.

Reproduced through sqly against the repository's own fixtures:

```
$ sqly --save --force --sql "UPDATE ppd_debit_entries SET amount = 999999999999" ppd-debit.ach
failed to save ACH set ppd_debit: ... FieldError Amount 999999999999 does not match formatted value 9999999999
$ ls -l ppd-debit.ach
-rw-rw-r-- 1 nao nao 0 ppd-debit.ach     # was 891 bytes

$ sqly --save --force --sql "UPDATE customer_transfer_message SET amount = 'BADAMOUNT'" customer-transfer.fed
failed to save FED set customer_transfer: ... Amount BADAMOUNT is an incorrect amount format
$ ls -l customer-transfer.fed
ls: cannot access 'customer-transfer.fed': No such file or directory
```

Fedwire lost the file entirely because its failure path called `os.Remove(outputPath)` to clean up a "partial file", not distinguishing a file it had just created from one it had truncated.

## Changes

- `atomic_write.go`: `writeFileAtomically` hands the caller a writer for a temporary file in the destination's directory and renames it over the destination only after the write and the close both succeed. On failure the staged file is removed and the destination is untouched.
- `ach.go` / `wire.go`: `DumpACHWithTableSet` and `DumpFedWireWithTableSet` write through it. Fedwire's `os.Remove` of the output path is gone with it.
- `atomic_write_test.go`: the helper's own cases — creating, replacing (asserting the old content leaves no tail), a failed write against an existing and an absent destination, permission preservation, the mode of a new file, and a destination directory that does not exist.
- `ach_test.go` / `wire_test.go`: `TestDumpACH_FailedWriteLeavesDestinationIntact` and `TestDumpFedWire_FailedWriteLeavesDestinationIntact` reproduce the reports above through the public dump functions, asserting the file is byte-for-byte unchanged and that no temporary file is left behind.

## Design Decisions

The temporary file is created in the destination's directory rather than the system temp directory, so the rename stays within one filesystem, where it is atomic. A cross-device rename would fail and reintroduce a partial-write window.

An existing destination keeps its permissions, matching what `os.Create` did to a file that already existed. A new file is created 0644 rather than the 0600 `os.CreateTemp` uses, so a saved data file stays as readable as it was before this change.

The writer's own error is returned unwrapped so callers keep matching on `ErrACH` and `ErrWire` exactly as before; only the I/O failures around the staging are new, and they wrap `ErrIOOperation`.

## Limitations

The other write paths in `filesql.go` and `compression.go` still open the destination directly. Those encoders do not validate the way the financial formats do, so a mid-write failure there needs an I/O error rather than bad data, and the parquet and XLSX branches reopen the output path themselves, which needs untangling before they can be staged the same way. Left for a separate change.