### PR TITLE
fix(dialect): propagate NULL through MySQL and GoogleSQL CONCAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **MySQL and GoogleSQL `CONCAT` swallowed a NULL argument.** Both return NULL when any argument is NULL; SQLite's own `concat()` treats a NULL as an empty string, and the call was passed straight through. `CONCAT(first_name, middle_name)` with a NULL middle name answered the first name where MySQL and BigQuery answer NULL, so a query written to detect incomplete rows reported them as complete. Both dialects now route the call to a NULL-propagating helper. PostgreSQL's `concat()` genuinely does ignore NULLs, so it is left on SQLite's, and `CONCAT_WS`, which skips NULLs in MySQL too, is unchanged.
+
+
 ## [0.24.0] - 2026-07-29
 
 ### Fixed

--- a/dialect/functions.go
+++ b/dialect/functions.go
@@ -157,6 +157,7 @@ func registerAll() error {
 		"mysql_ord":           {1, fnMySQLOrd},
 		"json_unquote":        {1, fnJSONUnquote},
 		"overlay":             {-1, fnOverlay},
+		"strict_concat":       {-1, fnStrictConcat},
 		"postgresql_cast":     {2, dialectCast(PostgreSQL, false)},
 		"googlesql_cast":      {2, dialectCast(GoogleSQL, false)},
 		"googlesql_divide":    {2, divideFloat(true)},

--- a/dialect/googlesql.go
+++ b/dialect/googlesql.go
@@ -124,6 +124,10 @@ func googlesqlRewriteCall(tokens []token, nameIdx, open, closeIdx int) ([]token,
 		return rewriteSafeCast(tokens, open, closeIdx)
 	case "FORMAT":
 		return rewriteRenameCall(tokens, open, closeIdx, "printf", googlesqlCallPass)
+	case "CONCAT":
+		// GoogleSQL CONCAT returns NULL when any argument is NULL, like MySQL and
+		// unlike SQLite's own concat(), which treats a NULL as an empty string.
+		return rewriteRenameCall(tokens, open, closeIdx, "strict_concat", googlesqlCallPass)
 	case "DATE_ADD", "TIMESTAMP_ADD":
 		return rewriteDateArith(tokens, open, closeIdx, "+", googlesqlCallPass)
 	case "DATE_SUB", "TIMESTAMP_SUB":

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -17,6 +17,7 @@ import (
 //	M-8  CAST(x AS mysql_type)           -> mysql_cast(x, 'mysql_type')
 //	M-9  x RLIKE p                       -> x REGEXP p
 //	M-11 a / b                           -> mysql_divide(a, b)
+//	M-12 CONCAT(a, b)                   -> strict_concat(a, b)
 //	M-12 a || b                          -> a OR b
 //	M-13 a <=> b                         -> a IS b
 //	M-14 DATE 'lit' / TIMESTAMP 'lit'    -> 'lit'
@@ -118,6 +119,11 @@ func mysqlRewriteCall(tokens []token, nameIdx, open, closeIdx int) ([]token, boo
 		return rewriteRenameCall(tokens, open, closeIdx, "length", mysqlCallPass)
 	case "ORD":
 		return rewriteRenameCall(tokens, open, closeIdx, "mysql_ord", mysqlCallPass)
+	case "CONCAT":
+		// MySQL CONCAT returns NULL when any argument is NULL. SQLite's own
+		// concat() treats a NULL as an empty string, so passing the call through
+		// answered a plausible non-NULL string where MySQL answers NULL.
+		return rewriteRenameCall(tokens, open, closeIdx, "strict_concat", mysqlCallPass)
 	case fnNameTrim:
 		return rewriteTrim(tokens, open, closeIdx, mysqlCallPass)
 	case "HEX":

--- a/dialect/mysql_test.go
+++ b/dialect/mysql_test.go
@@ -23,6 +23,15 @@ func TestMySQLTranslate(t *testing.T) {
 		{"M-5_date_add_hour", "SELECT DATE_ADD(ts, INTERVAL 5 HOUR)", "SELECT interval_add(ts, 5, 'hour')"},
 		{"M-5_date_add_string_arg", "SELECT DATE_ADD('2020-01-01', INTERVAL 1 YEAR)", "SELECT interval_add('2020-01-01', 1, 'year')"},
 
+		// MySQL CONCAT is NULL-propagating: any NULL argument makes the whole
+		// result NULL. SQLite's own concat() treats NULL as an empty string, so the
+		// call has to be routed to a helper rather than passed through.
+		{"M-x_concat", "SELECT CONCAT(a, b) FROM t", "SELECT strict_concat(a, b) FROM t"},
+		{"M-x_concat_one_arg", "SELECT CONCAT(a)", "SELECT strict_concat(a)"},
+		{"M-x_concat_nested", "SELECT CONCAT(a, CONCAT(b, c))", "SELECT strict_concat(a, strict_concat(b, c))"},
+		{"M-x_concat_ws_untouched", "SELECT CONCAT_WS(',', a, b)", "SELECT CONCAT_WS(',', a, b)"},
+		{"M-x_group_concat_untouched", "SELECT GROUP_CONCAT(a) FROM t", "SELECT GROUP_CONCAT(a) FROM t"},
+
 		{"M-6_group_concat_separator", "SELECT GROUP_CONCAT(name SEPARATOR ', ') FROM t", "SELECT GROUP_CONCAT(name, ', ') FROM t"},
 		{"M-6_group_concat_plain", "SELECT GROUP_CONCAT(name) FROM t", "SELECT GROUP_CONCAT(name) FROM t"},
 		{"M-6_group_concat_distinct", "SELECT GROUP_CONCAT(DISTINCT name) FROM t", "SELECT GROUP_CONCAT(DISTINCT name) FROM t"},

--- a/dialect/operators.go
+++ b/dialect/operators.go
@@ -520,3 +520,24 @@ func unionDistinctPass(tokens []token) []token {
 	}
 	return out
 }
+
+// fnStrictConcat concatenates its arguments the way MySQL and GoogleSQL CONCAT
+// do: a NULL anywhere makes the whole result NULL. SQLite's own concat() treats
+// a NULL as an empty string, so a call passed through to it answered a plausible
+// non-NULL string where the source dialect answers NULL — a wrong answer with no
+// error to notice. PostgreSQL's concat() does ignore NULLs, so it keeps using
+// SQLite's and never reaches this helper.
+func fnStrictConcat(args []driver.Value) (driver.Value, error) {
+	var b strings.Builder
+	for _, arg := range args {
+		if arg == nil {
+			return nil, nil
+		}
+		s, ok := toString(arg)
+		if !ok {
+			return nil, nil
+		}
+		b.WriteString(s)
+	}
+	return b.String(), nil
+}

--- a/dialect/operators_test.go
+++ b/dialect/operators_test.go
@@ -233,3 +233,54 @@ func TestWindowFunctionOperands(t *testing.T) {
 		})
 	}
 }
+
+// TestStrictConcatSemantics runs CONCAT through the real driver for every
+// dialect. MySQL and GoogleSQL propagate a NULL argument to a NULL result;
+// PostgreSQL's concat() ignores NULLs, and SQLite's does too, so only the first
+// two are routed to the helper. Passing all of them through to SQLite answered a
+// plausible non-NULL string where MySQL and BigQuery answer NULL, with nothing
+// to notice.
+func TestStrictConcatSemantics(t *testing.T) {
+	// Not parallel: castDB touches the process-global driver registration.
+	db := castDB(t)
+
+	tests := []struct {
+		name    string
+		dialect Dialect
+		query   string
+		want    string
+		null    bool
+	}{
+		{name: "mysql concat joins", dialect: MySQL, query: `SELECT CONCAT('a', 'b')`, want: "ab"},
+		{name: "mysql concat with null is null", dialect: MySQL, query: `SELECT CONCAT('a', NULL)`, null: true},
+		{name: "mysql concat null first", dialect: MySQL, query: `SELECT CONCAT(NULL, 'b')`, null: true},
+		{name: "mysql concat single argument", dialect: MySQL, query: `SELECT CONCAT('a')`, want: "a"},
+		{name: "mysql concat numbers", dialect: MySQL, query: `SELECT CONCAT(1, 2)`, want: "12"},
+		{name: "mysql concat nested null", dialect: MySQL, query: `SELECT CONCAT('a', CONCAT('b', NULL))`, null: true},
+		{name: "mysql concat_ws still skips null", dialect: MySQL, query: `SELECT CONCAT_WS(',', 'a', NULL, 'b')`, want: "a,b"},
+
+		{name: "googlesql concat joins", dialect: GoogleSQL, query: `SELECT CONCAT('a', 'b')`, want: "ab"},
+		{name: "googlesql concat with null is null", dialect: GoogleSQL, query: `SELECT CONCAT('a', NULL)`, null: true},
+
+		// PostgreSQL's concat() ignores NULLs, so it must NOT be rewritten.
+		{name: "postgresql concat ignores null", dialect: PostgreSQL, query: `SELECT CONCAT('a', NULL)`, want: "a"},
+		{name: "sqlite concat ignores null", dialect: SQLite, query: `SELECT CONCAT('a', NULL)`, want: "a"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := runDialect(t, db, tt.dialect, tt.query)
+			if err != nil {
+				t.Fatalf("%s: %v", tt.query, err)
+			}
+			if tt.null {
+				if got.Valid {
+					t.Fatalf("%s = %q, want NULL", tt.query, got.String)
+				}
+				return
+			}
+			if !got.Valid || got.String != tt.want {
+				t.Fatalf("%s = %v, want %q", tt.query, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

MySQL and GoogleSQL `CONCAT` return NULL when any argument is NULL. SQLite's own `concat()` treats a NULL as an empty string, and the call was passed straight through, so:

```
$ sqly --dialect mysql --csv --sql "SELECT CONCAT('a', NULL) AS x"
x
a          # MySQL and BigQuery both answer NULL
```

No error, no warning — a query written to find rows with a missing field reports them as complete. It is the same shape as the divergences fixed in v0.20.0: a plausible wrong answer rather than a failure.

PostgreSQL is not affected: its `concat()` genuinely does ignore NULLs, which is what SQLite already does.

## Changes

- `dialect/operators.go`: `fnStrictConcat`, a variadic helper that returns NULL as soon as any argument is NULL and otherwise concatenates.
- `dialect/functions.go`: registers it as `strict_concat` with variadic arity.
- `dialect/mysql.go`, `dialect/googlesql.go`: `CONCAT` is rewritten to `strict_concat`. `CONCAT_WS` is untouched — MySQL skips NULLs there, which SQLite's own function already does — and so is `GROUP_CONCAT`, which has its own rewrite.
- `dialect/mysql_test.go`: translation cases for the plain call, a single argument, a nested call, and the two neighbours that must not be rewritten.
- `dialect/operators_test.go`: `TestStrictConcatSemantics` runs the query through the real driver for all four dialects — NULL in either position, a nested NULL, numeric arguments, `CONCAT_WS` still skipping NULLs, and PostgreSQL and SQLite still ignoring them.

## Design Decisions

A helper rather than a `CASE WHEN ... IS NULL` rewrite: `CONCAT` is variadic, so the rewrite would have to expand to one `IS NULL` test per argument and evaluate each argument twice, which changes the cost and misbehaves for a non-deterministic argument.

The helper is named `strict_concat` rather than `mysql_concat` because GoogleSQL uses it on identical terms, matching how `like_sensitive` and `overlay` are already shared across dialects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed MySQL and GoogleSQL `CONCAT` behavior so `NULL` arguments correctly produce a `NULL` result.
  - Preserved existing behavior for PostgreSQL, SQLite, `CONCAT_WS`, and `GROUP_CONCAT`.
  - Ensured nested and single-argument `CONCAT` expressions follow the correct dialect-specific semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->