### PR TITLE
chore: prepare v0.27.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-07-30
+
 ### Fixed
 - Auto-save in overwrite mode wrote a new file instead of the one it was overwriting. `EnableAutoSave("")` handed the whole database to `DumpDatabase` with one output directory and the format from its options, which defaults to CSV. A `.tsv` source therefore got a new `.csv` beside it holding the change while the `.tsv` the caller asked to overwrite still held the old rows; the same for `.ltsv`, for a compressed source like `.csv.gz`, and for a workbook, which became one CSV per sheet. Sources in different directories all landed next to whichever was loaded first, and a table created during the session was written out as a file of its own. Each table is now written back to the file it came from, in that file's own format and compression, and only those files are written. A source in a format this package reads but does not write (JSON, JSONL), and a workbook of more than one sheet, now fail the save instead of turning into something else on disk.
 - An LTSV file's columns came out in a different order on every load. LTSV has no header line, so the columns are the labels its records carry; those were collected into a map and then read back out of it, and Go randomizes map iteration. The same file answered `SELECT *` as `id,name` one run and `name,id` the next, a dump of it wrote its columns in a different order each time, and any query written against the column positions was unreliable. The columns are now the labels in the order they first appear. Both the whole-file and the chunked load path had their own copy of this.
@@ -842,7 +844,8 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/nao1215/filesql/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/nao1215/filesql/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/nao1215/filesql/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/nao1215/filesql/compare/v0.23.0...v0.24.0


### PR DESCRIPTION
Rolls the Unreleased entries into v0.27.0. Both are bugs where the result changed without anything saying so.

- An LTSV file's columns came out in a different order on every load, because they were read back out of a map. `SELECT *` answered differently run to run, and a dump of the table wrote its columns differently each time.
- Auto-save in overwrite mode wrote a new file beside the source rather than the source itself, for every format except CSV: the format came from the auto-save options instead of from the file being overwritten. A `.tsv` source kept its old rows while a new `.csv` appeared holding the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `v0.27.0` release entry dated July 30, 2026.
  * Updated changelog comparison links for the new release and the unreleased changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->