### PR TITLE
fix(dump): keep a row whose only column is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- A row whose only column was empty disappeared from a CSV or TSV dump. Written plainly, a record of one empty field is a blank line, and a blank line is not a record — a reader skips it. A one-column table of five rows, two of them empty, was dumped and read back as three, and the dump reported success. Such a record is now written as `""`, which says "one field, and it is empty" and cannot be read as anything else. A record of several columns is unaffected, because its delimiters already say how many fields there are.
+
 ## [0.27.0] - 2026-07-30
 
 ### Fixed

--- a/dump_lone_empty_test.go
+++ b/dump_lone_empty_test.go
@@ -1,0 +1,109 @@
+package filesql
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDumpLoneEmptyField pins that a row whose only column is empty survives a
+// dump and a reload.
+//
+// In CSV and TSV a record of one empty field, written plainly, is a blank line,
+// and a blank line is not a record — a reader skips it. A one-column table of
+// five rows, two of them empty, came back with three: the rows were gone and the
+// dump reported success. Quoting the field says "one field, empty" and cannot be
+// read as anything else. A record of several columns is unaffected, because the
+// delimiters already say how many fields there are.
+func TestDumpLoneEmptyField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		format OutputFormat
+		want   string
+	}{
+		{name: "csv", format: OutputFormatCSV, want: "v\nalice\n\"\"\nbob\n"},
+		{name: "tsv", format: OutputFormatTSV, want: "v\nalice\n\"\"\nbob\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			db := openWithTable(t,
+				"CREATE TABLE t (v TEXT)",
+				"INSERT INTO t VALUES ('alice')",
+				"INSERT INTO t VALUES ('')",
+				"INSERT INTO t VALUES ('bob')")
+
+			assert.Equal(t, tt.want, dumpToString(t, db, NewDumpOptions().WithFormat(tt.format)))
+		})
+	}
+
+	t.Run("every row comes back, empty ones included", func(t *testing.T) {
+		t.Parallel()
+
+		stored := []string{"alice", "", "bob", "", "carol"}
+
+		ctx := t.Context()
+		src := filepath.Join(t.TempDir(), "seed.csv")
+		require.NoError(t, os.WriteFile(src, []byte("a\n1\n"), 0o600))
+
+		db, err := OpenContext(ctx, src)
+		require.NoError(t, err)
+		defer db.Close()
+
+		_, err = db.ExecContext(ctx, "DROP TABLE seed")
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, "CREATE TABLE names (v TEXT)")
+		require.NoError(t, err)
+		for _, v := range stored {
+			_, err = db.ExecContext(ctx, "INSERT INTO names VALUES (?)", v)
+			require.NoError(t, err)
+		}
+
+		outDir := t.TempDir()
+		require.NoError(t, DumpDatabase(db, outDir, NewDumpOptions()))
+
+		reloaded, err := OpenContext(ctx, filepath.Join(outDir, "names.csv"))
+		require.NoError(t, err)
+		defer reloaded.Close()
+
+		rows, err := reloaded.QueryContext(ctx, "SELECT v FROM names")
+		require.NoError(t, err)
+		defer rows.Close()
+		got := make([]string, 0, len(stored))
+		for rows.Next() {
+			var v string
+			require.NoError(t, rows.Scan(&v))
+			got = append(got, v)
+		}
+		require.NoError(t, rows.Err())
+
+		assert.Equal(t, stored, got)
+	})
+
+	t.Run("a multi-column row with every field empty is unaffected", func(t *testing.T) {
+		t.Parallel()
+
+		db := openWithTable(t,
+			"CREATE TABLE t (a TEXT, b TEXT)",
+			"INSERT INTO t VALUES ('', '')")
+
+		assert.Equal(t, "a,b\n,\n", dumpToString(t, db, NewDumpOptions()))
+	})
+
+	t.Run("a lone NULL is written the same way, since neither format has a NULL", func(t *testing.T) {
+		t.Parallel()
+
+		db := openWithTable(t,
+			"CREATE TABLE t (v TEXT)",
+			"INSERT INTO t VALUES (NULL)")
+
+		assert.Equal(t, "v\n\"\"\n", dumpToString(t, db, NewDumpOptions()))
+	})
+}

--- a/filesql.go
+++ b/filesql.go
@@ -528,6 +528,16 @@ func createCompressedWriter(w io.Writer, compression CompressionType) (io.Writer
 	return handler.CreateWriter(w)
 }
 
+// loneEmptyField is what a record of one empty field is written as.
+//
+// Written plainly it is a blank line, and a blank line is not a record: a reader
+// skips it, so a one-column table's empty rows disappeared and the dump reported
+// success. The quotes say "one field, and it is empty", which cannot be read as
+// anything else. encoding/csv's writer does not quote an empty field — it has no
+// way to know it is the only one on the line — so this record is written around
+// it.
+const loneEmptyField = `""`
+
 // writeDelimitedData writes data in CSV or TSV format based on delimiter
 func writeDelimitedData(writer io.Writer, columns []string, rows *sql.Rows, delimiter rune) error {
 	csvWriter := csv.NewWriter(writer)
@@ -536,8 +546,22 @@ func writeDelimitedData(writer io.Writer, columns []string, rows *sql.Rows, deli
 	}
 	defer csvWriter.Flush()
 
+	// writeRecord writes one record, taking the lone empty field around the csv
+	// writer. Flushing first keeps the two writers' output in order.
+	writeRecord := func(record []string) error {
+		if len(record) != 1 || record[0] != "" {
+			return csvWriter.Write(record)
+		}
+		csvWriter.Flush()
+		if err := csvWriter.Error(); err != nil {
+			return err
+		}
+		_, err := io.WriteString(writer, loneEmptyField+"\n")
+		return err
+	}
+
 	// Write header
-	if err := csvWriter.Write(columns); err != nil {
+	if err := writeRecord(columns); err != nil {
 		return err
 	}
 
@@ -559,7 +583,7 @@ func writeDelimitedData(writer io.Writer, columns []string, rows *sql.Rows, deli
 			record[i] = formatDumpValue(value)
 		}
 
-		if err := csvWriter.Write(record); err != nil {
+		if err := writeRecord(record); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

In CSV and TSV, a record of one empty field written plainly is a blank line — and a blank line is not a record, so a reader skips it.

```go
// names holds: alice, "", bob, "", carol
filesql.DumpDatabase(db, "./out", filesql.NewDumpOptions())
// wrote:  v\nalice\n\nbob\n\ncarol\n
// reads back as 3 rows, not 5
```

The dump reported success both times. Two rows were gone.

## What changed

A record of exactly one empty field is written as `""`. That says "one field, and it is empty", and `encoding/csv`'s reader reads it back as exactly that, where it skips a blank line entirely.

`encoding/csv`'s writer does not quote an empty field — it cannot know the field is the only one on the line — so this one record is written around it, flushing the csv writer first so the two writers' output stays in order.

A record of several columns is unaffected, because its delimiters already say how many fields there are: a two-column row of two empty strings still writes as `,`.

## Tests

`TestDumpLoneEmptyField` covers the written bytes for CSV and TSV, a five-row one-column table through a full dump and reload with its empty rows intact, a multi-column all-empty row staying as it was, and a lone NULL, which neither format distinguishes from an empty string and which is written the same way.