### PR TITLE
fix(ltsv): keep the columns in the order their labels appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- An LTSV file's columns came out in a different order on every load. LTSV has no header line, so the columns are the labels its records carry; those were collected into a map and then read back out of it, and Go randomizes map iteration. The same file answered `SELECT *` as `id,name` one run and `name,id` the next, a dump of it wrote its columns in a different order each time, and any query written against the column positions was unreliable. The columns are now the labels in the order they first appear. Both the whole-file and the chunked load path had their own copy of this.
+
 ## [0.26.0] - 2026-07-30
 
 ### Fixed

--- a/ltsv_column_order_test.go
+++ b/ltsv_column_order_test.go
@@ -1,0 +1,122 @@
+package filesql
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLTSVColumnOrderIsTheOrderTheLabelsAppear pins that an LTSV file's columns
+// come out in the order its labels are written.
+//
+// They were collected into a map and then read back out of it, and Go randomizes
+// map iteration, so the column order was drawn afresh on every load: the same
+// file gave "id,name" one run and "name,id" the next. SELECT * answered in a
+// different order each time, and a dump of an LTSV table wrote its columns in a
+// different order each time, which made the file's own round-trip unstable.
+//
+// The load is repeated because one pass cannot tell a stable order from a lucky
+// draw.
+func TestLTSVColumnOrderIsTheOrderTheLabelsAppear(t *testing.T) {
+	t.Parallel()
+
+	const attempts = 20
+
+	tests := []struct {
+		name    string
+		content string
+		want    []string
+	}{
+		{
+			name:    "one record",
+			content: "id:1\tname:alice\tage:20\n",
+			want:    []string{"id", "name", "age"},
+		},
+		{
+			name:    "a label that only appears in a later record goes last",
+			content: "id:1\tname:alice\nid:2\tname:bob\tnickname:bo\n",
+			want:    []string{"id", "name", "nickname"},
+		},
+		{
+			name:    "a record that lists its labels in another order does not reorder the columns",
+			content: "id:1\tname:alice\nname:bob\tid:2\n",
+			want:    []string{"id", "name"},
+		},
+		{
+			name:    "labels that sort differently than they appear",
+			content: "zebra:1\tapple:2\tmango:3\n",
+			want:    []string{"zebra", "apple", "mango"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			for range attempts {
+				ctx := t.Context()
+				src := filepath.Join(t.TempDir(), "logs.ltsv")
+				require.NoError(t, os.WriteFile(src, []byte(tt.content), 0o600))
+
+				db, err := OpenContext(ctx, src)
+				require.NoError(t, err)
+
+				rows, err := db.QueryContext(ctx, "SELECT * FROM logs")
+				require.NoError(t, err)
+				got, err := rows.Columns()
+				require.NoError(t, err)
+				require.NoError(t, rows.Err())
+				require.NoError(t, rows.Close())
+				require.NoError(t, db.Close())
+
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+// TestLTSVColumnOrderSurvivesChunking pins the same order for a file large enough
+// to be loaded in chunks, which is a second code path with its own copy of the
+// header collection.
+func TestLTSVColumnOrderSurvivesChunking(t *testing.T) {
+	t.Parallel()
+
+	const attempts = 10
+
+	var sb strings.Builder
+	for i := range 500 {
+		sb.WriteString("id:")
+		sb.WriteString(strings.Repeat("0", 1) + string(rune('0'+i%10)))
+		sb.WriteString("\tname:alice\tage:20\n")
+	}
+	content := sb.String()
+
+	for range attempts {
+		ctx := t.Context()
+		src := filepath.Join(t.TempDir(), "logs.ltsv")
+		require.NoError(t, os.WriteFile(src, []byte(content), 0o600))
+
+		validated, err := NewBuilder().AddPath(src).SetDefaultChunkSize(10).Build(ctx)
+		require.NoError(t, err)
+		db, err := validated.Open(ctx)
+		require.NoError(t, err)
+
+		rows, err := db.QueryContext(ctx, "SELECT * FROM logs")
+		require.NoError(t, err)
+		got, err := rows.Columns()
+		require.NoError(t, err)
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+
+		var count int
+		require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM logs").Scan(&count))
+		require.NoError(t, db.Close())
+
+		require.Equal(t, []string{"id", "name", "age"}, got)
+		assert.Equal(t, 500, count)
+	}
+}

--- a/stream.go
+++ b/stream.go
@@ -197,6 +197,38 @@ func (p *streamingParser) parseTSVStream(reader io.Reader) (*table, error) {
 }
 
 // parseLTSVStream parses LTSV data from reader using streaming approach
+// labelOrder collects LTSV labels, keeping each one once and in the order it was
+// first seen. LTSV has no header line, so the columns can only be the labels the
+// records carry; the set has to be built while reading, and the order has to be
+// remembered rather than recovered from the set afterwards.
+type labelOrder struct {
+	seen  map[string]bool
+	order []string
+}
+
+func newLabelOrder() *labelOrder {
+	return &labelOrder{seen: make(map[string]bool)}
+}
+
+// add records a label, ignoring one already seen.
+func (l *labelOrder) add(name string) {
+	if l.seen[name] {
+		return
+	}
+	l.seen[name] = true
+	l.order = append(l.order, name)
+}
+
+// names returns the labels in the order they were first seen.
+func (l *labelOrder) names() []string {
+	return l.order
+}
+
+// len returns how many distinct labels were seen.
+func (l *labelOrder) len() int {
+	return len(l.order)
+}
+
 func (p *streamingParser) parseLTSVStream(reader io.Reader) (*table, error) {
 	content, err := io.ReadAll(reader)
 	if err != nil {
@@ -208,7 +240,11 @@ func (p *streamingParser) parseLTSVStream(reader io.Reader) (*table, error) {
 		return nil, fmt.Errorf("%w: empty LTSV data", ErrEmptyData)
 	}
 
-	headerMap := make(map[string]bool)
+	// The columns are the labels in the order they first appear. Reading them out
+	// of a map instead drew a fresh order on every load, because Go randomizes map
+	// iteration: the same file answered SELECT * as "id,name" one run and
+	// "name,id" the next, and its dump was unstable with it.
+	labels := newLabelOrder()
 	var records []map[string]string
 
 	for _, line := range lines {
@@ -230,7 +266,7 @@ func (p *streamingParser) parseLTSVStream(reader io.Reader) (*table, error) {
 					return nil, fmt.Errorf("%w: duplicate column name %q in LTSV record", ErrParsing, key)
 				}
 				recordMap[key] = value
-				headerMap[key] = true
+				labels.add(key)
 			}
 		}
 		if len(recordMap) > 0 {
@@ -242,10 +278,7 @@ func (p *streamingParser) parseLTSVStream(reader io.Reader) (*table, error) {
 		return nil, fmt.Errorf("%w: no valid LTSV records found", ErrEmptyData)
 	}
 
-	var header header
-	for key := range headerMap {
-		header = append(header, key)
-	}
+	header := header(labels.names())
 
 	tablerecords := make([]Record, 0, len(records))
 	for _, recordMap := range records {
@@ -456,9 +489,9 @@ func (p *streamingParser) processLTSVInChunks(reader io.Reader, processor chunkP
 		return fmt.Errorf("%w: empty LTSV data", ErrEmptyData)
 	}
 
-	headerMap := make(map[string]bool)
-
-	// First pass: collect all possible keys
+	// First pass: collect the labels in the order they first appear. See
+	// parseLTSVStream for why the order cannot come out of a map.
+	labels := newLabelOrder()
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -468,20 +501,16 @@ func (p *streamingParser) processLTSVInChunks(reader io.Reader, processor chunkP
 		for pair := range strings.SplitSeq(line, "\t") {
 			kv := strings.SplitN(pair, ":", 2)
 			if len(kv) == 2 {
-				key := strings.TrimSpace(kv[0])
-				headerMap[key] = true
+				labels.add(strings.TrimSpace(kv[0]))
 			}
 		}
 	}
 
-	if len(headerMap) == 0 {
+	if labels.len() == 0 {
 		return fmt.Errorf("%w: no valid LTSV keys found", ErrEmptyData)
 	}
 
-	var header header
-	for key := range headerMap {
-		header = append(header, key)
-	}
+	header := header(labels.names())
 
 	// Second pass: process records in chunks
 	chunkrecords := make([]Record, 0) // Pre-allocate slice


### PR DESCRIPTION
## Summary

LTSV has no header line, so a table's columns are the labels its records carry. Both load paths collected those labels into a `map[string]bool` and then built the column list by ranging over it — and Go randomizes map iteration, so the column order was drawn afresh on every load.

```
$ cat logs.ltsv
id:1	name:alice	age:20

# same file, two runs
SELECT * FROM logs  ->  age, id, name
SELECT * FROM logs  ->  id, name, age
```

The consequences reach past display: a dump of an LTSV table wrote its columns in a different order each time, so the file's own round-trip was unstable, and any query written against column positions could not be relied on.

## What changed

`labelOrder` keeps each label once and in the order it was first seen. Both the whole-file load and the chunked load — which had their own copy of the collection — use it. A label that only appears in a later record still goes last, and a record that lists its labels in another order does not reorder the columns already established.

The `parser` package's own LTSV reader was already written this way, with a slice beside the set. The streaming paths, which are the ones a load actually goes through, were not.

## Tests

`TestLTSVColumnOrderIsTheOrderTheLabelsAppear` loads the same file twenty times per case, because one pass cannot tell a stable order from a lucky draw. It covers a single record, a label introduced by a later record, a record that lists its labels in another order, and labels whose appearance order differs from their sort order — the last of these is what distinguishes "first seen" from "sorted". `TestLTSVColumnOrderSurvivesChunking` does the same through the chunked path with a 500-row file and a chunk size of 10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - LTSV columns now consistently appear in the order their labels first occur in the source data.
  - Preserved column ordering across repeated loads, including large files processed in chunks.
  - Ensured query results maintain stable column names and complete record loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->