### PR TITLE
fix(ltsv): read a value as the bytes up to the field's end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- An LTSV value lost the whitespace around it. The reader trimmed the value, while the LTSV writer wrote it and CSV and TSV kept theirs, so `v:  padded  ` loaded as `padded`: a dump and reload through LTSV lost the spaces, and the same data read from LTSV and from CSV disagreed. LTSV defines a value as everything up to the next tab or newline and says nothing about trimming, so the value is now read as those bytes. The trailing side needed the line-level trim narrowed to the line terminator, which had been taking the last field's trailing spaces with it. A label is still trimmed: LTSV restricts one to letters, digits, underscore, dot, and hyphen, so a space around a label is malformed either way.
+
 ## [0.28.0] - 2026-07-30
 
 ### Fixed

--- a/ltsv_whitespace_test.go
+++ b/ltsv_whitespace_test.go
@@ -1,0 +1,115 @@
+package filesql
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLTSVValueKeepsSurroundingWhitespace pins that an LTSV value is read as the
+// bytes between the colon and the field's end.
+//
+// The reader trimmed the value, so a cell with meaningful spaces around it came
+// back without them, while CSV and TSV kept theirs and the LTSV writer wrote
+// them: a dump and reload through LTSV lost them, and the same data loaded from
+// two formats disagreed. LTSV defines a value as everything up to the next tab or
+// newline and says nothing about trimming.
+//
+// The label is still trimmed. LTSV restricts a label to letters, digits,
+// underscore, dot, and hyphen, so a space around one is already malformed, and
+// tolerating it costs nothing.
+func TestLTSVValueKeepsSurroundingWhitespace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "a space after the colon belongs to the value", content: "v: padded\n", want: " padded"},
+		{name: "a trailing space belongs to the value", content: "v:padded \n", want: "padded "},
+		{name: "spaces on both sides belong to the value", content: "v:  padded  \n", want: "  padded  "},
+		{name: "a value of only spaces is not an empty value", content: "v:   \n", want: "   "},
+		{name: "a value with no whitespace is unchanged", content: "v:padded\n", want: "padded"},
+		{name: "an inner space was never at risk", content: "v:two words\n", want: "two words"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			src := filepath.Join(t.TempDir(), "t.ltsv")
+			require.NoError(t, os.WriteFile(src, []byte(tt.content), 0o600))
+
+			db, err := OpenContext(ctx, src)
+			require.NoError(t, err)
+			defer db.Close()
+
+			var got string
+			require.NoError(t, db.QueryRowContext(ctx, "SELECT v FROM t").Scan(&got))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	t.Run("a label keeps being trimmed, since a space in one is malformed", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		src := filepath.Join(t.TempDir(), "t.ltsv")
+		require.NoError(t, os.WriteFile(src, []byte(" v :x\n"), 0o600))
+
+		db, err := OpenContext(ctx, src)
+		require.NoError(t, err)
+		defer db.Close()
+
+		rows, err := db.QueryContext(ctx, "SELECT * FROM t")
+		require.NoError(t, err)
+		defer rows.Close()
+		cols, err := rows.Columns()
+		require.NoError(t, err)
+		require.NoError(t, rows.Err())
+		assert.Equal(t, []string{"v"}, cols)
+	})
+
+	t.Run("a dump and reload through LTSV keeps the whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		db := openWithTable(t, "CREATE TABLE t (v TEXT)", "INSERT INTO t VALUES ('  padded  ')")
+
+		outDir := t.TempDir()
+		require.NoError(t, DumpDatabase(db, outDir, NewDumpOptions().WithFormat(OutputFormatLTSV)))
+
+		reloaded, err := OpenContext(t.Context(), filepath.Join(outDir, "t.ltsv"))
+		require.NoError(t, err)
+		defer reloaded.Close()
+
+		var got string
+		require.NoError(t, reloaded.QueryRowContext(t.Context(), "SELECT v FROM t").Scan(&got))
+		assert.Equal(t, "  padded  ", got)
+	})
+
+	t.Run("LTSV and CSV agree on the same value", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		dir := t.TempDir()
+
+		ltsvPath := filepath.Join(dir, "a.ltsv")
+		require.NoError(t, os.WriteFile(ltsvPath, []byte("v:  padded  \n"), 0o600))
+		csvPath := filepath.Join(dir, "b.csv")
+		require.NoError(t, os.WriteFile(csvPath, []byte("v\n\"  padded  \"\n"), 0o600))
+
+		db, err := OpenContext(ctx, ltsvPath, csvPath)
+		require.NoError(t, err)
+		defer db.Close()
+
+		var fromLTSV, fromCSV string
+		require.NoError(t, db.QueryRowContext(ctx, "SELECT v FROM a").Scan(&fromLTSV))
+		require.NoError(t, db.QueryRowContext(ctx, "SELECT v FROM b").Scan(&fromCSV))
+		assert.Equal(t, fromCSV, fromLTSV)
+	})
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -751,7 +751,9 @@ func parseLTSV(reader io.Reader) (*TableData, error) {
 	var parsedRecords []map[string]string
 
 	for _, line := range lines {
-		line = strings.TrimSpace(line)
+		// Only the line terminator is removed. TrimSpace took the trailing spaces
+		// of the last field with it, so a value ending in a space lost it.
+		line = strings.TrimRight(line, "\r")
 		if line == "" {
 			continue
 		}
@@ -762,7 +764,11 @@ func parseLTSV(reader io.Reader) (*TableData, error) {
 			kv := strings.SplitN(pair, ":", 2)
 			if len(kv) == 2 {
 				key := strings.TrimSpace(kv[0])
-				value := strings.TrimSpace(kv[1])
+				// The value is the bytes up to the next tab or newline. Trimming it lost
+				// whitespace the writer had written and CSV would have kept, so the same
+				// data read from two formats disagreed. The label is trimmed because a
+				// space around one is malformed either way.
+				value := kv[1]
 				// A label repeated within one record cannot map to distinct columns.
 				// Reject it rather than silently keeping only the last value.
 				if _, dup := recordMap[key]; dup {

--- a/stream.go
+++ b/stream.go
@@ -248,7 +248,9 @@ func (p *streamingParser) parseLTSVStream(reader io.Reader) (*table, error) {
 	var records []map[string]string
 
 	for _, line := range lines {
-		line = strings.TrimSpace(line)
+		// Only the line terminator is removed. TrimSpace took the trailing spaces
+		// of the last field with it, so a value ending in a space lost it.
+		line = strings.TrimRight(line, "\r")
 		if line == "" {
 			continue
 		}
@@ -258,7 +260,11 @@ func (p *streamingParser) parseLTSVStream(reader io.Reader) (*table, error) {
 			kv := strings.SplitN(pair, ":", 2)
 			if len(kv) == 2 {
 				key := strings.TrimSpace(kv[0])
-				value := strings.TrimSpace(kv[1])
+				// The value is the bytes up to the next tab or newline. Trimming it lost
+				// whitespace the writer had written and CSV would have kept, so the same
+				// data read from two formats disagreed. The label is trimmed because a
+				// space around one is malformed either way.
+				value := kv[1]
 				// A label repeated within the same record cannot be two distinct
 				// columns; keeping the last value would silently drop the earlier
 				// one, so reject it. Ref nao1215/sqly#467.
@@ -493,7 +499,9 @@ func (p *streamingParser) processLTSVInChunks(reader io.Reader, processor chunkP
 	// parseLTSVStream for why the order cannot come out of a map.
 	labels := newLabelOrder()
 	for _, line := range lines {
-		line = strings.TrimSpace(line)
+		// Only the line terminator is removed. TrimSpace took the trailing spaces
+		// of the last field with it, so a value ending in a space lost it.
+		line = strings.TrimRight(line, "\r")
 		if line == "" {
 			continue
 		}
@@ -523,7 +531,9 @@ func (p *streamingParser) processLTSVInChunks(reader io.Reader, processor chunkP
 	}
 
 	for _, line := range lines {
-		line = strings.TrimSpace(line)
+		// Only the line terminator is removed. TrimSpace took the trailing spaces
+		// of the last field with it, so a value ending in a space lost it.
+		line = strings.TrimRight(line, "\r")
 		if line == "" {
 			continue
 		}
@@ -533,7 +543,11 @@ func (p *streamingParser) processLTSVInChunks(reader io.Reader, processor chunkP
 			kv := strings.SplitN(pair, ":", 2)
 			if len(kv) == 2 {
 				key := strings.TrimSpace(kv[0])
-				value := strings.TrimSpace(kv[1])
+				// The value is the bytes up to the next tab or newline. Trimming it lost
+				// whitespace the writer had written and CSV would have kept, so the same
+				// data read from two formats disagreed. The label is trimmed because a
+				// space around one is malformed either way.
+				value := kv[1]
 				// A label repeated within the same record cannot be two distinct
 				// columns; keeping the last value would silently drop the earlier
 				// one, so reject it. Ref nao1215/sqly#467.


### PR DESCRIPTION
## Summary

The LTSV reader trimmed the value. The LTSV writer does not, and CSV and TSV keep their whitespace, so the same cell came out differently depending on how it got there.

```
v:  padded  
```

loaded as `padded`. A dump and reload through LTSV therefore lost the spaces the dump had just written, and loading the same value from an LTSV file and from a CSV file gave two different answers.

LTSV defines a value as everything up to the next tab or newline and says nothing about trimming, so the value is now read as those bytes.

## Two changes, not one

Removing the trim on the value fixed the leading side only. The line was being trimmed with `TrimSpace` before it was split into fields, which took the last field's trailing spaces with it — so the line-level trim is now narrowed to the line terminator, which is all it was there for.

A label is still trimmed. LTSV restricts a label to letters, digits, underscore, dot, and hyphen, so a space around one is malformed either way and tolerating it costs nothing.

## Trade-off worth naming

A hand-written file using `key: value` — with a space after the colon, which the format does not call for — now yields a value that begins with a space. That is the same reading CSV would give for `"  padded  "`, and it is what the LTSV writer produces, but it is a change for anyone whose input is written that way.

## Tests

`TestLTSVValueKeepsSurroundingWhitespace` covers a leading space, a trailing space, both, a value of only spaces, a value with no whitespace, an inner space, that a label is still trimmed, a dump-and-reload round trip through LTSV, and LTSV agreeing with CSV on the same value. The full existing LTSV suite passes unchanged, as does sqly's 634-scenario binary suite against this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - LTSV field values now preserve leading, trailing, and all-whitespace content correctly.
  - LTSV parsing remains consistent across standard and streaming workflows.
  - LTSV data retains its original whitespace through dump-and-reload operations.
  - LTSV and CSV inputs now produce consistent values for equivalent data.

- **Documentation**
  - Updated the unreleased changelog with details about the LTSV whitespace fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->