### PR TITLE
fix(dump): adapt a table name to Excel's sheet-name rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - An LTSV value lost the whitespace around it. The reader trimmed the value, while the LTSV writer wrote it and CSV and TSV kept theirs, so `v:  padded  ` loaded as `padded`: a dump and reload through LTSV lost the spaces, and the same data read from LTSV and from CSV disagreed. LTSV defines a value as everything up to the next tab or newline and says nothing about trimming, so the value is now read as those bytes. The trailing side needed the line-level trim narrowed to the line terminator, which had been taking the last field's trailing spaces with it. A label is still trimmed: LTSV restricts one to letters, digits, underscore, dot, and hyphen, so a space around a label is malformed either way.
+- An XLSX dump failed for a table whose name Excel cannot use as a sheet name. A table name comes from a file name, so one longer than 31 characters or holding one of `: \ / ? * [ ]` is ordinary input — a table named after `monthly_sales_report_2026_q3_final.csv` could not be exported to XLSX at all, and the error came from the Excel library rather than this package. The name is now adapted the way sqly already adapted it: the forbidden characters become underscores, the name is cut to 31 runes, and apostrophes are trimmed from the edges. A table whose name Excel cannot hold does not read back under it, because no name would; the alternative was refusing to write the file.
 
 ## [0.28.0] - 2026-07-30
 

--- a/filesql.go
+++ b/filesql.go
@@ -969,11 +969,8 @@ func writeXLSXTableData(w io.Writer, tableName string, columns []string, rows *s
 	}()
 
 	// The sheet name is what a reader turns back into a table name, so it comes
-	// from the table this dump is of.
-	sheetName := tableName
-	if sheetName == "" {
-		sheetName = defaultSheetName
-	}
+	// from the table this dump is of, adapted to what Excel accepts.
+	sheetName := excelSheetName(tableName)
 
 	// Create new sheet (replace default Sheet1)
 	if sheetName != defaultSheetName {

--- a/table.go
+++ b/table.go
@@ -13,6 +13,46 @@ const sheetFallbackName = "sheet"
 // defaultSheetName is the sheet a new Excel workbook is created with.
 const defaultSheetName = "Sheet1"
 
+// excelSheetNameMaxLen is the longest worksheet name Excel accepts, in runes.
+const excelSheetNameMaxLen = 31
+
+// excelForbiddenSheetChars are the characters Excel rejects in a worksheet name.
+const excelForbiddenSheetChars = `:\/?*[]`
+
+// excelSheetName adapts a table name to Excel's worksheet-name rules.
+//
+// A table name comes from a file name, so one that is long or punctuated is
+// ordinary input rather than a mistake — and handing it to Excel as-is failed the
+// whole dump, so a table named after monthly_sales_report_2026_q3_final.csv could
+// not be exported to XLSX at all. The forbidden characters become underscores,
+// the name is cut to 31 runes, and apostrophes are trimmed from the edges, which
+// Excel also disallows; a name that leaves nothing usable falls back.
+//
+// The adapted name is what a reader turns back into a table name, so a table
+// whose name Excel cannot hold does not survive a round trip under it. There is
+// no name that would: the alternative is refusing to write the file.
+func excelSheetName(name string) string {
+	var b strings.Builder
+	for _, r := range name {
+		if strings.ContainsRune(excelForbiddenSheetChars, r) {
+			b.WriteByte('_')
+			continue
+		}
+		b.WriteRune(r)
+	}
+
+	sheet := []rune(b.String())
+	if len(sheet) > excelSheetNameMaxLen {
+		sheet = sheet[:excelSheetNameMaxLen]
+	}
+
+	trimmed := strings.Trim(string(sheet), "'")
+	if trimmed == "" {
+		return defaultSheetName
+	}
+	return trimmed
+}
+
 // table represents file contents as database table structure.
 type table struct {
 	// Name is table name derived from file path.

--- a/xlsx_sheet_name_test.go
+++ b/xlsx_sheet_name_test.go
@@ -1,0 +1,95 @@
+package filesql
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExcelSheetName pins how a table name is adapted to Excel's worksheet-name
+// rules. A table name comes from a file name, so one that is long or punctuated
+// is ordinary input rather than a mistake: the dump used to hand it to Excel
+// as-is and fail, so a table named after monthly_sales_report_2026_q3_final.csv
+// could not be exported to XLSX at all.
+func TestExcelSheetName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		table string
+		want  string
+	}{
+		{name: "a short name is unchanged", table: "sales", want: "sales"},
+		{name: "exactly the limit is unchanged", table: strings.Repeat("a", 31), want: strings.Repeat("a", 31)},
+		{name: "one over the limit is cut to it", table: strings.Repeat("a", 32), want: strings.Repeat("a", 31)},
+		{name: "the limit counts runes, not bytes", table: strings.Repeat("売", 32), want: strings.Repeat("売", 31)},
+		{name: "a bracket becomes an underscore", table: "sales[2026]", want: "sales_2026_"},
+		{name: "a question mark becomes an underscore", table: "what?", want: "what_"},
+		{name: "a star becomes an underscore", table: "a*b", want: "a_b"},
+		{name: "a colon becomes an underscore", table: "12:34", want: "12_34"},
+		{name: "a slash becomes an underscore", table: "a/b", want: "a_b"},
+		{name: "a backslash becomes an underscore", table: `a\b`, want: "a_b"},
+		{name: "surrounding apostrophes are dropped", table: "'sales'", want: "sales"},
+		{name: "a name that leaves nothing usable falls back", table: "'", want: defaultSheetName},
+		{name: "an empty name falls back", table: "", want: defaultSheetName},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, excelSheetName(tt.table))
+		})
+	}
+}
+
+// TestDumpXLSXAdaptsSheetName pins that a dump of such a table succeeds and can
+// be read back.
+func TestDumpXLSXAdaptsSheetName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		table     string
+		wantSheet string
+	}{
+		{name: "a long name", table: "monthly_sales_report_2026_q3_final", wantSheet: "monthly_sales_report_2026_q3_fi"},
+		{name: "a punctuated name", table: "sales[2026]", wantSheet: "sales_2026_"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			db := openWithTable(t,
+				`CREATE TABLE "`+tt.table+`" (x TEXT)`,
+				`INSERT INTO "`+tt.table+`" VALUES ('kept')`)
+
+			outDir := t.TempDir()
+			require.NoError(t, DumpDatabase(db, outDir, NewDumpOptions().WithFormat(OutputFormatXLSX)))
+
+			reloaded, err := OpenContext(t.Context(), filepath.Join(outDir, tt.table+".xlsx"))
+			require.NoError(t, err)
+			defer reloaded.Close()
+
+			rows, err := reloaded.QueryContext(t.Context(), "SELECT name FROM sqlite_master WHERE type='table'")
+			require.NoError(t, err)
+			defer rows.Close()
+			names := make([]string, 0, 1)
+			for rows.Next() {
+				var n string
+				require.NoError(t, rows.Scan(&n))
+				names = append(names, n)
+			}
+			require.NoError(t, rows.Err())
+
+			// The sheet name is what a reader turns into a table name, and Excel
+			// cannot hold the original, so the reloaded name is the adapted one.
+			require.Len(t, names, 1)
+			assert.Contains(t, names[0], sanitizeTableName(tt.wantSheet))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

An XLSX dump handed the table name straight to Excel as the sheet name, and failed whenever Excel would not take it — longer than 31 characters, or holding one of `: \ / ? * [ ]`.

```
failed to export table monthly_sales_report_2026_q3_final:
  failed to create sheet monthly_sales_report_2026_q3_final:
  the sheet name length exceeds the 31 characters limit
```

A table name comes from a file name, so a long or punctuated one is ordinary input rather than a mistake. `monthly_sales_report_2026_q3_final.csv` is 38 characters, and a table loaded from it could not be exported to XLSX at all. The error also came from the Excel library rather than from this package, so it carried none of this package's sentinels.

## What changed

`excelSheetName` adapts the name using the same rule sqly's own Excel writer already applies, which also stops the two from disagreeing about the same table: the forbidden characters become underscores, the name is cut to 31 runes, and apostrophes are trimmed from the edges, which Excel disallows there too. A name that leaves nothing usable falls back to `Sheet1`.

The length is counted in runes, so a 32-character Japanese table name is cut to 31 characters rather than mid-byte.

## What this gives up

The sheet name is what a reader turns back into a table name, so a table whose name Excel cannot hold does not read back under it. No name would — Excel has no 38-character sheet names. The choice is between a file that exists under an adapted name and no file at all.

## Tests

`TestExcelSheetName` covers each rule and each forbidden character, the limit exactly and one over, the rune-versus-byte count, apostrophe trimming, and both fallback cases. `TestDumpXLSXAdaptsSheetName` dumps a long name and a punctuated one and reads each back.