### PR TITLE
fix(dump): make every format survive the staged write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- An XLSX dump could not be written at all. v0.24.0 staged every table dump in a temporary file next to its destination, and Excel was still saved with `SaveAs`, which picks the container format from the file extension — the staged name ends in `.tmp1234567`, which is not a workbook format, so every uncompressed `OutputFormatXLSX` dump failed with "unsupported workbook file format". A compressed one was written, but its sheet was named after the staged file, so reading it back produced a table called `seed__seed_xlsx_gz` instead of `seed`. Every format now writes to the writer it is handed and takes the table name as a parameter, so no format decides anything from a name that belongs to a temporary file.
+- A Parquet dump reported failure after writing the file correctly. The Parquet writer closes the destination it is given when it can, so the staged file was already closed when the dump came to close it and check that error, and a complete dump failed with "file already closed". The destination is now passed as a writer that exposes only `Write`.
+- A sheet named after its own workbook no longer doubles up in the table name. A sheet's name is appended to the file's name because one workbook holds several sheets, which turned a dumped table read back into `people_people`, and meant a save could not overwrite the file it came from. The suffix is now omitted when it would only repeat the file name; a workbook whose sheet name differs is unaffected.
+
 ## [0.25.0] - 2026-07-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ filesql is for cases where the data is already in a file and the fastest useful 
 | `.json` | JSON | Query nested data with `json_extract()` |
 | `.jsonl` | JSONL | One JSON value per line |
 | `.parquet` | Parquet | Columnar format |
-| `.xlsx` | Excel XLSX | One sheet becomes one table |
+| `.xlsx` | Excel XLSX | One sheet becomes one table, named `file_sheet` (just `file` when the sheet repeats it) |
 | `.ach` | ACH (NACHA) | Experimental |
 | `.fed` | Fedwire | Experimental |
 

--- a/atomic_write.go
+++ b/atomic_write.go
@@ -13,63 +13,45 @@ import (
 const defaultOutputFileMode os.FileMode = 0o644
 
 // writeFileAtomically hands write a writer for a temporary file in dest's
-// directory and renames it over dest only after write and the close both
-// succeed. See writeFileAtomicallyAtPath for why every write goes through this.
-func writeFileAtomically(dest string, write func(io.Writer) error) error {
-	return writeFileAtomicallyAtPath(dest, func(path string) error {
-		f, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, defaultOutputFileMode) //nolint:gosec // path is the staged file this package just created
-		if err != nil {
-			return fmt.Errorf("%w: failed to open the staged file for %s: %s", ErrIOOperation, dest, err.Error())
-		}
-		if err := write(f); err != nil {
-			_ = f.Close()
-			return err
-		}
-		if err := f.Close(); err != nil {
-			return fmt.Errorf("%w: failed to close the staged file for %s: %s", ErrIOOperation, dest, err.Error())
-		}
-		return nil
-	})
-}
-
-// writeFileAtomicallyAtPath reserves a temporary path in dest's directory, hands
-// it to write, and renames it over dest only when write returns nil. When write
-// fails, dest is left exactly as it was and the temporary file is removed. It is
-// the form for writers that need a path of their own (Parquet and XLSX open the
-// output themselves); writeFileAtomically is the form for writers that take an
-// io.Writer.
+// directory and renames it over dest only when write and the close both succeed.
+// When either fails, dest is left exactly as it was and the temporary file is
+// removed.
 //
-// Why every write goes through one of these: opening dest with os.Create
-// truncates it before a single byte has been produced, and a write can still
-// fail after that. The ACH and Fedwire encoders validate while they encode, so a
-// value the format cannot represent is rejected partway through; an encoder can
-// also fail on a full disk or an unwritable row. For an in-place save dest is
-// the caller's own source file, so a rejected write destroyed the data it was
-// saving. Staging means a failure costs nothing.
+// Why every write goes through this: opening dest with os.Create truncates it
+// before a single byte has been produced, and a write can still fail after that.
+// The ACH and Fedwire encoders validate while they encode, so a value the format
+// cannot represent is rejected partway through; an encoder can also fail on a
+// full disk or an unwritable row. For an in-place save dest is the caller's own
+// source file, so a rejected write destroyed the data it was saving. Staging
+// means a failure costs nothing.
+//
+// Why the writer and not the staged path is what write receives: the staged name
+// carries a temporary suffix, so a format that reads anything out of its file
+// name gets the wrong answer from it. Excel picks both its container format and
+// its sheet name that way, which is how a staged XLSX dump came out unreadable.
 //
 // The temporary file is created in dest's directory so the rename stays within
 // one filesystem, where it is atomic. An existing dest keeps its permissions; a
 // new file is created 0644.
-func writeFileAtomicallyAtPath(dest string, write func(path string) error) error {
+func writeFileAtomically(dest string, write func(io.Writer) error) error {
 	dir := filepath.Dir(dest)
 	tmp, err := os.CreateTemp(dir, "."+filepath.Base(dest)+".tmp*")
 	if err != nil {
 		return fmt.Errorf("%w: failed to create a temporary file next to %s: %s", ErrIOOperation, dest, err.Error())
 	}
 	tmpName := tmp.Name()
-	// The handle only reserves the name; write opens the path itself.
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpName) //nolint:errcheck // Best-effort cleanup of a file this package just created
-		return fmt.Errorf("%w: failed to close the temporary file for %s: %s", ErrIOOperation, dest, err.Error())
-	}
 	// Remove the staged file unless the rename below claimed it; a no-op after a
 	// successful rename.
 	defer func() {
 		_ = os.Remove(tmpName) //nolint:errcheck // Best-effort cleanup; the file is gone after a successful rename
 	}()
 
-	if err := write(tmpName); err != nil {
+	if err := write(tmp); err != nil {
+		_ = tmp.Close() // The write error is the one to report
 		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("%w: failed to close the staged file for %s: %s", ErrIOOperation, dest, err.Error())
 	}
 
 	mode := defaultOutputFileMode

--- a/builder.go
+++ b/builder.go
@@ -781,8 +781,7 @@ func (b *DBBuilder) streamXLSXFileToSQLite(ctx context.Context, db *sql.DB, read
 			continue
 		}
 
-		// Create table name: filename_sheetname
-		tableName := fmt.Sprintf("%s_%s", baseTableName, sanitizeTableName(sheetName))
+		tableName := xlsxSheetTableName(baseTableName, sheetName)
 
 		// Check if table already exists
 		var tableExists int

--- a/dump_roundtrip_test.go
+++ b/dump_roundtrip_test.go
@@ -1,0 +1,83 @@
+package filesql
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDumpDatabase_RoundTripPerFormat dumps the same table in every format the
+// dump supports and reads the result back. It is the check that was missing when
+// the tabular dump moved to a staged file: the staged name carries a temporary
+// suffix, and a writer that decides anything from the file name it is handed —
+// Excel picks both its container format and its sheet name that way — produced a
+// broken file or none at all while the dump reported success.
+func TestDumpDatabase_RoundTripPerFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		format      OutputFormat
+		compression CompressionType
+	}{
+		{name: "csv", format: OutputFormatCSV, compression: CompressionNone},
+		{name: "csv gz", format: OutputFormatCSV, compression: CompressionGZ},
+		{name: "tsv", format: OutputFormatTSV, compression: CompressionNone},
+		{name: "ltsv", format: OutputFormatLTSV, compression: CompressionNone},
+		{name: "parquet", format: OutputFormatParquet, compression: CompressionNone},
+		{name: "xlsx", format: OutputFormatXLSX, compression: CompressionNone},
+		{name: "xlsx gz", format: OutputFormatXLSX, compression: CompressionGZ},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			srcDir := t.TempDir()
+			src := filepath.Join(srcDir, "people.csv")
+			require.NoError(t, os.WriteFile(src, []byte("id,name\n1,alice\n2,bob\n"), 0o600))
+
+			db, err := OpenContext(ctx, src)
+			require.NoError(t, err)
+			defer db.Close()
+
+			opts := NewDumpOptions().WithFormat(tt.format).WithCompression(tt.compression)
+			outDir := t.TempDir()
+			require.NoError(t, DumpDatabase(db, outDir, opts))
+
+			entries, err := os.ReadDir(outDir)
+			require.NoError(t, err)
+			require.Len(t, entries, 1, "no staged file may be left behind: %v", entries)
+			assert.Equal(t, "people"+opts.FileExtension(), entries[0].Name())
+
+			// Reading the dump back is what catches a file that was written in the
+			// wrong shape: the table name comes from the sheet or file name, and the
+			// rows from the payload.
+			reloaded, err := OpenContext(ctx, filepath.Join(outDir, entries[0].Name()))
+			require.NoError(t, err)
+			defer reloaded.Close()
+
+			var count int
+			require.NoError(t, reloaded.QueryRowContext(ctx, "SELECT COUNT(*) FROM people").Scan(&count))
+			assert.Equal(t, 2, count)
+
+			rows, err := reloaded.QueryContext(ctx, "SELECT name FROM people ORDER BY name")
+			require.NoError(t, err)
+			defer rows.Close()
+			names := make([]string, 0, 2)
+			for rows.Next() {
+				var name string
+				require.NoError(t, rows.Scan(&name))
+				names = append(names, name)
+			}
+			require.NoError(t, rows.Err())
+			sort.Strings(names)
+			assert.Equal(t, []string{"alice", "bob"}, names)
+		})
+	}
+}

--- a/filesql.go
+++ b/filesql.go
@@ -1,7 +1,6 @@
 package filesql
 
 import (
-	"bytes"
 	"context"
 	"database/sql"
 	"encoding/csv"
@@ -367,7 +366,7 @@ func dumpSQLiteTable(db *sql.DB, tableName, outputDir string, options DumpOption
 	fileName := tableName + options.FileExtension()
 	outputPath := filepath.Join(outputDir, fileName)
 
-	return writeSQLiteTableData(outputPath, columns, rows, options)
+	return writeSQLiteTableData(outputPath, tableName, columns, rows, options)
 }
 
 // getSQLiteTableColumns retrieves column names for a specific table
@@ -403,50 +402,39 @@ func getSQLiteTableColumns(db *sql.DB, tableName string) ([]string, error) {
 // write is staged and moved into place, so a format or I/O error partway through
 // leaves an existing destination — which for a write-back is the caller's source
 // file — exactly as it was.
-func writeSQLiteTableData(outputPath string, columns []string, rows *sql.Rows, options DumpOptions) error {
-	return writeFileAtomicallyAtPath(outputPath, func(path string) error {
-		return writeSQLiteTableDataTo(path, columns, rows, options)
+func writeSQLiteTableData(outputPath, tableName string, columns []string, rows *sql.Rows, options DumpOptions) error {
+	return writeFileAtomically(outputPath, func(w io.Writer) error {
+		return writeSQLiteTableDataTo(w, tableName, columns, rows, options)
 	})
 }
 
-// writeSQLiteTableDataTo writes table data to the given path with the specified
-// format. Callers reach it through writeSQLiteTableData, which stages the path.
+// writeSQLiteTableDataTo writes table data to w in the requested format.
 //
-// The named return lets the deferred closes report their own failure. A
-// compressor writes its trailer on Close, so a compressed output that failed to
-// finish is only detectable there; dropping that error would commit a truncated
-// archive over the destination as if it had been written.
-func writeSQLiteTableDataTo(outputPath string, columns []string, rows *sql.Rows, options DumpOptions) (err error) {
-	// Parquet and XLSX open the output themselves, so they neither need the file
-	// created here nor the compression wrapper.
-	switch options.Format {
-	case OutputFormatParquet:
-		return writeParquetTableData(outputPath, columns, rows, options.Compression)
-	case OutputFormatXLSX:
-		return writeXLSXTableData(outputPath, columns, rows, options.Compression)
+// Why every format writes to an io.Writer rather than to a path of its own: the
+// caller stages the write, so the only path available here is a temporary one
+// whose name means nothing. Excel reads both its container format and its sheet
+// name out of the name it is given, so handing it the staged path produced a
+// rejected save or a sheet named after the temporary file. tableName carries the
+// one piece of naming a format legitimately needs.
+//
+// The named return lets the deferred close report its own failure. A compressor
+// writes its trailer on Close, so a compressed output that failed to finish is
+// only detectable there; dropping that error would commit a truncated archive
+// over the destination as if it had been written.
+func writeSQLiteTableDataTo(w io.Writer, tableName string, columns []string, rows *sql.Rows, options DumpOptions) (err error) {
+	// Parquet compresses per column internally, so an outer compressor would only
+	// bloat the file and hide it behind a second extension.
+	if options.Format == OutputFormatParquet && options.Compression != CompressionNone {
+		return fmt.Errorf("%w: external compression not supported for Parquet format - use Parquet's built-in compression instead", ErrUnsupportedFormat)
 	}
 
-	// Create the file
-	file, err := os.Create(outputPath) //nolint:gosec // Output path is constructed from validated directory and table name
-	if err != nil {
-		return fmt.Errorf("%w: failed to create file %s: %s", ErrIOOperation, outputPath, err.Error())
-	}
-	// Registered first so it runs last: the compressor must flush its trailer
-	// into the file before the file is closed.
-	defer func() {
-		if closeErr := file.Close(); closeErr != nil && err == nil {
-			err = fmt.Errorf("%w: failed to close file %s: %s", ErrIOOperation, outputPath, closeErr.Error())
-		}
-	}()
-
-	// Create writer with compression if needed
-	writer, closeWriter, err := createCompressedWriter(file, options.Compression)
+	writer, closeWriter, err := createCompressedWriter(w, options.Compression)
 	if err != nil {
 		return fmt.Errorf("%w: failed to create writer: %s", ErrCompression, err.Error())
 	}
 	defer func() {
 		if closeErr := closeWriter(); closeErr != nil && err == nil {
-			err = fmt.Errorf("%w: failed to finish writing %s: %s", ErrCompression, outputPath, closeErr.Error())
+			err = fmt.Errorf("%w: failed to finish writing %s: %s", ErrCompression, tableName, closeErr.Error())
 		}
 	}()
 
@@ -458,15 +446,19 @@ func writeSQLiteTableDataTo(outputPath string, columns []string, rows *sql.Rows,
 		return writeTSVData(writer, columns, rows)
 	case OutputFormatLTSV:
 		return writeLTSVData(writer, columns, rows)
+	case OutputFormatParquet:
+		return writeParquetTableData(writer, columns, rows)
+	case OutputFormatXLSX:
+		return writeXLSXTableData(writer, tableName, columns, rows)
 	default:
 		return fmt.Errorf("%w: unsupported output format: %v", ErrUnsupportedFormat, options.Format)
 	}
 }
 
 // createCompressedWriter creates an appropriate writer based on compression type
-func createCompressedWriter(file *os.File, compression CompressionType) (io.Writer, func() error, error) {
+func createCompressedWriter(w io.Writer, compression CompressionType) (io.Writer, func() error, error) {
 	handler := NewCompressionHandler(compression)
-	return handler.CreateWriter(file)
+	return handler.CreateWriter(w)
 }
 
 // writeDelimitedData writes data in CSV or TSV format based on delimiter
@@ -662,15 +654,9 @@ func extractValueFromArrowArray(arr arrow.Array, index int64) string {
 }
 
 // writeParquetTableData writes SQLite table data to Parquet format
-func writeParquetTableData(outputPath string, columns []string, rows *sql.Rows, compression CompressionType) error {
+func writeParquetTableData(w io.Writer, columns []string, rows *sql.Rows) error {
 	if len(columns) == 0 {
 		return fmt.Errorf("%w: no columns defined", ErrEmptyData)
-	}
-
-	// For Parquet format, compression is handled at the file level, not stream level
-	// We ignore the compression parameter for now as Parquet has its own compression
-	if compression != CompressionNone {
-		return fmt.Errorf("%w: external compression not supported for Parquet format - use Parquet's built-in compression instead", ErrUnsupportedFormat)
 	}
 
 	// Read all rows into memory first. nulls runs parallel to rows and marks the
@@ -708,25 +694,28 @@ func writeParquetTableData(outputPath string, columns []string, rows *sql.Rows, 
 		return fmt.Errorf("%w: error iterating rows: %s", ErrDatabaseOperation, err.Error())
 	}
 
-	return writeParquetData(outputPath, columns, allRows, allNulls)
+	return writeParquetData(w, columns, allRows, allNulls)
+}
+
+// writeOnly exposes only Write, so a library that would close or seek the
+// destination it is given cannot reach past what it was handed.
+type writeOnly struct {
+	w io.Writer
+}
+
+func (o writeOnly) Write(p []byte) (int, error) {
+	return o.w.Write(p)
 }
 
 // writeParquetData writes data to Parquet format. nulls, when non-nil, marks the
 // cells to store as a Parquet null; rows[r][c] is ignored for a cell marked null.
-func writeParquetData(outputPath string, columns []string, rows [][]string, nulls [][]bool) error {
+func writeParquetData(w io.Writer, columns []string, rows [][]string, nulls [][]bool) error {
 	if len(rows) == 0 {
 		return fmt.Errorf("%w: no data to write", ErrEmptyData)
 	}
 	if len(columns) == 0 {
 		return fmt.Errorf("%w: no columns defined", ErrEmptyData)
 	}
-
-	// Create output file
-	file, err := os.Create(outputPath) //nolint:gosec
-	if err != nil {
-		return fmt.Errorf("%w: failed to create parquet file: %s", ErrIOOperation, err.Error())
-	}
-	defer file.Close()
 
 	// Create Arrow schema - for simplicity, treat all columns as strings
 	fields := make([]arrow.Field, len(columns))
@@ -767,18 +756,20 @@ func writeParquetData(outputPath string, columns []string, rows [][]string, null
 
 	// Create Parquet writer
 	arrowProps := pqarrow.NewArrowWriterProperties(pqarrow.WithStoreSchema())
-	writer, err := pqarrow.NewFileWriter(schema, file, nil, arrowProps)
+	// writeOnly hides the destination's Close from the Parquet writer, which
+	// closes its sink when it can. The caller owns the file and closes it after
+	// checking that error; a Parquet-side close leaves it with "file already
+	// closed" and turns a good dump into a failure.
+	writer, err := pqarrow.NewFileWriter(schema, writeOnly{w}, nil, arrowProps)
 	if err != nil {
 		return fmt.Errorf("%w: failed to create parquet writer: %s", ErrIOOperation, err.Error())
 	}
-	defer writer.Close()
-
-	// Write record to Parquet file
 	if err := writer.Write(record); err != nil {
+		_ = writer.Close() // Release the writer; the write error is the one to report
 		return fmt.Errorf("%w: failed to write record to parquet: %s", ErrIOOperation, err.Error())
 	}
 
-	// Flush and close writer explicitly
+	// Close writes the footer, so this is where an incomplete file shows up.
 	if err := writer.Close(); err != nil {
 		return fmt.Errorf("%w: failed to close parquet writer: %s", ErrIOOperation, err.Error())
 	}
@@ -787,7 +778,7 @@ func writeParquetData(outputPath string, columns []string, rows [][]string, null
 }
 
 // writeXLSXTableData writes SQLite table data to Excel XLSX format
-func writeXLSXTableData(outputPath string, columns []string, rows *sql.Rows, compression CompressionType) error {
+func writeXLSXTableData(w io.Writer, tableName string, columns []string, rows *sql.Rows) error {
 	if len(columns) == 0 {
 		return fmt.Errorf("%w: no columns defined", ErrEmptyData)
 	}
@@ -798,36 +789,21 @@ func writeXLSXTableData(outputPath string, columns []string, rows *sql.Rows, com
 		_ = f.Close() // Ignore close error
 	}()
 
-	// For Excel, we use the table name as sheet name
-	// Extract table name from output path (remove directory and extension)
-	fileName := filepath.Base(outputPath)
-
-	// First remove compression extension if present (case-insensitive)
-	compressionExts := []string{extGZ, extBZ2, extXZ, extZSTD, extZLIB, extSNAPPY, extS2, extLZ4}
-	for _, ext := range compressionExts {
-		if strings.HasSuffix(strings.ToLower(fileName), ext) {
-			fileName = strings.TrimSuffix(fileName, ext)
-			break
-		}
-	}
-
-	// Then remove the file extension (e.g., .xlsx)
-	tableName := strings.TrimSuffix(fileName, filepath.Ext(fileName))
-
-	// Create a sheet with the table name, or use default if invalid
+	// The sheet name is what a reader turns back into a table name, so it comes
+	// from the table this dump is of.
 	sheetName := tableName
 	if sheetName == "" {
-		sheetName = "Sheet1"
+		sheetName = defaultSheetName
 	}
 
 	// Create new sheet (replace default Sheet1)
-	if sheetName != "Sheet1" {
+	if sheetName != defaultSheetName {
 		_, err := f.NewSheet(sheetName)
 		if err != nil {
 			return fmt.Errorf("failed to create sheet %s: %w", sheetName, err)
 		}
 		// Delete default sheet
-		if err := f.DeleteSheet("Sheet1"); err != nil {
+		if err := f.DeleteSheet(defaultSheetName); err != nil {
 			return fmt.Errorf("failed to delete default sheet: %w", err)
 		}
 	}
@@ -889,39 +865,12 @@ func writeXLSXTableData(outputPath string, columns []string, rows *sql.Rows, com
 		return fmt.Errorf("error reading rows: %w", err)
 	}
 
-	// Handle compression by saving to buffer first if needed
-	if compression != CompressionNone {
-		// For compressed output, we need to save to a buffer first
-		var buf bytes.Buffer
-		if err := f.Write(&buf); err != nil {
-			return fmt.Errorf("failed to write Excel file to buffer: %w", err)
-		}
-
-		// Create compressed output file
-		file, err := os.Create(outputPath) //nolint:gosec // Output path is constructed from validated directory and table name
-		if err != nil {
-			return fmt.Errorf("failed to create output file: %w", err)
-		}
-		defer file.Close()
-
-		// Create compressed writer
-		compressedWriter, closeWriter, err := createCompressedWriter(file, compression)
-		if err != nil {
-			return fmt.Errorf("failed to create compressed writer: %w", err)
-		}
-		defer closeWriter()
-
-		// Write compressed data
-		if _, err := compressedWriter.Write(buf.Bytes()); err != nil {
-			return fmt.Errorf("failed to write compressed data: %w", err)
-		}
-
-		return nil
-	}
-
-	// Save directly to file for uncompressed output
-	if err := f.SaveAs(outputPath); err != nil {
-		return fmt.Errorf("failed to save Excel file: %w", err)
+	// Why Write and not SaveAs: SaveAs picks the container format from the file
+	// extension, and the caller stages the write, so the only name available here
+	// carries a temporary suffix that Excel rejects. Any compression the caller
+	// asked for is already wrapped around w.
+	if err := f.Write(w); err != nil {
+		return fmt.Errorf("%w: failed to write Excel file: %s", ErrIOOperation, err.Error())
 	}
 
 	return nil

--- a/filesql_test.go
+++ b/filesql_test.go
@@ -3569,256 +3569,121 @@ func TestParquetDirectParsing(t *testing.T) {
 func TestWriteXLSXTableData(t *testing.T) {
 	t.Parallel()
 
-	t.Run("writeXLSXTableData with no compression", func(t *testing.T) {
-		// Create test data
+	// The write goes through writeSQLiteTableData rather than the XLSX writer
+	// directly: that is the path a dump takes, and it stages the file under a
+	// temporary name. Calling the writer with a final path hid the fact that a
+	// staged XLSX write could not succeed at all.
+	dumpSheet := func(t *testing.T, table, query string, opts DumpOptions) string {
+		t.Helper()
+
 		db, err := Open(filepath.Join("testdata", "excel", "sample.xlsx"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer db.Close()
 
-		// Query data from first sheet
-		rows, err := db.QueryContext(context.Background(), "SELECT * FROM sample_Sheet1")
-		if err != nil {
-			t.Fatal(err)
-		}
+		rows, err := db.QueryContext(context.Background(), query)
+		require.NoError(t, err)
 		defer rows.Close()
 
 		columns, err := rows.Columns()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		// Create temp output file
-		tempDir := t.TempDir()
-		outputPath := filepath.Join(tempDir, "output.xlsx")
+		outputPath := filepath.Join(t.TempDir(), table+opts.FileExtension())
+		require.NoError(t, writeSQLiteTableData(outputPath, table, columns, rows, opts))
+		return outputPath
+	}
 
-		// Test writeXLSXTableData
-		err = writeXLSXTableData(outputPath, columns, rows, CompressionNone)
-		if err != nil {
-			t.Fatal(err)
-		}
+	t.Run("uncompressed output is a readable workbook named after the table", func(t *testing.T) {
+		t.Parallel()
 
-		// Verify file was created
-		if _, err := os.Stat(outputPath); os.IsNotExist(err) {
-			t.Error("Output file was not created")
-		}
+		opts := NewDumpOptions().WithFormat(OutputFormatXLSX)
+		outputPath := dumpSheet(t, "people", "SELECT * FROM sample_Sheet1", opts)
 
-		// Verify file can be read back
 		xlsxFile, err := excelize.OpenFile(outputPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer xlsxFile.Close()
 
-		// Check sheet exists
 		sheets := xlsxFile.GetSheetList()
-		if len(sheets) != 1 {
-			assert.Fail(t, "Expected 1 sheet, got %d", len(sheets))
-		}
-		if sheets[0] != "output" {
-			assert.Fail(t, "Expected sheet 'output', got '%s'", sheets[0])
-		}
+		require.Len(t, sheets, 1)
+		assert.Equal(t, "people", sheets[0], "the sheet is named after the table, not after the staged file")
 
-		// Check data
 		sheetRows, err := xlsxFile.GetRows(sheets[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Should have header + 3 data rows = 4 total rows
-		if len(sheetRows) != 4 {
-			assert.Fail(t, "Expected 4 rows (1 header + 3 data), got %d", len(sheetRows))
-		}
-
-		// Check header
-		expectedHeaders := []string{"id", "name"}
-		assert.Equal(t, expectedHeaders, sheetRows[0], "Expected headers %v, got %v", expectedHeaders, sheetRows[0])
-
-		// Check first data row
-		if len(sheetRows) > 1 {
-			if sheetRows[1][0] != "1" || sheetRows[1][1] != "Gina" {
-				assert.Fail(t, "Expected first row [1, Gina], got %v", sheetRows[1])
-			}
-		}
+		require.NoError(t, err)
+		require.Len(t, sheetRows, 4, "1 header + 3 data rows")
+		assert.Equal(t, []string{"id", "name"}, sheetRows[0])
+		assert.Equal(t, []string{"1", "Gina"}, sheetRows[1])
 	})
 
-	t.Run("writeXLSXTableData with gzip compression", func(t *testing.T) {
-		// Create test data
-		db, err := Open(filepath.Join("testdata", "excel", "sample.xlsx"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
+	t.Run("gzip output decompresses to the same workbook", func(t *testing.T) {
+		t.Parallel()
 
-		// Query data from second sheet
-		rows, err := db.QueryContext(context.Background(), "SELECT * FROM sample_Sheet2")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer rows.Close()
+		opts := NewDumpOptions().WithFormat(OutputFormatXLSX).WithCompression(CompressionGZ)
+		outputPath := dumpSheet(t, "mails", "SELECT * FROM sample_Sheet2", opts)
 
-		columns, err := rows.Columns()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Create temp output file
-		tempDir := t.TempDir()
-		outputPath := filepath.Join(tempDir, "output.xlsx.gz")
-
-		// Test writeXLSXTableData with compression
-		err = writeXLSXTableData(outputPath, columns, rows, CompressionGZ)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Verify compressed file was created
-		if _, err := os.Stat(outputPath); os.IsNotExist(err) {
-			t.Error("Compressed output file was not created")
-		}
-
-		// Verify file can be decompressed and read
 		file, err := os.Open(outputPath) //nolint:gosec // Test file path is safe
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer file.Close()
 
 		gzipReader, err := gzip.NewReader(file)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer gzipReader.Close()
 
-		// Read decompressed data into buffer
 		var buf bytes.Buffer
-		if _, err := io.Copy(&buf, gzipReader); err != nil { //nolint:gosec // Test data is safe
-			t.Fatal(err)
-		}
+		_, err = io.Copy(&buf, gzipReader) //nolint:gosec // Test data is safe
+		require.NoError(t, err)
 
-		// Create Excel reader from buffer
 		xlsxFile, err := excelize.OpenReader(&buf)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer xlsxFile.Close()
 
-		// Check data
 		sheets := xlsxFile.GetSheetList()
-		if len(sheets) != 1 {
-			assert.Fail(t, "Expected 1 sheet, got %d", len(sheets))
-		}
+		require.Len(t, sheets, 1)
+		assert.Equal(t, "mails", sheets[0])
 
 		sheetRows, err := xlsxFile.GetRows(sheets[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Should have header + 3 data rows = 4 total rows
-		if len(sheetRows) != 4 {
-			assert.Fail(t, "Expected 4 rows (1 header + 3 data), got %d", len(sheetRows))
-		}
-
-		// Check header
-		expectedHeaders := []string{"id", "mail"}
-		assert.Equal(t, expectedHeaders, sheetRows[0], "Expected headers %v, got %v", expectedHeaders, sheetRows[0])
+		require.NoError(t, err)
+		require.Len(t, sheetRows, 4, "1 header + 3 data rows")
+		assert.Equal(t, []string{"id", "mail"}, sheetRows[0])
 	})
 
-	t.Run("writeXLSXTableData with no columns error", func(t *testing.T) {
-		tempDir := t.TempDir()
-		outputPath := filepath.Join(tempDir, "empty.xlsx")
+	t.Run("xz output is written and is not empty", func(t *testing.T) {
+		t.Parallel()
 
-		// Test with no columns
-		err := writeXLSXTableData(outputPath, []string{}, nil, CompressionNone)
-		if err == nil {
-			t.Error("Expected error for no columns")
-		}
-		if !strings.Contains(err.Error(), "no columns defined") {
-			assert.NoError(t, err, "Expected 'no columns defined' error, got")
-		}
+		opts := NewDumpOptions().WithFormat(OutputFormatXLSX).WithCompression(CompressionXZ)
+		outputPath := dumpSheet(t, "people", "SELECT * FROM sample_Sheet1", opts)
+
+		info, err := os.Stat(outputPath)
+		require.NoError(t, err)
+		assert.Greater(t, info.Size(), int64(100), "a compressed workbook is larger than this")
 	})
 
-	t.Run("writeXLSXTableData with unsupported bz2 compression", func(t *testing.T) {
-		// Create test data
+	t.Run("no columns is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		err := writeXLSXTableData(io.Discard, "empty", []string{}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no columns defined")
+	})
+
+	t.Run("bz2 is rejected because it has no writer", func(t *testing.T) {
+		t.Parallel()
+
 		db, err := Open(filepath.Join("testdata", "excel", "sample.xlsx"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer db.Close()
 
-		// Query data from first sheet
 		rows, err := db.QueryContext(context.Background(), "SELECT * FROM sample_Sheet1")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer rows.Close()
 
 		columns, err := rows.Columns()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		// Create temp output file
-		tempDir := t.TempDir()
-		outputPath := filepath.Join(tempDir, "output.xlsx.bz2")
-
-		// Test writeXLSXTableData with bz2 compression (should fail)
-		err = writeXLSXTableData(outputPath, columns, rows, CompressionBZ2)
-		if err == nil {
-			t.Error("Expected error for unsupported bz2 compression")
-		}
-		if !strings.Contains(err.Error(), "bzip2 compression is not supported") {
-			assert.NoError(t, err, "Expected 'bzip2 compression is not supported' error, got")
-		}
-	})
-
-	t.Run("writeXLSXTableData with xz compression", func(t *testing.T) {
-		// Create test data
-		db, err := Open(filepath.Join("testdata", "excel", "sample.xlsx"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-
-		// Query data from first sheet
-		rows, err := db.QueryContext(context.Background(), "SELECT * FROM sample_Sheet1")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer rows.Close()
-
-		columns, err := rows.Columns()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Create temp output file
-		tempDir := t.TempDir()
-		outputPath := filepath.Join(tempDir, "output.xlsx.xz")
-
-		// Test writeXLSXTableData with xz compression
-		err = writeXLSXTableData(outputPath, columns, rows, CompressionXZ)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Verify compressed file was created
-		if _, err := os.Stat(outputPath); os.IsNotExist(err) {
-			t.Error("Compressed output file was not created")
-		}
-
-		// Verify file size is reasonable (compressed, but not empty)
-		fileInfo, err := os.Stat(outputPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if fileInfo.Size() == 0 {
-			t.Error("Compressed output file is empty")
-		}
-		if fileInfo.Size() < 100 {
-			assert.Fail(t, "Compressed file seems too small: %d bytes", fileInfo.Size())
-		}
+		opts := NewDumpOptions().WithFormat(OutputFormatXLSX).WithCompression(CompressionBZ2)
+		outputPath := filepath.Join(t.TempDir(), "people"+opts.FileExtension())
+		err = writeSQLiteTableData(outputPath, "people", columns, rows, opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bzip2 compression is not supported")
+		assert.NoFileExists(t, outputPath, "a rejected dump leaves nothing behind")
 	})
 }
 

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -592,8 +592,7 @@ func (sp *streamProcessor) streamXLSXFileToDatabase(ctx context.Context, db *sql
 			continue
 		}
 
-		// Create table name: filename_sheetname
-		tableName := fmt.Sprintf("%s_%s", baseTableName, sanitizeTableName(sheetName))
+		tableName := xlsxSheetTableName(baseTableName, sheetName)
 		sp.logger.Debug("creating table from sheet", "path", filePath, logKeySheet, sheetName, logKeyTable, tableName, "rows", len(rows))
 
 		// Check if table already exists

--- a/table.go
+++ b/table.go
@@ -10,6 +10,9 @@ import (
 // sheetFallbackName is the table name used when a sheet name sanitizes to empty.
 const sheetFallbackName = "sheet"
 
+// defaultSheetName is the sheet a new Excel workbook is created with.
+const defaultSheetName = "Sheet1"
+
 // table represents file contents as database table structure.
 type table struct {
 	// Name is table name derived from file path.
@@ -124,6 +127,23 @@ func sanitizeTableName(name string) string {
 	}
 
 	return finalResult
+}
+
+// xlsxSheetTableName is the table name a sheet is loaded under. The sheet name
+// is appended to the file's name because one workbook holds several sheets and
+// each needs a table of its own.
+//
+// It is not appended when it would only repeat the file name. That is the shape
+// a dump produces — one table per file, in a sheet named after the table — so
+// without this a dumped table read back gained a suffix ("people" became
+// "people_people") and a save that overwrote its own source stopped matching it.
+// A workbook whose sheet name differs from its file name is unaffected.
+func xlsxSheetTableName(baseTableName, sheetName string) string {
+	sanitized := sanitizeTableName(sheetName)
+	if sanitized == baseTableName {
+		return baseTableName
+	}
+	return baseTableName + "_" + sanitized
 }
 
 // identifierRunes maps a derived name onto the characters an identifier may

--- a/table_test.go
+++ b/table_test.go
@@ -267,3 +267,29 @@ func TestSanitizeTableName(t *testing.T) {
 		})
 	}
 }
+
+func TestXLSXSheetTableName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		base     string
+		sheet    string
+		expected string
+	}{
+		{"a differing sheet name is appended", "sample", "Sheet1", "sample_Sheet1"},
+		{"a second sheet keeps its own table", "sample", "Sheet2", "sample_Sheet2"},
+		{"a sheet named after the file is not repeated", "people", "people", "people"},
+		{"the comparison is made after sanitizing", "my_data", "my-data", "my_data"},
+		{"a sheet name that only differs in case is still appended", "people", "People", "people_People"},
+		{"an unusable sheet name falls back and is appended", "sample", "!!!", "sample_" + sheetFallbackName},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, xlsxSheetTableName(tt.base, tt.sheet))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

v0.24.0 staged each table dump in a temporary file next to its destination so a failed write could not destroy what was already there. The staged name ends in `.tmp1234567`, and two of the formats read meaning out of the file name they are handed, so staging broke them.

Excel's `SaveAs` picks its container format from the extension. Every uncompressed `OutputFormatXLSX` dump has failed since v0.24.0 with "unsupported workbook file format", and a compressed one was written with its sheet named after the staged file, so reading it back produced a table called `seed__seed_xlsx_gz` instead of `seed`. The Parquet writer closes the sink it is given, so the staged file was already closed when the dump came to close it and check that error, and a complete dump reported "file already closed".

## What changed

Every writer now takes an `io.Writer` plus the table name, so no format decides anything from a name that belongs to a temporary file. That leaves the staging helper with one form instead of two, and removes the trap along with it. Parquet receives a writer that exposes only `Write`, so it cannot close a file it does not own.

A sheet's name is appended to its file's name so several sheets in one workbook get tables of their own. That suffix is now omitted when it would only repeat the file name: a table dumped to `people.xlsx` reads back as `people` rather than `people_people`, and a save can overwrite the file it came from. A workbook whose sheet name differs from its file name is unaffected.

## Why it was not caught

The XLSX writer tests called the writer directly with a final path, which is not the path a dump takes. They now go through the dump entry point that stages the file, and `TestDumpDatabase_RoundTripPerFormat` dumps and re-reads CSV, TSV, LTSV, Parquet, and XLSX with and without compression, so a write that produces an unreadable file fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved XLSX and Parquet export reliability, including more accurate error reporting.
  * Prevented temporary filenames from affecting exported table and sheet names.
  * Avoided redundant XLSX table names when sheet names match the source name.
  * Improved atomic export handling to prevent incomplete or misleading output files.

* **Documentation**
  * Clarified XLSX sheet-to-table naming behavior in the supported formats documentation.

* **Tests**
  * Added coverage for round-trip exports across supported formats and compression options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->