### PR TITLE
chore: prepare v0.26.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-07-30
+
 ### Fixed
 - An XLSX dump could not be written at all. v0.24.0 staged every table dump in a temporary file next to its destination, and Excel was still saved with `SaveAs`, which picks the container format from the file extension — the staged name ends in `.tmp1234567`, which is not a workbook format, so every uncompressed `OutputFormatXLSX` dump failed with "unsupported workbook file format". A compressed one was written, but its sheet was named after the staged file, so reading it back produced a table called `seed__seed_xlsx_gz` instead of `seed`. Every format now writes to the writer it is handed and takes the table name as a parameter, so no format decides anything from a name that belongs to a temporary file.
 - A Parquet dump reported failure after writing the file correctly. The Parquet writer closes the destination it is given when it can, so the staged file was already closed when the dump came to close it and check that error, and a complete dump failed with "file already closed". The destination is now passed as a writer that exposes only `Write`.
@@ -836,7 +838,8 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/nao1215/filesql/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/nao1215/filesql/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/nao1215/filesql/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/nao1215/filesql/compare/v0.22.0...v0.23.0


### PR DESCRIPTION
Rolls the Unreleased entries into v0.26.0. Every one is a write-path fix found by dumping each format and reading the result back.

- An XLSX dump could not be written at all since v0.24.0: staging handed Excel a temporary file name, and `SaveAs` picks its container format from the extension.
- A compressed XLSX dump named its sheet after the staged file, so it read back as `seed__seed_xlsx_gz`.
- A correct Parquet dump reported "file already closed", because the Parquet writer closes the sink it is given.
- A dumped XLSX sheet named after its own table read back as `people_people`.
- A BLOB was written as the decimal bytes of a Go slice.
- A column declared `DATE`, `DATETIME`, or `TIMESTAMP` was written in Go's default time layout, so a dump and reload changed the cell.
- An LTSV value carrying a tab or a newline was written out and silently lost on read; it is now refused.
- A table with no rows could not be dumped to Parquet, so an auto-save kept the rows the caller had deleted.
- A dump could write outside the directory it was given, through a table name carrying a path separator or a parent reference.
- A dump error kept the inner failure only as text, so `errors.Is` could not reach the format's own sentinel.