### PR TITLE
chore: prepare v0.25.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-07-29
+
 ### Fixed
 - **MySQL and GoogleSQL `CONCAT` swallowed a NULL argument.** Both return NULL when any argument is NULL; SQLite's own `concat()` treats a NULL as an empty string, and the call was passed straight through. `CONCAT(first_name, middle_name)` with a NULL middle name answered the first name where MySQL and BigQuery answer NULL, so a query written to detect incomplete rows reported them as complete. Both dialects now route the call to a NULL-propagating helper. PostgreSQL's `concat()` genuinely does ignore NULLs, so it is left on SQLite's, and `CONCAT_WS`, which skips NULLs in MySQL too, is unchanged.
 
@@ -823,7 +825,8 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/nao1215/filesql/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/nao1215/filesql/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/nao1215/filesql/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/nao1215/filesql/compare/v0.21.0...v0.22.0


### PR DESCRIPTION
Roll the Unreleased entry into v0.25.0. The release carries one fix: MySQL and GoogleSQL `CONCAT` propagate a NULL argument to a NULL result instead of dropping it, which used to answer a plausible non-NULL string with no error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new changelog section for release 0.25.0 dated July 29, 2026.
  * Updated release comparison links to include the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->