### PR TITLE
chore: prepare v0.24.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-07-29
+
 ### Fixed
 - **A compressed dump that failed to finish was written out as if it had succeeded.** The compression writer's `Close`, which is where a gzip, xz, zstd, zlib, snappy, s2, or lz4 stream writes its trailer, ran in a deferred call whose error was discarded. A dump that could not finish its archive therefore reported success and left a truncated file that no longer decompresses. Both that error and the file's own `Close` error are now returned.
 - **A failed table dump destroyed the file it was overwriting.** v0.23.0 staged the ACH and Fedwire writes; the CSV, TSV, LTSV, Parquet, and XLSX path still opened the destination with `os.Create`, which truncates before a byte has been produced. A format the writer rejects, or an I/O failure partway through, left the destination empty — the caller's own source file when the dump is a write-back over it. Every dump now writes to a temporary file beside its destination and moves it into place only on success, so the two paths behave the same way. Windows refuses to rename over a destination another handle still has open, and refuses to rename it out of the way too, which is exactly a save that overwrites a file this package is streaming from; there the staged bytes are copied over it after a copy of it has been taken, and that copy is restored if the write fails, so a refused commit still leaves the data that was there.
@@ -817,7 +819,8 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/nao1215/filesql/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/nao1215/filesql/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/nao1215/filesql/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/nao1215/filesql/compare/v0.20.0...v0.21.0


### PR DESCRIPTION
## Summary

Roll the Unreleased entries into v0.24.0. The release finishes what v0.23.0 started: the CSV, TSV, LTSV, Parquet, and XLSX dump path is staged like the ACH and Fedwire ones, so a rejected write no longer destroys the file it was overwriting, and a compressed dump that cannot finish its archive now fails instead of committing a truncated file.

## Changes

- `CHANGELOG.md`: the Unreleased entries become `[0.24.0] - 2026-07-29`, with the compare links updated.