### PR TITLE
refactor: FileType names a format, not a format-and-codec combination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `FileType` names a format and no longer fuses in the codec wrapping it, so it has 10 constants instead of 65. 56 of the old ones named a combination — `FileTypeCSVGZ`, `FileTypeCSVBZ2`, and the same eight codecs for TSV, LTSV, Parquet, XLSX, JSON, and JSONL — which made them the single largest part of this package's public API, and the naming was ambiguous where the two axes collided: `FileTypeJSONLZ4` was lz4-compressed JSON while `FileTypeJSONLLZ4` was lz4-compressed JSONL, one `L` apart with nothing in the name to say which reading was right. `AddReader` was the only caller that needed them, because an `io.Reader` carries no path to infer a codec from; it now takes options, and the codec is stated with `WithCompression(CompressionGZ)`. The existing three-argument call is unchanged, so a caller reading uncompressed bytes needs no edit. `prep` re-exported 56 of the parser's compressed constants under a second spelling and now re-exports formats only; `parser.FileType` keeps its fused constants, since that is the lower level where a format-and-codec name is the honest description of what it dispatches on, and `parser.BaseFileType` folds one back.
+- `stream.go`'s `createDecompressedReader` was 70 lines of eight arms naming seven formats each — a second implementation of what `CompressionHandler.CreateReader` already did from a `CompressionType` — and is now one line that calls it. One behavior follows from that: for an uncompressed source it returns a no-op close function rather than `nil`, which is `CreateReader`'s convention, so a caller can invoke it unconditionally.
+
 ## [0.29.0] - 2026-07-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ codec that is. A reader has no path, so `AddReader` takes the codec as an
 option:
 
 ```go
-gz, _ := os.Open("users.csv.gz")
+gz, err := os.Open("users.csv.gz")
+if err != nil {
+	return err
+}
+defer gz.Close()
+
 builder.AddReader(gz, "users", filesql.FileTypeCSV, filesql.WithCompression(filesql.CompressionGZ))
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ Compressed wrappers are supported for CSV, TSV, LTSV, JSON, JSONL, Parquet, and 
 
 ACH and Fedwire do not use external compression wrappers.
 
+Format and compression are separate. `FileType` names the format only —
+`FileTypeCSV` is a CSV whether or not a codec wraps it — and a path says which
+codec that is. A reader has no path, so `AddReader` takes the codec as an
+option:
+
+```go
+gz, _ := os.Open("users.csv.gz")
+builder.AddReader(gz, "users", filesql.FileTypeCSV, filesql.WithCompression(filesql.CompressionGZ))
+```
+
+Without `WithCompression` the reader's bytes are read as the format directly,
+so the ordinary three-argument call is unchanged.
+
 ## Installation
 
 ```bash
@@ -378,6 +391,7 @@ The GoDoc examples are fully tested with `go test`. The tables below show the fa
 | Open files and query them | `ExampleOpen`, `ExampleOpenContext` | [example_api_test.go](./example_api_test.go), [example_test.go](./example_test.go) |
 | Load files into an existing `*sql.DB` | `ExampleLoadInto`, `ExampleDBBuilder_LoadInto` | [example_api_test.go](./example_api_test.go) |
 | Build from readers, paths, or embedded FS | `ExampleNewBuilder`, `ExampleDBBuilder_AddReader`, `ExampleDBBuilder_AddPath`, `ExampleDBBuilder_AddFS` | [example_test.go](./example_test.go) |
+| Read a compressed reader | `ExampleDBBuilder_AddReader_compressed` | [example_test.go](./example_test.go) |
 | Tune chunked loading | `ExampleDBBuilder_SetDefaultChunkSize` | [example_api_test.go](./example_api_test.go) |
 | Handle malformed CSV/TSV rows | `ExampleDBBuilder_WithMalformedRowPolicy` | [example_api_test.go](./example_api_test.go) |
 | Attach your own logger | `ExampleDBBuilder_WithLogger`, `ExampleNewSlogAdapter` | [example_api_test.go](./example_api_test.go) |

--- a/builder.go
+++ b/builder.go
@@ -79,9 +79,31 @@ type readerInput struct {
 	tableName string
 	// fileType specifies the file format using domain/model types
 	fileType FileType
+	// compression is the codec wrapping the reader, CompressionNone when the
+	// bytes are already the format.
+	compression CompressionType
 	// closer is an optional closer for the reader (set when the reader was opened internally, e.g. from AddFS).
 	// User-provided readers (from AddReader) do not set this field.
 	closer io.Closer
+}
+
+// ReaderOption configures one reader added with AddReader.
+//
+// It is the place per-source settings go. A reader has no path, so anything a
+// file's name would have answered — which codec wraps it — has to be stated,
+// and stating it here keeps AddReader's ordinary three-argument call unchanged.
+type ReaderOption func(*readerInput)
+
+// WithCompression declares the codec wrapping a reader passed to AddReader.
+//
+// Example:
+//
+//	gz, _ := os.Open("users.csv.gz")
+//	builder.AddReader(gz, "users", filesql.FileTypeCSV, filesql.WithCompression(filesql.CompressionGZ))
+func WithCompression(compression CompressionType) ReaderOption {
+	return func(input *readerInput) {
+		input.compression = compression
+	}
 }
 
 // NewBuilder creates a new database builder.
@@ -147,19 +169,31 @@ func (b *DBBuilder) AddPaths(paths ...string) *DBBuilder {
 //   - reader: Any io.Reader (file, bytes.Buffer, http.Response.Body, etc.)
 //   - tableName: Name for the SQL table (e.g., "users")
 //   - fileType: Data format (FileTypeCSV, FileTypeTSV, FileTypeLTSV, etc.)
+//   - opts: Per-source settings, such as WithCompression
+//
+// The reader's bytes are read as fileType directly. When they are wrapped in a
+// codec, say so with WithCompression — a reader has no path to infer it from.
 //
 // Example:
 //
 //	resp, _ := http.Get("https://example.com/data.csv")
 //	builder.AddReader(resp.Body, "remote_data", FileTypeCSV)
 //
+//	gz, _ := os.Open("users.csv.gz")
+//	builder.AddReader(gz, "users", FileTypeCSV, WithCompression(CompressionGZ))
+//
 // Returns self for chaining.
-func (b *DBBuilder) AddReader(reader io.Reader, tableName string, fileType FileType) *DBBuilder {
-	b.readers = append(b.readers, readerInput{
-		reader:    reader,
-		tableName: tableName,
-		fileType:  fileType,
-	})
+func (b *DBBuilder) AddReader(reader io.Reader, tableName string, fileType FileType, opts ...ReaderOption) *DBBuilder {
+	input := readerInput{
+		reader:      reader,
+		tableName:   tableName,
+		fileType:    fileType,
+		compression: CompressionNone,
+	}
+	for _, opt := range opts {
+		opt(&input)
+	}
+	b.readers = append(b.readers, input)
 	return b
 }
 

--- a/builder.go
+++ b/builder.go
@@ -98,7 +98,12 @@ type ReaderOption func(*readerInput)
 //
 // Example:
 //
-//	gz, _ := os.Open("users.csv.gz")
+//	gz, err := os.Open("users.csv.gz")
+//	if err != nil {
+//		return err
+//	}
+//	defer gz.Close()
+//
 //	builder.AddReader(gz, "users", filesql.FileTypeCSV, filesql.WithCompression(filesql.CompressionGZ))
 func WithCompression(compression CompressionType) ReaderOption {
 	return func(input *readerInput) {

--- a/builder_test.go
+++ b/builder_test.go
@@ -142,6 +142,52 @@ func TestDBBuilder_AddFS_Compressed(t *testing.T) {
 	}
 }
 
+// TestDBBuilder_AddFS_CompressedHeaderOnly loads a compressed file that has a
+// header and no rows. The chunked reader and the header-only fallback are two
+// different paths over the same reader, and only one of them can consume it, so
+// the case is worth pinning separately from the file that has rows.
+func TestDBBuilder_AddFS_CompressedHeaderOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, codec := range []CompressionType{CompressionNone, CompressionGZ, CompressionZSTD, CompressionLZ4} {
+		t.Run(codec.String(), func(t *testing.T) {
+			t.Parallel()
+
+			var compressed bytes.Buffer
+			w, closeWriter, err := NewCompressionHandler(codec).CreateWriter(&compressed)
+			require.NoError(t, err)
+			_, err = w.Write([]byte("id,name,email\n"))
+			require.NoError(t, err)
+			require.NoError(t, closeWriter())
+
+			mockFS := fstest.MapFS{
+				"empty" + FileTypeCSV.extension() + codec.Extension(): &fstest.MapFile{Data: compressed.Bytes()},
+			}
+
+			ctx := context.Background()
+			validated, err := NewBuilder().AddFS(mockFS).Build(ctx)
+			require.NoError(t, err, "Build() failed for %s", codec)
+
+			db, err := validated.Open(ctx)
+			require.NoError(t, err, "Open() failed for %s", codec)
+			defer db.Close()
+
+			// The table exists with the header's columns and holds no rows.
+			var count int
+			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM empty").Scan(&count))
+			assert.Equal(t, 0, count, "a header-only file should load no rows")
+
+			rows, err := db.QueryContext(ctx, "SELECT id, name, email FROM empty")
+			require.NoError(t, err, "the header's columns should exist for %s", codec)
+			defer rows.Close()
+			cols, err := rows.Columns()
+			require.NoError(t, err)
+			assert.Equal(t, []string{"id", "name", "email"}, cols)
+			require.NoError(t, rows.Err())
+		})
+	}
+}
+
 func TestDBBuilder_AddReader(t *testing.T) {
 	t.Parallel()
 

--- a/builder_test.go
+++ b/builder_test.go
@@ -87,6 +87,61 @@ func TestDBBuilder_AddFS(t *testing.T) {
 	})
 }
 
+// TestDBBuilder_AddFS_Compressed loads a genuinely compressed file out of an
+// fs.FS. AddFS hands the file over still wrapped, so the codec has to travel
+// alongside the format on the reader input: the file name is the only place it
+// is written down, and nothing downstream sees that name.
+func TestDBBuilder_AddFS_Compressed(t *testing.T) {
+	t.Parallel()
+
+	csvData := "name,age\nAlice,30\nBob,25\n"
+
+	codecs := []struct {
+		compression CompressionType
+		ext         string
+	}{
+		{CompressionGZ, ".gz"},
+		{CompressionXZ, ".xz"},
+		{CompressionZSTD, ".zst"},
+		{CompressionZLIB, ".z"},
+		{CompressionSNAPPY, ".snappy"},
+		{CompressionS2, ".s2"},
+		{CompressionLZ4, ".lz4"},
+	}
+
+	for _, codec := range codecs {
+		t.Run(codec.compression.String(), func(t *testing.T) {
+			t.Parallel()
+
+			var compressed bytes.Buffer
+			w, closeWriter, err := NewCompressionHandler(codec.compression).CreateWriter(&compressed)
+			require.NoError(t, err)
+			_, err = w.Write([]byte(csvData))
+			require.NoError(t, err)
+			require.NoError(t, closeWriter())
+
+			mockFS := fstest.MapFS{
+				"users.csv" + codec.ext: &fstest.MapFile{Data: compressed.Bytes()},
+			}
+
+			ctx := context.Background()
+			validated, err := NewBuilder().AddFS(mockFS).Build(ctx)
+			require.NoError(t, err, "Build() failed for %s", codec.compression)
+
+			db, err := validated.Open(ctx)
+			require.NoError(t, err, "Open() failed for %s", codec.compression)
+			defer db.Close()
+
+			var name string
+			var age int
+			err = db.QueryRowContext(ctx, "SELECT name, age FROM users ORDER BY age").Scan(&name, &age)
+			require.NoError(t, err, "query failed for %s", codec.compression)
+			assert.Equal(t, "Bob", name)
+			assert.Equal(t, 25, age)
+		})
+	}
+}
+
 func TestDBBuilder_AddReader(t *testing.T) {
 	t.Parallel()
 
@@ -117,10 +172,10 @@ func TestDBBuilder_AddReader(t *testing.T) {
 		data := []byte{} // Empty data for test
 		reader := bytes.NewReader(data)
 
-		builder := NewBuilder().AddReader(reader, "logs", FileTypeCSVGZ)
+		builder := NewBuilder().AddReader(reader, "logs", FileTypeCSV, WithCompression(CompressionGZ))
 		assert.Len(t, builder.readers, 1, "should have 1 reader")
-		assert.Equal(t, FileTypeCSVGZ, builder.readers[0].fileType, "file type should be CSV.GZ")
-		// Regular CSV type for testing
+		assert.Equal(t, FileTypeCSV, builder.readers[0].fileType, "file type should be CSV")
+		assert.Equal(t, CompressionGZ, builder.readers[0].compression, "compression should be gzip")
 	})
 
 	t.Run("add multiple readers", func(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -3,6 +3,7 @@ package filesql_test
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"embed"
 	"fmt"
@@ -2255,16 +2256,30 @@ func ExampleDBBuilder_AddReader() {
 	// - Diana (Marketing): $85000
 }
 
-// ExampleDBBuilder_AddReader_compressed demonstrates using compressed data from io.Reader
+// ExampleDBBuilder_AddReader_compressed demonstrates reading compressed data
+// from an io.Reader.
+//
+// A file's name says which codec wraps it, but a reader has no name, so the
+// codec is stated with WithCompression. The FileType stays the format itself:
+// gzipped TSV is FileTypeTSV plus CompressionGZ.
 func ExampleDBBuilder_AddReader_compressed() {
-	// Simulate compressed TSV data (in practice, this would be actual compressed data)
 	tsvData := "product_id\tproduct_name\tprice\n1\tLaptop\t999\n2\tMouse\t25\n3\tKeyboard\t75"
-	reader := bytes.NewReader([]byte(tsvData))
+
+	// Compress the TSV, standing in for a .tsv.gz opened from disk or fetched
+	// over the network.
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	if _, err := gz.Write([]byte(tsvData)); err != nil {
+		log.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		log.Fatal(err)
+	}
+	reader := bytes.NewReader(compressed.Bytes())
 
 	ctx := context.Background()
 	builder := filesql.NewBuilder().
-		// Specify that this is TSV data (not actually compressed in this example)
-		AddReader(reader, "products", filesql.FileTypeTSV)
+		AddReader(reader, "products", filesql.FileTypeTSV, filesql.WithCompression(filesql.CompressionGZ))
 
 	validatedBuilder, err := builder.Build(ctx)
 	if err != nil {

--- a/file.go
+++ b/file.go
@@ -3,13 +3,14 @@ package filesql
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/nao1215/filesql/parser"
 )
 
-// FileType represents supported file types including compression variants
+// FileType names an input format. It says nothing about compression: a
+// gzipped CSV and a plain CSV are both FileTypeCSV, and the codec wrapping a
+// stream is stated separately with [WithCompression].
 type FileType int
 
 // String returns a human-readable string representation of the FileType.
@@ -35,130 +36,10 @@ const (
 	FileTypeParquet
 	// FileTypeXLSX represents Excel XLSX file type
 	FileTypeXLSX
-	// FileTypeCSVGZ represents gzip-compressed CSV file type
-	FileTypeCSVGZ
-	// FileTypeTSVGZ represents gzip-compressed TSV file type
-	FileTypeTSVGZ
-	// FileTypeLTSVGZ represents gzip-compressed LTSV file type
-	FileTypeLTSVGZ
-	// FileTypeParquetGZ represents gzip-compressed Parquet file type
-	FileTypeParquetGZ
-	// FileTypeCSVBZ2 represents bzip2-compressed CSV file type
-	FileTypeCSVBZ2
-	// FileTypeTSVBZ2 represents bzip2-compressed TSV file type
-	FileTypeTSVBZ2
-	// FileTypeLTSVBZ2 represents bzip2-compressed LTSV file type
-	FileTypeLTSVBZ2
-	// FileTypeParquetBZ2 represents bzip2-compressed Parquet file type
-	FileTypeParquetBZ2
-	// FileTypeCSVXZ represents xz-compressed CSV file type
-	FileTypeCSVXZ
-	// FileTypeTSVXZ represents xz-compressed TSV file type
-	FileTypeTSVXZ
-	// FileTypeLTSVXZ represents xz-compressed LTSV file type
-	FileTypeLTSVXZ
-	// FileTypeParquetXZ represents xz-compressed Parquet file type
-	FileTypeParquetXZ
-	// FileTypeCSVZSTD represents zstd-compressed CSV file type
-	FileTypeCSVZSTD
-	// FileTypeTSVZSTD represents zstd-compressed TSV file type
-	FileTypeTSVZSTD
-	// FileTypeLTSVZSTD represents zstd-compressed LTSV file type
-	FileTypeLTSVZSTD
-	// FileTypeParquetZSTD represents zstd-compressed Parquet file type
-	FileTypeParquetZSTD
-	// FileTypeXLSXGZ represents gzip-compressed Excel XLSX file type
-	FileTypeXLSXGZ
-	// FileTypeXLSXBZ2 represents bzip2-compressed Excel XLSX file type
-	FileTypeXLSXBZ2
-	// FileTypeXLSXXZ represents xz-compressed Excel XLSX file type
-	FileTypeXLSXXZ
-	// FileTypeXLSXZSTD represents zstd-compressed Excel XLSX file type
-	FileTypeXLSXZSTD
-
-	// FileTypeCSVZLIB represents zlib-compressed CSV file type
-	FileTypeCSVZLIB
-	// FileTypeTSVZLIB represents zlib-compressed TSV file type
-	FileTypeTSVZLIB
-	// FileTypeLTSVZLIB represents zlib-compressed LTSV file type
-	FileTypeLTSVZLIB
-	// FileTypeParquetZLIB represents zlib-compressed Parquet file type
-	FileTypeParquetZLIB
-	// FileTypeXLSXZLIB represents zlib-compressed XLSX file type
-	FileTypeXLSXZLIB
-
-	// FileTypeCSVSNAPPY represents snappy-compressed CSV file type
-	FileTypeCSVSNAPPY
-	// FileTypeTSVSNAPPY represents snappy-compressed TSV file type
-	FileTypeTSVSNAPPY
-	// FileTypeLTSVSNAPPY represents snappy-compressed LTSV file type
-	FileTypeLTSVSNAPPY
-	// FileTypeParquetSNAPPY represents snappy-compressed Parquet file type
-	FileTypeParquetSNAPPY
-	// FileTypeXLSXSNAPPY represents snappy-compressed XLSX file type
-	FileTypeXLSXSNAPPY
-
-	// FileTypeCSVS2 represents s2-compressed CSV file type
-	FileTypeCSVS2
-	// FileTypeTSVS2 represents s2-compressed TSV file type
-	FileTypeTSVS2
-	// FileTypeLTSVS2 represents s2-compressed LTSV file type
-	FileTypeLTSVS2
-	// FileTypeParquetS2 represents s2-compressed Parquet file type
-	FileTypeParquetS2
-	// FileTypeXLSXS2 represents s2-compressed XLSX file type
-	FileTypeXLSXS2
-
-	// FileTypeCSVLZ4 represents lz4-compressed CSV file type
-	FileTypeCSVLZ4
-	// FileTypeTSVLZ4 represents lz4-compressed TSV file type
-	FileTypeTSVLZ4
-	// FileTypeLTSVLZ4 represents lz4-compressed LTSV file type
-	FileTypeLTSVLZ4
-	// FileTypeParquetLZ4 represents lz4-compressed Parquet file type
-	FileTypeParquetLZ4
-	// FileTypeXLSXLZ4 represents lz4-compressed XLSX file type
-	FileTypeXLSXLZ4
-
 	// FileTypeJSON represents JSON file type
 	FileTypeJSON
 	// FileTypeJSONL represents JSON Lines file type
 	FileTypeJSONL
-
-	// FileTypeJSONGZ represents gzip-compressed JSON file type
-	FileTypeJSONGZ
-	// FileTypeJSONBZ2 represents bzip2-compressed JSON file type
-	FileTypeJSONBZ2
-	// FileTypeJSONXZ represents xz-compressed JSON file type
-	FileTypeJSONXZ
-	// FileTypeJSONZSTD represents zstd-compressed JSON file type
-	FileTypeJSONZSTD
-	// FileTypeJSONZLIB represents zlib-compressed JSON file type
-	FileTypeJSONZLIB
-	// FileTypeJSONSNAPPY represents snappy-compressed JSON file type
-	FileTypeJSONSNAPPY
-	// FileTypeJSONS2 represents s2-compressed JSON file type
-	FileTypeJSONS2
-	// FileTypeJSONLZ4 represents lz4-compressed JSON file type
-	FileTypeJSONLZ4
-
-	// FileTypeJSONLGZ represents gzip-compressed JSONL file type
-	FileTypeJSONLGZ
-	// FileTypeJSONLBZ2 represents bzip2-compressed JSONL file type
-	FileTypeJSONLBZ2
-	// FileTypeJSONLXZ represents xz-compressed JSONL file type
-	FileTypeJSONLXZ
-	// FileTypeJSONLZSTD represents zstd-compressed JSONL file type
-	FileTypeJSONLZSTD
-	// FileTypeJSONLZLIB represents zlib-compressed JSONL file type
-	FileTypeJSONLZLIB
-	// FileTypeJSONLSNAPPY represents snappy-compressed JSONL file type
-	FileTypeJSONLSNAPPY
-	// FileTypeJSONLS2 represents s2-compressed JSONL file type
-	FileTypeJSONLS2
-	// FileTypeJSONLLZ4 represents lz4-compressed JSONL file type
-	FileTypeJSONLLZ4
-
 	// FileTypeACH represents ACH (NACHA) file type
 	FileTypeACH
 	// FileTypeFedWire represents Fedwire file type
@@ -237,7 +118,11 @@ type chunkProcessor func(chunk *tableChunk) error
 
 // streamingParser represents a parser that can read from io.Reader directly
 type streamingParser struct {
-	fileType    FileType
+	fileType FileType
+	// compression is the codec wrapping the reader. A reader carries no path,
+	// so the caller states it; files answer CompressionNone because the file
+	// path is unwrapped before the parser sees it.
+	compression CompressionType
 	tableName   string
 	chunkSize   ChunkSize
 	memoryPool  *MemoryPool  // Pool for reusable memory allocations
@@ -288,7 +173,8 @@ func isSupportedExtension(ext string) bool {
 	return isSupportedFile("file" + ext)
 }
 
-// extension returns the file extension for the FileType
+// extension returns the file extension for the FileType. The codec's suffix is
+// not part of it: a gzipped CSV is FileTypeCSV plus CompressionGZ.Extension().
 func (ft FileType) extension() string {
 	switch ft {
 	case FileTypeCSV:
@@ -301,122 +187,10 @@ func (ft FileType) extension() string {
 		return extParquet
 	case FileTypeXLSX:
 		return extXLSX
-	case FileTypeCSVGZ:
-		return extCSV + extGZ
-	case FileTypeTSVGZ:
-		return extTSV + extGZ
-	case FileTypeLTSVGZ:
-		return extLTSV + extGZ
-	case FileTypeParquetGZ:
-		return extParquet + extGZ
-	case FileTypeCSVBZ2:
-		return extCSV + extBZ2
-	case FileTypeTSVBZ2:
-		return extTSV + extBZ2
-	case FileTypeLTSVBZ2:
-		return extLTSV + extBZ2
-	case FileTypeParquetBZ2:
-		return extParquet + extBZ2
-	case FileTypeCSVXZ:
-		return extCSV + extXZ
-	case FileTypeTSVXZ:
-		return extTSV + extXZ
-	case FileTypeLTSVXZ:
-		return extLTSV + extXZ
-	case FileTypeParquetXZ:
-		return extParquet + extXZ
-	case FileTypeCSVZSTD:
-		return extCSV + extZSTD
-	case FileTypeTSVZSTD:
-		return extTSV + extZSTD
-	case FileTypeLTSVZSTD:
-		return extLTSV + extZSTD
-	case FileTypeParquetZSTD:
-		return extParquet + extZSTD
-	case FileTypeXLSXGZ:
-		return extXLSX + extGZ
-	case FileTypeXLSXBZ2:
-		return extXLSX + extBZ2
-	case FileTypeXLSXXZ:
-		return extXLSX + extXZ
-	case FileTypeXLSXZSTD:
-		return extXLSX + extZSTD
-	case FileTypeCSVZLIB:
-		return extCSV + extZLIB
-	case FileTypeTSVZLIB:
-		return extTSV + extZLIB
-	case FileTypeLTSVZLIB:
-		return extLTSV + extZLIB
-	case FileTypeParquetZLIB:
-		return extParquet + extZLIB
-	case FileTypeXLSXZLIB:
-		return extXLSX + extZLIB
-	case FileTypeCSVSNAPPY:
-		return extCSV + extSNAPPY
-	case FileTypeTSVSNAPPY:
-		return extTSV + extSNAPPY
-	case FileTypeLTSVSNAPPY:
-		return extLTSV + extSNAPPY
-	case FileTypeParquetSNAPPY:
-		return extParquet + extSNAPPY
-	case FileTypeXLSXSNAPPY:
-		return extXLSX + extSNAPPY
-	case FileTypeCSVS2:
-		return extCSV + extS2
-	case FileTypeTSVS2:
-		return extTSV + extS2
-	case FileTypeLTSVS2:
-		return extLTSV + extS2
-	case FileTypeParquetS2:
-		return extParquet + extS2
-	case FileTypeXLSXS2:
-		return extXLSX + extS2
-	case FileTypeCSVLZ4:
-		return extCSV + extLZ4
-	case FileTypeTSVLZ4:
-		return extTSV + extLZ4
-	case FileTypeLTSVLZ4:
-		return extLTSV + extLZ4
-	case FileTypeParquetLZ4:
-		return extParquet + extLZ4
-	case FileTypeXLSXLZ4:
-		return extXLSX + extLZ4
 	case FileTypeJSON:
 		return extJSON
 	case FileTypeJSONL:
 		return extJSONL
-	case FileTypeJSONGZ:
-		return extJSON + extGZ
-	case FileTypeJSONBZ2:
-		return extJSON + extBZ2
-	case FileTypeJSONXZ:
-		return extJSON + extXZ
-	case FileTypeJSONZSTD:
-		return extJSON + extZSTD
-	case FileTypeJSONZLIB:
-		return extJSON + extZLIB
-	case FileTypeJSONSNAPPY:
-		return extJSON + extSNAPPY
-	case FileTypeJSONS2:
-		return extJSON + extS2
-	case FileTypeJSONLZ4:
-		return extJSON + extLZ4
-	case FileTypeJSONLGZ:
-		return extJSONL + extGZ
-	case FileTypeJSONLBZ2:
-		return extJSONL + extBZ2
-	case FileTypeJSONLXZ:
-		return extJSONL + extXZ
-	case FileTypeJSONLZSTD:
-		return extJSONL + extZSTD
-	case FileTypeJSONLZLIB:
-		return extJSONL + extZLIB
-	case FileTypeJSONLSNAPPY:
-		return extJSONL + extSNAPPY
-	case FileTypeJSONLS2:
-		return extJSONL + extS2
-	case FileTypeJSONLLZ4:
-		return extJSONL + extLZ4
 	case FileTypeACH:
 		return extACH
 	case FileTypeFedWire:
@@ -426,28 +200,10 @@ func (ft FileType) extension() string {
 	}
 }
 
-// baseType returns the base file type without compression
-func (ft FileType) baseType() FileType {
-	switch ft {
-	case FileTypeACH:
-		return FileTypeACH
-	case FileTypeFedWire:
-		return FileTypeFedWire
-	default:
-		return filesqlFileType(parser.BaseFileType(parserFileType(ft)))
-	}
-}
-
 // getFileExtension returns the file extension for a given FileType
 // Deprecated: Use FileType.extension() method instead
 func getFileExtension(fileType FileType) string {
 	return fileType.extension()
-}
-
-// getBaseFileType returns the base file type without compression
-// Deprecated: Use FileType.baseType() method instead
-func getBaseFileType(fileType FileType) FileType {
-	return fileType.baseType()
 }
 
 // getPath returns file path
@@ -462,22 +218,22 @@ func (f *file) getFileType() FileType {
 
 // isCSV returns true if the file is CSV format
 func (f *file) isCSV() bool {
-	return f.getFileType().baseType() == FileTypeCSV
+	return f.getFileType() == FileTypeCSV
 }
 
 // isTSV returns true if the file is TSV format
 func (f *file) isTSV() bool {
-	return f.getFileType().baseType() == FileTypeTSV
+	return f.getFileType() == FileTypeTSV
 }
 
 // isLTSV returns true if the file is LTSV format
 func (f *file) isLTSV() bool {
-	return f.getFileType().baseType() == FileTypeLTSV
+	return f.getFileType() == FileTypeLTSV
 }
 
 // isXLSX returns true if the file is XLSX format
 func (f *file) isXLSX() bool {
-	return f.getFileType().baseType() == FileTypeXLSX
+	return f.getFileType() == FileTypeXLSX
 }
 
 // isCompressed returns true if file is compressed
@@ -525,17 +281,20 @@ func (f *file) isLZ4() bool {
 	return strings.HasSuffix(f.path, extLZ4)
 }
 
-// toTable converts file to table structure
+// toTable converts file to table structure.
+//
+// The reader is opened through openReader so the codec is unwrapped here. The
+// parser is handed the format's own bytes, because fileType names the format
+// only and no longer tells the parser what to decompress.
 func (f *file) toTable() (*table, error) {
-	// Open file for reading
-	file, err := os.Open(f.path)
+	reader, closeReader, err := f.openReader()
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file %s: %w", f.path, err)
 	}
-	defer file.Close()
+	defer handleCloseError(closeReader)()
 
 	tableName := sanitizeTableName(tableFromFilePath(f.path))
-	return parseWithParser(file, f.fileType, tableName)
+	return parseWithParser(reader, f.fileType, tableName)
 }
 
 // detectFileType detects file type from extension, considering compressed files

--- a/file_processor.go
+++ b/file_processor.go
@@ -207,19 +207,22 @@ func (fp *fileProcessor) processFSToReaders(_ context.Context, filesystem fs.FS)
 			return nil, fmt.Errorf("%w: failed to open FS file %s: %s", ErrIOOperation, match, err.Error())
 		}
 
-		// Determine file type from extension using NewFile
+		// Determine format and codec from the extension. The file is handed over
+		// still compressed, so the codec has to travel with it.
 		fileInfo := newFile(match)
 		fileType := fileInfo.getFileType()
+		compression := NewCompressionFactory().DetectCompressionType(match)
 
 		// Generate table name from file path (remove extension and clean up)
 		tableName := sanitizeTableName(tableFromFilePath(match))
 
 		// Create ReaderInput with closer so the file is released after streaming
 		readerInput := readerInput{
-			reader:    file,
-			tableName: tableName,
-			fileType:  fileType,
-			closer:    file,
+			reader:      file,
+			tableName:   tableName,
+			fileType:    fileType,
+			compression: compression,
+			closer:      file,
 		}
 
 		readers = append(readers, readerInput)

--- a/file_test.go
+++ b/file_test.go
@@ -16,95 +16,128 @@ import (
 func TestNewFile(t *testing.T) {
 	t.Parallel()
 
+	// FileType names the format, and the codec is a separate axis. A compressed
+	// path answers the same FileType as its uncompressed form, and the codec is
+	// read off the same path by the compression factory.
 	tests := []struct {
-		name     string
-		path     string
-		expected FileType
+		name        string
+		path        string
+		expected    FileType
+		compression CompressionType
 	}{
 		{
-			name:     "CSV file",
-			path:     "test.csv",
-			expected: FileTypeCSV,
+			name:        "CSV file",
+			path:        "test.csv",
+			expected:    FileTypeCSV,
+			compression: CompressionNone,
 		},
 		{
-			name:     "TSV file",
-			path:     "test.tsv",
-			expected: FileTypeTSV,
+			name:        "TSV file",
+			path:        "test.tsv",
+			expected:    FileTypeTSV,
+			compression: CompressionNone,
 		},
 		{
-			name:     "LTSV file",
-			path:     "test.ltsv",
-			expected: FileTypeLTSV,
+			name:        "LTSV file",
+			path:        "test.ltsv",
+			expected:    FileTypeLTSV,
+			compression: CompressionNone,
 		},
 		{
-			name:     "Compressed CSV file",
-			path:     "test.csv.gz",
-			expected: FileTypeCSVGZ,
+			name:        "Compressed CSV file",
+			path:        "test.csv.gz",
+			expected:    FileTypeCSV,
+			compression: CompressionGZ,
 		},
 		{
-			name:     "Compressed TSV file",
-			path:     "test.tsv.bz2",
-			expected: FileTypeTSVBZ2,
+			name:        "Compressed TSV file",
+			path:        "test.tsv.bz2",
+			expected:    FileTypeTSV,
+			compression: CompressionBZ2,
 		},
 		{
-			name:     "Compressed LTSV file",
-			path:     "test.ltsv.xz",
-			expected: FileTypeLTSVXZ,
+			name:        "Compressed LTSV file",
+			path:        "test.ltsv.xz",
+			expected:    FileTypeLTSV,
+			compression: CompressionXZ,
 		},
 		{
-			name:     "Zstd compressed CSV file",
-			path:     "test.csv.zst",
-			expected: FileTypeCSVZSTD,
+			name:        "Zstd compressed CSV file",
+			path:        "test.csv.zst",
+			expected:    FileTypeCSV,
+			compression: CompressionZSTD,
 		},
 		{
-			name:     "XLSX file",
-			path:     "test.xlsx",
-			expected: FileTypeXLSX,
+			name:        "XLSX file",
+			path:        "test.xlsx",
+			expected:    FileTypeXLSX,
+			compression: CompressionNone,
 		},
 		{
-			name:     "Compressed XLSX file with gzip",
-			path:     "test.xlsx.gz",
-			expected: FileTypeXLSXGZ,
+			name:        "Compressed XLSX file with gzip",
+			path:        "test.xlsx.gz",
+			expected:    FileTypeXLSX,
+			compression: CompressionGZ,
 		},
 		{
-			name:     "Compressed XLSX file with bzip2",
-			path:     "test.xlsx.bz2",
-			expected: FileTypeXLSXBZ2,
+			name:        "Compressed XLSX file with bzip2",
+			path:        "test.xlsx.bz2",
+			expected:    FileTypeXLSX,
+			compression: CompressionBZ2,
 		},
 		{
-			name:     "Compressed XLSX file with xz",
-			path:     "test.xlsx.xz",
-			expected: FileTypeXLSXXZ,
+			name:        "Compressed XLSX file with xz",
+			path:        "test.xlsx.xz",
+			expected:    FileTypeXLSX,
+			compression: CompressionXZ,
 		},
 		{
-			name:     "Compressed XLSX file with zstd",
-			path:     "test.xlsx.zst",
-			expected: FileTypeXLSXZSTD,
+			name:        "Compressed XLSX file with zstd",
+			path:        "test.xlsx.zst",
+			expected:    FileTypeXLSX,
+			compression: CompressionZSTD,
 		},
 		{
-			name:     "Zlib compressed CSV file",
-			path:     "test.csv.z",
-			expected: FileTypeCSVZLIB,
+			name:        "Zlib compressed CSV file",
+			path:        "test.csv.z",
+			expected:    FileTypeCSV,
+			compression: CompressionZLIB,
 		},
 		{
-			name:     "Snappy compressed CSV file",
-			path:     "test.csv.snappy",
-			expected: FileTypeCSVSNAPPY,
+			name:        "Snappy compressed CSV file",
+			path:        "test.csv.snappy",
+			expected:    FileTypeCSV,
+			compression: CompressionSNAPPY,
 		},
 		{
-			name:     "S2 compressed CSV file",
-			path:     "test.csv.s2",
-			expected: FileTypeCSVS2,
+			name:        "S2 compressed CSV file",
+			path:        "test.csv.s2",
+			expected:    FileTypeCSV,
+			compression: CompressionS2,
 		},
 		{
-			name:     "LZ4 compressed CSV file",
-			path:     "test.csv.lz4",
-			expected: FileTypeCSVLZ4,
+			name:        "LZ4 compressed CSV file",
+			path:        "test.csv.lz4",
+			expected:    FileTypeCSV,
+			compression: CompressionLZ4,
 		},
 		{
-			name:     "Unsupported file",
-			path:     "test.txt",
-			expected: FileTypeUnsupported,
+			name:        "JSON file",
+			path:        "test.json",
+			expected:    FileTypeJSON,
+			compression: CompressionNone,
+		},
+		{
+			name:        "Compressed JSONL file",
+			path:        "test.jsonl.gz",
+			expected:    FileTypeJSONL,
+			compression: CompressionGZ,
+		},
+		{
+			name:        "Unsupported file",
+			path:        "test.txt",
+			expected:    FileTypeUnsupported,
+			compression: CompressionNone,
 		},
 	}
 
@@ -115,6 +148,8 @@ func TestNewFile(t *testing.T) {
 			file := newFile(tt.path)
 			assert.Equal(t, tt.expected, file.getFileType(), "File type mismatch")
 			assert.Equal(t, tt.path, file.getPath(), "File path mismatch")
+			assert.Equal(t, tt.compression, NewCompressionFactory().DetectCompressionType(tt.path),
+				"Compression mismatch")
 		})
 	}
 }
@@ -782,6 +817,8 @@ John,25,Doe,john@example.com,26`
 func TestFileTypeExtension(t *testing.T) {
 	t.Parallel()
 
+	// extension() answers the format's own suffix. The codec's suffix is not
+	// part of it; see TestFileTypeExtension_WithCompression for the compound.
 	tests := []struct {
 		name     string
 		fileType FileType
@@ -791,39 +828,11 @@ func TestFileTypeExtension(t *testing.T) {
 		{"TSV", FileTypeTSV, ".tsv"},
 		{"LTSV", FileTypeLTSV, ".ltsv"},
 		{"Parquet", FileTypeParquet, ".parquet"},
-		{"CSV GZ", FileTypeCSVGZ, ".csv.gz"},
-		{"TSV BZ2", FileTypeTSVBZ2, ".tsv.bz2"},
-		{"LTSV XZ", FileTypeLTSVXZ, ".ltsv.xz"},
-		{"CSV ZSTD", FileTypeCSVZSTD, ".csv.zst"},
 		{"XLSX", FileTypeXLSX, ".xlsx"},
-		{"XLSX GZ", FileTypeXLSXGZ, ".xlsx.gz"},
-		{"XLSX BZ2", FileTypeXLSXBZ2, ".xlsx.bz2"},
-		{"XLSX XZ", FileTypeXLSXXZ, ".xlsx.xz"},
-		{"XLSX ZSTD", FileTypeXLSXZSTD, ".xlsx.zst"},
-		{"Parquet GZ", FileTypeParquetGZ, ".parquet.gz"},
-		{"Parquet BZ2", FileTypeParquetBZ2, ".parquet.bz2"},
-		{"Parquet XZ", FileTypeParquetXZ, ".parquet.xz"},
-		{"Parquet ZSTD", FileTypeParquetZSTD, ".parquet.zst"},
-		{"CSV ZLIB", FileTypeCSVZLIB, ".csv.z"},
-		{"CSV SNAPPY", FileTypeCSVSNAPPY, ".csv.snappy"},
-		{"CSV S2", FileTypeCSVS2, ".csv.s2"},
-		{"CSV LZ4", FileTypeCSVLZ4, ".csv.lz4"},
-		{"TSV ZLIB", FileTypeTSVZLIB, ".tsv.z"},
-		{"TSV SNAPPY", FileTypeTSVSNAPPY, ".tsv.snappy"},
-		{"TSV S2", FileTypeTSVS2, ".tsv.s2"},
-		{"TSV LZ4", FileTypeTSVLZ4, ".tsv.lz4"},
-		{"LTSV ZLIB", FileTypeLTSVZLIB, ".ltsv.z"},
-		{"LTSV SNAPPY", FileTypeLTSVSNAPPY, ".ltsv.snappy"},
-		{"LTSV S2", FileTypeLTSVS2, ".ltsv.s2"},
-		{"LTSV LZ4", FileTypeLTSVLZ4, ".ltsv.lz4"},
-		{"Parquet ZLIB", FileTypeParquetZLIB, ".parquet.z"},
-		{"Parquet SNAPPY", FileTypeParquetSNAPPY, ".parquet.snappy"},
-		{"Parquet S2", FileTypeParquetS2, ".parquet.s2"},
-		{"Parquet LZ4", FileTypeParquetLZ4, ".parquet.lz4"},
-		{"XLSX ZLIB", FileTypeXLSXZLIB, ".xlsx.z"},
-		{"XLSX SNAPPY", FileTypeXLSXSNAPPY, ".xlsx.snappy"},
-		{"XLSX S2", FileTypeXLSXS2, ".xlsx.s2"},
-		{"XLSX LZ4", FileTypeXLSXLZ4, ".xlsx.lz4"},
+		{"JSON", FileTypeJSON, ".json"},
+		{"JSONL", FileTypeJSONL, ".jsonl"},
+		{FileTypeACH.String(), FileTypeACH, extACH},
+		{FileTypeFedWire.String(), FileTypeFedWire, extFED},
 		{"Unsupported", FileTypeUnsupported, ""},
 	}
 
@@ -834,6 +843,64 @@ func TestFileTypeExtension(t *testing.T) {
 				t.Errorf("FileType.extension() = %v, want %v", got, tt.expected)
 			}
 		})
+	}
+}
+
+// TestFileTypeExtension_WithCompression pins the compound suffix a compressed
+// file carries. It used to be one fused constant per cell of this grid; now it
+// is the format's extension followed by the codec's, and every cell of the
+// cross product still has to come out right.
+func TestFileTypeExtension_WithCompression(t *testing.T) {
+	t.Parallel()
+
+	formats := []struct {
+		fileType FileType
+		ext      string
+	}{
+		{FileTypeCSV, ".csv"},
+		{FileTypeTSV, ".tsv"},
+		{FileTypeLTSV, ".ltsv"},
+		{FileTypeParquet, ".parquet"},
+		{FileTypeXLSX, ".xlsx"},
+		{FileTypeJSON, ".json"},
+		{FileTypeJSONL, ".jsonl"},
+	}
+	codecs := []struct {
+		compression CompressionType
+		ext         string
+	}{
+		{CompressionNone, ""},
+		{CompressionGZ, ".gz"},
+		{CompressionBZ2, ".bz2"},
+		{CompressionXZ, ".xz"},
+		{CompressionZSTD, ".zst"},
+		{CompressionZLIB, ".z"},
+		{CompressionSNAPPY, ".snappy"},
+		{CompressionS2, ".s2"},
+		{CompressionLZ4, ".lz4"},
+	}
+
+	for _, format := range formats {
+		for _, codec := range codecs {
+			t.Run(format.fileType.String()+"_"+codec.compression.String(), func(t *testing.T) {
+				t.Parallel()
+
+				want := format.ext + codec.ext
+				got := format.fileType.extension() + codec.compression.Extension()
+				if got != want {
+					t.Errorf("extension() + Extension() = %q, want %q", got, want)
+				}
+
+				// The same path read back has to answer the pair it was built from.
+				path := "sample" + want
+				if ft := detectFileType(path); ft != format.fileType {
+					t.Errorf("detectFileType(%q) = %v, want %v", path, ft, format.fileType)
+				}
+				if c := NewCompressionFactory().DetectCompressionType(path); c != codec.compression {
+					t.Errorf("DetectCompressionType(%q) = %v, want %v", path, c, codec.compression)
+				}
+			})
+		}
 	}
 }
 
@@ -1161,7 +1228,7 @@ func TestGetFileExtension(t *testing.T) {
 		{FileTypeCSV, ".csv"},
 		{FileTypeTSV, ".tsv"},
 		{FileTypeLTSV, ".ltsv"},
-		{FileTypeCSVGZ, ".csv.gz"},
+		{FileTypeJSON, ".json"},
 		{FileTypeUnsupported, ""},
 	}
 
@@ -1175,55 +1242,16 @@ func TestGetFileExtension(t *testing.T) {
 	}
 }
 
-// TestGetBaseFileType tests the deprecated GetBaseFileType function
-func TestGetBaseFileType(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		fileType FileType
-		expected FileType
-	}{
-		{FileTypeCSV, FileTypeCSV},
-		{FileTypeCSVGZ, FileTypeCSV},
-		{FileTypeCSVBZ2, FileTypeCSV},
-		{FileTypeCSVZLIB, FileTypeCSV},
-		{FileTypeCSVSNAPPY, FileTypeCSV},
-		{FileTypeCSVS2, FileTypeCSV},
-		{FileTypeCSVLZ4, FileTypeCSV},
-		{FileTypeTSV, FileTypeTSV},
-		{FileTypeTSVGZ, FileTypeTSV},
-		{FileTypeTSVZLIB, FileTypeTSV},
-		{FileTypeLTSV, FileTypeLTSV},
-		{FileTypeLTSVXZ, FileTypeLTSV},
-		{FileTypeLTSVSNAPPY, FileTypeLTSV},
-		{FileTypeParquet, FileTypeParquet},
-		{FileTypeParquetLZ4, FileTypeParquet},
-		{FileTypeXLSX, FileTypeXLSX},
-		{FileTypeXLSXS2, FileTypeXLSX},
-		{FileTypeUnsupported, FileTypeUnsupported},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.fileType.extension(), func(t *testing.T) {
-			result := getBaseFileType(tt.fileType)
-			if result != tt.expected {
-				t.Errorf("getBaseFileType(%v) = %v, want %v", tt.fileType, result, tt.expected)
-			}
-		})
-	}
-}
-
 // TestCreateDecompressedReader tests the createDecompressedReader function
 func TestCreateDecompressedReader(t *testing.T) {
 	t.Parallel()
 
-	t.Run("unsupported compression", func(t *testing.T) {
+	t.Run("no compression", func(t *testing.T) {
 		t.Parallel()
 
-		parser := newStreamingParser(FileTypeCSV, "test", 1024)
+		parser := newStreamingParser(FileTypeCSV, CompressionNone, "test", 1024)
 		reader := strings.NewReader("test data")
 
-		// Test with unsupported compression (should return original reader)
 		result, closeFunc, err := parser.createDecompressedReader(reader)
 		if err != nil {
 			t.Errorf("createDecompressedReader should not error for uncompressed data: %v", err)
@@ -1233,8 +1261,14 @@ func TestCreateDecompressedReader(t *testing.T) {
 			t.Error("createDecompressedReader should return original reader for uncompressed data")
 		}
 
-		if closeFunc != nil {
-			t.Error("createDecompressedReader should not return close function for uncompressed data")
+		// CompressionHandler.CreateReader never hands back a nil close function,
+		// so an uncompressed source gets a no-op one rather than nil. Callers can
+		// therefore call it unconditionally.
+		if closeFunc == nil {
+			t.Fatal("createDecompressedReader should return a no-op close function, not nil")
+		}
+		if err := closeFunc(); err != nil {
+			t.Errorf("the no-op close function should not error: %v", err)
 		}
 	})
 
@@ -1252,7 +1286,7 @@ func TestCreateDecompressedReader(t *testing.T) {
 			t.Fatalf("Failed to close gzip writer: %v", err)
 		}
 
-		parser := newStreamingParser(FileTypeCSVGZ, "test", 1024)
+		parser := newStreamingParser(FileTypeCSV, CompressionGZ, "test", 1024)
 		reader := strings.NewReader(buf.String())
 
 		result, closeFunc, err := parser.createDecompressedReader(reader)
@@ -1279,7 +1313,7 @@ func TestCreateDecompressedReader(t *testing.T) {
 	t.Run("invalid gzip data", func(t *testing.T) {
 		t.Parallel()
 
-		parser := newStreamingParser(FileTypeCSVGZ, "test", 1024)
+		parser := newStreamingParser(FileTypeCSV, CompressionGZ, "test", 1024)
 		reader := strings.NewReader("invalid gzip data")
 
 		_, _, err := parser.createDecompressedReader(reader)
@@ -1603,7 +1637,9 @@ func TestConvertXLSXRowsToTable(t *testing.T) {
 	})
 }
 
-// TestDetectFileType tests the detectFileType function with all file type and compression combinations
+// TestDetectFileType pins that every supported extension, compressed or not,
+// resolves to its format. FileType names formats only, so the codec suffix no
+// longer changes the answer — it only has to not break the detection.
 func TestDetectFileType(t *testing.T) {
 	t.Parallel()
 
@@ -1611,116 +1647,91 @@ func TestDetectFileType(t *testing.T) {
 		path     string
 		expected FileType
 	}{
-		// Base types (uncompressed)
 		{"data.csv", FileTypeCSV},
 		{"data.tsv", FileTypeTSV},
 		{"data.ltsv", FileTypeLTSV},
 		{"data.parquet", FileTypeParquet},
-		{"data.xlsx", FileTypeXLSX},
-
-		// CSV with all compression types
-		{"data.csv.gz", FileTypeCSVGZ},
-		{"data.csv.bz2", FileTypeCSVBZ2},
-		{"data.csv.xz", FileTypeCSVXZ},
-		{"data.csv.zst", FileTypeCSVZSTD},
-		{"data.csv.z", FileTypeCSVZLIB},
-		{"data.csv.snappy", FileTypeCSVSNAPPY},
-		{"data.csv.s2", FileTypeCSVS2},
-		{"data.csv.lz4", FileTypeCSVLZ4},
-
-		// TSV with all compression types
-		{"data.tsv.gz", FileTypeTSVGZ},
-		{"data.tsv.bz2", FileTypeTSVBZ2},
-		{"data.tsv.xz", FileTypeTSVXZ},
-		{"data.tsv.zst", FileTypeTSVZSTD},
-		{"data.tsv.z", FileTypeTSVZLIB},
-		{"data.tsv.snappy", FileTypeTSVSNAPPY},
-		{"data.tsv.s2", FileTypeTSVS2},
-		{"data.tsv.lz4", FileTypeTSVLZ4},
-
-		// LTSV with all compression types
-		{"data.ltsv.gz", FileTypeLTSVGZ},
-		{"data.ltsv.bz2", FileTypeLTSVBZ2},
-		{"data.ltsv.xz", FileTypeLTSVXZ},
-		{"data.ltsv.zst", FileTypeLTSVZSTD},
-		{"data.ltsv.z", FileTypeLTSVZLIB},
-		{"data.ltsv.snappy", FileTypeLTSVSNAPPY},
-		{"data.ltsv.s2", FileTypeLTSVS2},
-		{"data.ltsv.lz4", FileTypeLTSVLZ4},
-
-		// Parquet with all compression types
-		{"data.parquet.gz", FileTypeParquetGZ},
-		{"data.parquet.bz2", FileTypeParquetBZ2},
-		{"data.parquet.xz", FileTypeParquetXZ},
-		{"data.parquet.zst", FileTypeParquetZSTD},
-		{"data.parquet.z", FileTypeParquetZLIB},
-		{"data.parquet.snappy", FileTypeParquetSNAPPY},
-		{"data.parquet.s2", FileTypeParquetS2},
-		{"data.parquet.lz4", FileTypeParquetLZ4},
-
-		// XLSX with all compression types
-		{"data.xlsx.gz", FileTypeXLSXGZ},
-		{"data.xlsx.bz2", FileTypeXLSXBZ2},
-		{"data.xlsx.xz", FileTypeXLSXXZ},
-		{"data.xlsx.zst", FileTypeXLSXZSTD},
-		{"data.xlsx.z", FileTypeXLSXZLIB},
-		{"data.xlsx.snappy", FileTypeXLSXSNAPPY},
-		{"data.xlsx.s2", FileTypeXLSXS2},
-		{"data.xlsx.lz4", FileTypeXLSXLZ4},
-
-		// JSON/JSONL types
+		{"data.xlsx", FileTypeXLSX}, // CSV with all compression types
+		{"data.csv.gz", FileTypeCSV},
+		{"data.csv.bz2", FileTypeCSV},
+		{"data.csv.xz", FileTypeCSV},
+		{"data.csv.zst", FileTypeCSV},
+		{"data.csv.z", FileTypeCSV},
+		{"data.csv.snappy", FileTypeCSV},
+		{"data.csv.s2", FileTypeCSV},
+		{"data.csv.lz4", FileTypeCSV}, // TSV with all compression types
+		{"data.tsv.gz", FileTypeTSV},
+		{"data.tsv.bz2", FileTypeTSV},
+		{"data.tsv.xz", FileTypeTSV},
+		{"data.tsv.zst", FileTypeTSV},
+		{"data.tsv.z", FileTypeTSV},
+		{"data.tsv.snappy", FileTypeTSV},
+		{"data.tsv.s2", FileTypeTSV},
+		{"data.tsv.lz4", FileTypeTSV}, // LTSV with all compression types
+		{"data.ltsv.gz", FileTypeLTSV},
+		{"data.ltsv.bz2", FileTypeLTSV},
+		{"data.ltsv.xz", FileTypeLTSV},
+		{"data.ltsv.zst", FileTypeLTSV},
+		{"data.ltsv.z", FileTypeLTSV},
+		{"data.ltsv.snappy", FileTypeLTSV},
+		{"data.ltsv.s2", FileTypeLTSV},
+		{"data.ltsv.lz4", FileTypeLTSV}, // Parquet with all compression types
+		{"data.parquet.gz", FileTypeParquet},
+		{"data.parquet.bz2", FileTypeParquet},
+		{"data.parquet.xz", FileTypeParquet},
+		{"data.parquet.zst", FileTypeParquet},
+		{"data.parquet.z", FileTypeParquet},
+		{"data.parquet.snappy", FileTypeParquet},
+		{"data.parquet.s2", FileTypeParquet},
+		{"data.parquet.lz4", FileTypeParquet}, // XLSX with all compression types
+		{"data.xlsx.gz", FileTypeXLSX},
+		{"data.xlsx.bz2", FileTypeXLSX},
+		{"data.xlsx.xz", FileTypeXLSX},
+		{"data.xlsx.zst", FileTypeXLSX},
+		{"data.xlsx.z", FileTypeXLSX},
+		{"data.xlsx.snappy", FileTypeXLSX},
+		{"data.xlsx.s2", FileTypeXLSX},
+		{"data.xlsx.lz4", FileTypeXLSX}, // JSON/JSONL types
 		{"data.json", FileTypeJSON},
 		{"data.jsonl", FileTypeJSONL},
-		{"data.json.gz", FileTypeJSONGZ},
-		{"data.json.bz2", FileTypeJSONBZ2},
-		{"data.json.xz", FileTypeJSONXZ},
-		{"data.json.zst", FileTypeJSONZSTD},
-		{"data.json.z", FileTypeJSONZLIB},
-		{"data.json.snappy", FileTypeJSONSNAPPY},
-		{"data.json.s2", FileTypeJSONS2},
-		{"data.json.lz4", FileTypeJSONLZ4},
-		{"data.jsonl.gz", FileTypeJSONLGZ},
-		{"data.jsonl.bz2", FileTypeJSONLBZ2},
-		{"data.jsonl.xz", FileTypeJSONLXZ},
-		{"data.jsonl.zst", FileTypeJSONLZSTD},
-		{"data.jsonl.z", FileTypeJSONLZLIB},
-		{"data.jsonl.snappy", FileTypeJSONLSNAPPY},
-		{"data.jsonl.s2", FileTypeJSONLS2},
-		{"data.jsonl.lz4", FileTypeJSONLLZ4},
-
-		// ACH and Fedwire types
+		{"data.json.gz", FileTypeJSON},
+		{"data.json.bz2", FileTypeJSON},
+		{"data.json.xz", FileTypeJSON},
+		{"data.json.zst", FileTypeJSON},
+		{"data.json.z", FileTypeJSON},
+		{"data.json.snappy", FileTypeJSON},
+		{"data.json.s2", FileTypeJSON},
+		{"data.json.lz4", FileTypeJSON},
+		{"data.jsonl.gz", FileTypeJSONL},
+		{"data.jsonl.bz2", FileTypeJSONL},
+		{"data.jsonl.xz", FileTypeJSONL},
+		{"data.jsonl.zst", FileTypeJSONL},
+		{"data.jsonl.z", FileTypeJSONL},
+		{"data.jsonl.snappy", FileTypeJSONL},
+		{"data.jsonl.s2", FileTypeJSONL},
+		{"data.jsonl.lz4", FileTypeJSONL}, // ACH and Fedwire types
 		{"payment.ach", FileTypeACH},
 		{"payment.ACH", FileTypeACH},
 		{"payment.fed", FileTypeFedWire},
 		{"payment.FED", FileTypeFedWire},
 		{".ach", FileTypeUnsupported}, // extension only
 		{".fed", FileTypeUnsupported}, // extension only
-
-		// Unsupported types
 		{"data.txt", FileTypeUnsupported},
 		{"data.xml", FileTypeUnsupported},
 		{"data", FileTypeUnsupported},
-		{"", FileTypeUnsupported},
-
-		// Paths with directories
+		{"", FileTypeUnsupported}, // Paths with directories
 		{"/path/to/data.csv", FileTypeCSV},
-		{"/path/to/data.csv.gz", FileTypeCSVGZ},
-		{"./relative/path/data.tsv.bz2", FileTypeTSVBZ2},
-
-		// Files with multiple dots in name
+		{"/path/to/data.csv.gz", FileTypeCSV},
+		{"./relative/path/data.tsv.bz2", FileTypeTSV}, // Files with multiple dots in name
 		{"my.data.file.csv", FileTypeCSV},
-		{"my.data.file.csv.gz", FileTypeCSVGZ},
-
-		// Edge cases
-		{".csv", FileTypeCSV},            // Hidden file with just extension
-		{".csv.gz", FileTypeCSVGZ},       // Hidden compressed file
-		{"file.gz", FileTypeUnsupported}, // Compression only, no base format
-
-		// Uppercase parser-backed extensions
+		{"my.data.file.csv.gz", FileTypeCSV}, // Edge cases
+		{".csv", FileTypeCSV},                // Hidden file with just extension
+		{".csv.gz", FileTypeCSV},             // Hidden compressed file
+		{"file.gz", FileTypeUnsupported},     // Compression only, no base format
 		{"DATA.CSV", FileTypeCSV},
-		{"DATA.CSV.GZ", FileTypeCSVGZ},
-		{"DATA.JSONL.SNAPPY", FileTypeJSONLSNAPPY},
-		{"DATA.PARQUET.LZ4", FileTypeParquetLZ4},
+		{"DATA.CSV.GZ", FileTypeCSV},
+		{"DATA.JSONL.SNAPPY", FileTypeJSONL},
+		{"DATA.PARQUET.LZ4", FileTypeParquet},
 	}
 
 	for _, tt := range tests {
@@ -1740,66 +1751,22 @@ func TestDetectFileType(t *testing.T) {
 func TestFileTypeString(t *testing.T) {
 	t.Parallel()
 
+	// String() names the format. It never carried a codec suffix of its own —
+	// the "CSV (gzip)" spellings came from the fused constants, and a codec is
+	// now described by CompressionType.String().
 	tests := []struct {
 		fileType FileType
 		expected string
 	}{
-		// Base types
 		{FileTypeCSV, "CSV"},
 		{FileTypeTSV, "TSV"},
 		{FileTypeLTSV, "LTSV"},
 		{FileTypeParquet, "Parquet"},
 		{FileTypeXLSX, "XLSX"},
-
-		// CSV compressed types
-		{FileTypeCSVGZ, "CSV (gzip)"},
-		{FileTypeCSVBZ2, "CSV (bzip2)"},
-		{FileTypeCSVXZ, "CSV (xz)"},
-		{FileTypeCSVZSTD, "CSV (zstd)"},
-		{FileTypeCSVZLIB, "CSV (zlib)"},
-		{FileTypeCSVSNAPPY, "CSV (snappy)"},
-		{FileTypeCSVS2, "CSV (s2)"},
-		{FileTypeCSVLZ4, "CSV (lz4)"},
-
-		// TSV compressed types
-		{FileTypeTSVGZ, "TSV (gzip)"},
-		{FileTypeTSVBZ2, "TSV (bzip2)"},
-		{FileTypeTSVXZ, "TSV (xz)"},
-		{FileTypeTSVZSTD, "TSV (zstd)"},
-		{FileTypeTSVZLIB, "TSV (zlib)"},
-		{FileTypeTSVSNAPPY, "TSV (snappy)"},
-		{FileTypeTSVS2, "TSV (s2)"},
-		{FileTypeTSVLZ4, "TSV (lz4)"},
-
-		// LTSV compressed types
-		{FileTypeLTSVGZ, "LTSV (gzip)"},
-		{FileTypeLTSVBZ2, "LTSV (bzip2)"},
-		{FileTypeLTSVXZ, "LTSV (xz)"},
-		{FileTypeLTSVZSTD, "LTSV (zstd)"},
-		{FileTypeLTSVZLIB, "LTSV (zlib)"},
-		{FileTypeLTSVSNAPPY, "LTSV (snappy)"},
-		{FileTypeLTSVS2, "LTSV (s2)"},
-		{FileTypeLTSVLZ4, "LTSV (lz4)"},
-
-		// Parquet compressed types
-		{FileTypeParquetGZ, "Parquet (gzip)"},
-		{FileTypeParquetBZ2, "Parquet (bzip2)"},
-		{FileTypeParquetXZ, "Parquet (xz)"},
-		{FileTypeParquetZSTD, "Parquet (zstd)"},
-		{FileTypeParquetZLIB, "Parquet (zlib)"},
-		{FileTypeParquetSNAPPY, "Parquet (snappy)"},
-		{FileTypeParquetS2, "Parquet (s2)"},
-		{FileTypeParquetLZ4, "Parquet (lz4)"},
-
-		// XLSX compressed types
-		{FileTypeXLSXGZ, "XLSX (gzip)"},
-		{FileTypeXLSXBZ2, "XLSX (bzip2)"},
-		{FileTypeXLSXXZ, "XLSX (xz)"},
-		{FileTypeXLSXZSTD, "XLSX (zstd)"},
-		{FileTypeXLSXZLIB, "XLSX (zlib)"},
-		{FileTypeXLSXSNAPPY, "XLSX (snappy)"},
-		{FileTypeXLSXS2, "XLSX (s2)"},
-		{FileTypeXLSXLZ4, "XLSX (lz4)"},
+		{FileTypeJSON, "JSON"},
+		{FileTypeJSONL, "JSONL"},
+		{FileTypeACH, "ACH"},
+		{FileTypeFedWire, "FedWire"},
 
 		// Unsupported type
 		{FileTypeUnsupported, "Unsupported"},

--- a/filesql_test.go
+++ b/filesql_test.go
@@ -1316,7 +1316,7 @@ func Test_FileFormatDetection(t *testing.T) {
 		{
 			name:         "Compressed CSV",
 			fileName:     "test.csv.gz",
-			expectedType: FileTypeCSVGZ,
+			expectedType: FileTypeCSV,
 			isSupported:  true,
 		},
 		{
@@ -1354,7 +1354,7 @@ func Test_FileFormatDetection(t *testing.T) {
 			assert.Equal(t, tc.isSupported, isSupportedFile(tc.fileName), "Expected supported=%v, got %v", tc.isSupported, isSupportedFile(tc.fileName))
 
 			// Test type-specific methods
-			switch tc.expectedType.baseType() {
+			switch tc.expectedType {
 			case FileTypeCSV:
 				assert.True(t, file.isCSV(), "isCSV() should return true for CSV file")
 				assert.False(t, file.isTSV() || file.isLTSV(), "Type methods should be exclusive")

--- a/memory_test.go
+++ b/memory_test.go
@@ -507,7 +507,7 @@ func TestStreamingParser_ParseXLSXStream_MemoryOptimized(t *testing.T) {
 		// Create a small test XLSX
 		buf := createTestXLSX(t, 10, 3)
 
-		parser := newStreamingParser(FileTypeXLSX, "test_table", 5)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_table", 5)
 		table, err := parser.parseXLSXStream(buf)
 
 		require.NoError(t, err)
@@ -520,7 +520,7 @@ func TestStreamingParser_ParseXLSXStream_MemoryOptimized(t *testing.T) {
 	t.Run("memory limit enforcement", func(t *testing.T) {
 		t.Parallel()
 		// Create parser with very restrictive memory limit
-		parser := newStreamingParser(FileTypeXLSX, "test_table", 1000)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_table", 1000)
 		parser.memoryLimit = NewMemoryLimit(1) // 1MB limit - very restrictive
 
 		// Create a small XLSX file
@@ -540,7 +540,7 @@ func TestStreamingParser_ParseXLSXStream_MemoryOptimized(t *testing.T) {
 
 	t.Run("memory pool reuse", func(t *testing.T) {
 		t.Parallel()
-		parser := newStreamingParser(FileTypeXLSX, "test_table", 5)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_table", 5)
 
 		// Process multiple XLSX files to test pool reuse
 		for range 3 {
@@ -568,7 +568,7 @@ func TestStreamingParser_ProcessXLSXInChunks_MemoryOptimized(t *testing.T) {
 		// Create XLSX with more rows than chunk size
 		buf := createTestXLSX(t, 25, 3) // 25 rows, 3 columns
 
-		parser := newStreamingParser(FileTypeXLSX, "test_table", 5) // 5 rows per chunk
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_table", 5) // 5 rows per chunk
 
 		var processedChunks int
 		var totalRecords int
@@ -601,7 +601,7 @@ func TestStreamingParser_ProcessXLSXInChunks_MemoryOptimized(t *testing.T) {
 
 		buf := createTestXLSX(t, 20, 3)
 
-		parser := newStreamingParser(FileTypeXLSX, "test_table", 10)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_table", 10)
 		parser.memoryLimit = NewMemoryLimit(5) // Very small limit
 
 		var processedChunks int
@@ -627,7 +627,7 @@ func TestStreamingParser_ProcessXLSXInChunks_MemoryOptimized(t *testing.T) {
 		// Create XLSX with headers only
 		buf := createTestXLSX(t, 0, 3) // 0 data rows
 
-		parser := newStreamingParser(FileTypeXLSX, "test_table", 5)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_table", 5)
 
 		var processedChunks int
 		var lastChunk *tableChunk
@@ -651,7 +651,7 @@ func TestStreamingParser_ProcessXLSXInChunks_MemoryOptimized(t *testing.T) {
 		t.Parallel()
 		buf := createTestXLSX(t, 10, 2)
 
-		parser := newStreamingParser(FileTypeXLSX, "test_table", 5)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_table", 5)
 
 		err := parser.ProcessInChunks(buf, func(_ *tableChunk) error {
 			return assert.AnError // Return an error to test error handling
@@ -667,7 +667,7 @@ func TestStreamingParser_MemoryPoolIntegration(t *testing.T) {
 
 	t.Run("memory pool usage during XLSX processing", func(t *testing.T) {
 		t.Parallel()
-		parser := newStreamingParser(FileTypeXLSX, "test_table", 10)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_table", 10)
 
 		// Verify memory pool is properly initialized
 		assert.NotNil(t, parser.memoryPool, "memory pool should be initialized")
@@ -689,7 +689,7 @@ func TestStreamingParser_MemoryPoolIntegration(t *testing.T) {
 
 	t.Run("memory limit configuration", func(t *testing.T) {
 		t.Parallel()
-		parser := newStreamingParser(FileTypeXLSX, "test_table", 10)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_table", 10)
 
 		// Test memory limit operations
 		assert.True(t, parser.memoryLimit.IsEnabled(), "memory limit should be enabled by default")
@@ -712,7 +712,7 @@ func TestStreamingParser_XLSXErrorHandling(t *testing.T) {
 
 	t.Run("invalid XLSX data", func(t *testing.T) {
 		t.Parallel()
-		parser := newStreamingParser(FileTypeXLSX, "test_table", 10)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_table", 10)
 
 		// Test with invalid XLSX data
 		invalidData := strings.NewReader("not an xlsx file")
@@ -724,7 +724,7 @@ func TestStreamingParser_XLSXErrorHandling(t *testing.T) {
 
 	t.Run("empty reader", func(t *testing.T) {
 		t.Parallel()
-		parser := newStreamingParser(FileTypeXLSX, "test_table", 10)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_table", 10)
 
 		// Test with empty reader
 		emptyReader := strings.NewReader("")
@@ -780,7 +780,7 @@ func BenchmarkStreamingParser_XLSXProcessing(b *testing.B) {
 	testData := createTestData()
 
 	b.Run("parseXLSXStream", func(b *testing.B) {
-		parser := newStreamingParser(FileTypeXLSX, "bench_table", 100)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "bench_table", 100)
 
 		b.ResetTimer()
 		for range b.N {
@@ -795,7 +795,7 @@ func BenchmarkStreamingParser_XLSXProcessing(b *testing.B) {
 	})
 
 	b.Run("processXLSXInChunks", func(b *testing.B) {
-		parser := newStreamingParser(FileTypeXLSX, "bench_table", 100)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "bench_table", 100)
 
 		b.ResetTimer()
 		for range b.N {

--- a/parser_bridge.go
+++ b/parser_bridge.go
@@ -8,70 +8,17 @@ import (
 	"github.com/nao1215/filesql/parser"
 )
 
+// filesqlToParserFileTypes maps a format to the parser's constant for it.
+// Only formats appear here: the parser's compressed constants are folded back
+// to their base by filesqlFileType.
 var filesqlToParserFileTypes = map[FileType]parser.FileType{
-	FileTypeCSV:           parser.CSV,
-	FileTypeTSV:           parser.TSV,
-	FileTypeLTSV:          parser.LTSV,
-	FileTypeParquet:       parser.Parquet,
-	FileTypeXLSX:          parser.XLSX,
-	FileTypeCSVGZ:         parser.CSVGZ,
-	FileTypeTSVGZ:         parser.TSVGZ,
-	FileTypeLTSVGZ:        parser.LTSVGZ,
-	FileTypeParquetGZ:     parser.ParquetGZ,
-	FileTypeCSVBZ2:        parser.CSVBZ2,
-	FileTypeTSVBZ2:        parser.TSVBZ2,
-	FileTypeLTSVBZ2:       parser.LTSVBZ2,
-	FileTypeParquetBZ2:    parser.ParquetBZ2,
-	FileTypeCSVXZ:         parser.CSVXZ,
-	FileTypeTSVXZ:         parser.TSVXZ,
-	FileTypeLTSVXZ:        parser.LTSVXZ,
-	FileTypeParquetXZ:     parser.ParquetXZ,
-	FileTypeCSVZSTD:       parser.CSVZSTD,
-	FileTypeTSVZSTD:       parser.TSVZSTD,
-	FileTypeLTSVZSTD:      parser.LTSVZSTD,
-	FileTypeParquetZSTD:   parser.ParquetZSTD,
-	FileTypeXLSXGZ:        parser.XLSXGZ,
-	FileTypeXLSXBZ2:       parser.XLSXBZ2,
-	FileTypeXLSXXZ:        parser.XLSXXZ,
-	FileTypeXLSXZSTD:      parser.XLSXZSTD,
-	FileTypeCSVZLIB:       parser.CSVZLIB,
-	FileTypeTSVZLIB:       parser.TSVZLIB,
-	FileTypeLTSVZLIB:      parser.LTSVZLIB,
-	FileTypeParquetZLIB:   parser.ParquetZLIB,
-	FileTypeXLSXZLIB:      parser.XLSXZLIB,
-	FileTypeCSVSNAPPY:     parser.CSVSNAPPY,
-	FileTypeTSVSNAPPY:     parser.TSVSNAPPY,
-	FileTypeLTSVSNAPPY:    parser.LTSVSNAPPY,
-	FileTypeParquetSNAPPY: parser.ParquetSNAPPY,
-	FileTypeXLSXSNAPPY:    parser.XLSXSNAPPY,
-	FileTypeCSVS2:         parser.CSVS2,
-	FileTypeTSVS2:         parser.TSVS2,
-	FileTypeLTSVS2:        parser.LTSVS2,
-	FileTypeParquetS2:     parser.ParquetS2,
-	FileTypeXLSXS2:        parser.XLSXS2,
-	FileTypeCSVLZ4:        parser.CSVLZ4,
-	FileTypeTSVLZ4:        parser.TSVLZ4,
-	FileTypeLTSVLZ4:       parser.LTSVLZ4,
-	FileTypeParquetLZ4:    parser.ParquetLZ4,
-	FileTypeXLSXLZ4:       parser.XLSXLZ4,
-	FileTypeJSON:          parser.JSON,
-	FileTypeJSONL:         parser.JSONL,
-	FileTypeJSONGZ:        parser.JSONGZ,
-	FileTypeJSONBZ2:       parser.JSONBZ2,
-	FileTypeJSONXZ:        parser.JSONXZ,
-	FileTypeJSONZSTD:      parser.JSONZSTD,
-	FileTypeJSONZLIB:      parser.JSONZLIB,
-	FileTypeJSONSNAPPY:    parser.JSONSNAPPY,
-	FileTypeJSONS2:        parser.JSONS2,
-	FileTypeJSONLZ4:       parser.JSONLZ4,
-	FileTypeJSONLGZ:       parser.JSONLGZ,
-	FileTypeJSONLBZ2:      parser.JSONLBZ2,
-	FileTypeJSONLXZ:       parser.JSONLXZ,
-	FileTypeJSONLZSTD:     parser.JSONLZSTD,
-	FileTypeJSONLZLIB:     parser.JSONLZLIB,
-	FileTypeJSONLSNAPPY:   parser.JSONLSNAPPY,
-	FileTypeJSONLS2:       parser.JSONLS2,
-	FileTypeJSONLLZ4:      parser.JSONLLZ4,
+	FileTypeCSV:     parser.CSV,
+	FileTypeTSV:     parser.TSV,
+	FileTypeLTSV:    parser.LTSV,
+	FileTypeParquet: parser.Parquet,
+	FileTypeXLSX:    parser.XLSX,
+	FileTypeJSON:    parser.JSON,
+	FileTypeJSONL:   parser.JSONL,
 }
 
 var parserToFilesqlFileTypes = reverseParserFileTypes(filesqlToParserFileTypes)
@@ -93,9 +40,11 @@ func parserFileType(ft FileType) parser.FileType {
 	return parser.Unsupported
 }
 
-// filesqlFileType converts parser.FileType to filesql.FileType.
+// filesqlFileType converts parser.FileType to filesql.FileType, folding any
+// compression the parser's constant carries away: parser.CSVGZ answers
+// FileTypeCSV, because FileType names the format only.
 func filesqlFileType(ft parser.FileType) FileType {
-	if filesqlType, ok := parserToFilesqlFileTypes[ft]; ok {
+	if filesqlType, ok := parserToFilesqlFileTypes[parser.BaseFileType(ft)]; ok {
 		return filesqlType
 	}
 
@@ -121,7 +70,7 @@ func parserColumnType(ct parser.ColumnType) columnType {
 func parseWithParser(reader io.Reader, fileType FileType, tableName string) (*table, error) {
 	// Strip a Unicode BOM (and transcode UTF-16) before the text parser sees it,
 	// matching the streaming path; binary formats keep their raw bytes.
-	if isTextBaseType(fileType.baseType()) {
+	if isTextBaseType(fileType) {
 		reader = decodeTextReader(reader)
 	}
 	result, err := parser.Parse(reader, parserFileType(fileType))

--- a/parser_bridge_test.go
+++ b/parser_bridge_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// fileTypePair is one format and the parser constant that names it. Only
+// formats appear here: FileType no longer has a constant for a codec.
 type fileTypePair struct {
 	name    string
 	filesql FileType
@@ -16,92 +18,86 @@ type fileTypePair struct {
 
 func parserBackedFileTypePairs() []fileTypePair {
 	return []fileTypePair{
-		// Base types
 		{"CSV", FileTypeCSV, parser.CSV},
 		{"TSV", FileTypeTSV, parser.TSV},
 		{"LTSV", FileTypeLTSV, parser.LTSV},
 		{"Parquet", FileTypeParquet, parser.Parquet},
 		{"XLSX", FileTypeXLSX, parser.XLSX},
-
-		// GZ compressed
-		{"CSV GZ", FileTypeCSVGZ, parser.CSVGZ},
-		{"TSV GZ", FileTypeTSVGZ, parser.TSVGZ},
-		{"LTSV GZ", FileTypeLTSVGZ, parser.LTSVGZ},
-		{"Parquet GZ", FileTypeParquetGZ, parser.ParquetGZ},
-		{"XLSX GZ", FileTypeXLSXGZ, parser.XLSXGZ},
-
-		// BZ2 compressed
-		{"CSV BZ2", FileTypeCSVBZ2, parser.CSVBZ2},
-		{"TSV BZ2", FileTypeTSVBZ2, parser.TSVBZ2},
-		{"LTSV BZ2", FileTypeLTSVBZ2, parser.LTSVBZ2},
-		{"Parquet BZ2", FileTypeParquetBZ2, parser.ParquetBZ2},
-		{"XLSX BZ2", FileTypeXLSXBZ2, parser.XLSXBZ2},
-
-		// XZ compressed
-		{"CSV XZ", FileTypeCSVXZ, parser.CSVXZ},
-		{"TSV XZ", FileTypeTSVXZ, parser.TSVXZ},
-		{"LTSV XZ", FileTypeLTSVXZ, parser.LTSVXZ},
-		{"Parquet XZ", FileTypeParquetXZ, parser.ParquetXZ},
-		{"XLSX XZ", FileTypeXLSXXZ, parser.XLSXXZ},
-
-		// ZSTD compressed
-		{"CSV ZSTD", FileTypeCSVZSTD, parser.CSVZSTD},
-		{"TSV ZSTD", FileTypeTSVZSTD, parser.TSVZSTD},
-		{"LTSV ZSTD", FileTypeLTSVZSTD, parser.LTSVZSTD},
-		{"Parquet ZSTD", FileTypeParquetZSTD, parser.ParquetZSTD},
-		{"XLSX ZSTD", FileTypeXLSXZSTD, parser.XLSXZSTD},
-
-		// ZLIB compressed
-		{"CSV ZLIB", FileTypeCSVZLIB, parser.CSVZLIB},
-		{"TSV ZLIB", FileTypeTSVZLIB, parser.TSVZLIB},
-		{"LTSV ZLIB", FileTypeLTSVZLIB, parser.LTSVZLIB},
-		{"Parquet ZLIB", FileTypeParquetZLIB, parser.ParquetZLIB},
-		{"XLSX ZLIB", FileTypeXLSXZLIB, parser.XLSXZLIB},
-
-		// SNAPPY compressed
-		{"CSV SNAPPY", FileTypeCSVSNAPPY, parser.CSVSNAPPY},
-		{"TSV SNAPPY", FileTypeTSVSNAPPY, parser.TSVSNAPPY},
-		{"LTSV SNAPPY", FileTypeLTSVSNAPPY, parser.LTSVSNAPPY},
-		{"Parquet SNAPPY", FileTypeParquetSNAPPY, parser.ParquetSNAPPY},
-		{"XLSX SNAPPY", FileTypeXLSXSNAPPY, parser.XLSXSNAPPY},
-
-		// S2 compressed
-		{"CSV S2", FileTypeCSVS2, parser.CSVS2},
-		{"TSV S2", FileTypeTSVS2, parser.TSVS2},
-		{"LTSV S2", FileTypeLTSVS2, parser.LTSVS2},
-		{"Parquet S2", FileTypeParquetS2, parser.ParquetS2},
-		{"XLSX S2", FileTypeXLSXS2, parser.XLSXS2},
-
-		// LZ4 compressed
-		{"CSV LZ4", FileTypeCSVLZ4, parser.CSVLZ4},
-		{"TSV LZ4", FileTypeTSVLZ4, parser.TSVLZ4},
-		{"LTSV LZ4", FileTypeLTSVLZ4, parser.LTSVLZ4},
-		{"Parquet LZ4", FileTypeParquetLZ4, parser.ParquetLZ4},
-		{"XLSX LZ4", FileTypeXLSXLZ4, parser.XLSXLZ4},
-
-		// JSON base types
 		{"JSON", FileTypeJSON, parser.JSON},
 		{"JSONL", FileTypeJSONL, parser.JSONL},
+	}
+}
 
-		// JSON compressed
-		{"JSON GZ", FileTypeJSONGZ, parser.JSONGZ},
-		{"JSON BZ2", FileTypeJSONBZ2, parser.JSONBZ2},
-		{"JSON XZ", FileTypeJSONXZ, parser.JSONXZ},
-		{"JSON ZSTD", FileTypeJSONZSTD, parser.JSONZSTD},
-		{"JSON ZLIB", FileTypeJSONZLIB, parser.JSONZLIB},
-		{"JSON SNAPPY", FileTypeJSONSNAPPY, parser.JSONSNAPPY},
-		{"JSON S2", FileTypeJSONS2, parser.JSONS2},
-		{"JSON LZ4", FileTypeJSONLZ4, parser.JSONLZ4},
-
-		// JSONL compressed
-		{"JSONL GZ", FileTypeJSONLGZ, parser.JSONLGZ},
-		{"JSONL BZ2", FileTypeJSONLBZ2, parser.JSONLBZ2},
-		{"JSONL XZ", FileTypeJSONLXZ, parser.JSONLXZ},
-		{"JSONL ZSTD", FileTypeJSONLZSTD, parser.JSONLZSTD},
-		{"JSONL ZLIB", FileTypeJSONLZLIB, parser.JSONLZLIB},
-		{"JSONL SNAPPY", FileTypeJSONLSNAPPY, parser.JSONLSNAPPY},
-		{"JSONL S2", FileTypeJSONLS2, parser.JSONLS2},
-		{"JSONL LZ4", FileTypeJSONLLZ4, parser.JSONLLZ4},
+// compressedParserFileTypes lists every fused constant the parser still has,
+// paired with the format it folds to. filesqlFileType has to drop the codec:
+// the bridge is where the two enums stop agreeing, because parser.FileType is
+// the lower level and keeps naming the combination.
+func compressedParserFileTypes() []struct {
+	name    string
+	parser  parser.FileType
+	filesql FileType
+} {
+	return []struct {
+		name    string
+		parser  parser.FileType
+		filesql FileType
+	}{
+		{"CSV GZ", parser.CSVGZ, FileTypeCSV},
+		{"TSV GZ", parser.TSVGZ, FileTypeTSV},
+		{"LTSV GZ", parser.LTSVGZ, FileTypeLTSV},
+		{"Parquet GZ", parser.ParquetGZ, FileTypeParquet},
+		{"XLSX GZ", parser.XLSXGZ, FileTypeXLSX},
+		{"CSV BZ2", parser.CSVBZ2, FileTypeCSV},
+		{"TSV BZ2", parser.TSVBZ2, FileTypeTSV},
+		{"LTSV BZ2", parser.LTSVBZ2, FileTypeLTSV},
+		{"Parquet BZ2", parser.ParquetBZ2, FileTypeParquet},
+		{"XLSX BZ2", parser.XLSXBZ2, FileTypeXLSX},
+		{"CSV XZ", parser.CSVXZ, FileTypeCSV},
+		{"TSV XZ", parser.TSVXZ, FileTypeTSV},
+		{"LTSV XZ", parser.LTSVXZ, FileTypeLTSV},
+		{"Parquet XZ", parser.ParquetXZ, FileTypeParquet},
+		{"XLSX XZ", parser.XLSXXZ, FileTypeXLSX},
+		{"CSV ZSTD", parser.CSVZSTD, FileTypeCSV},
+		{"TSV ZSTD", parser.TSVZSTD, FileTypeTSV},
+		{"LTSV ZSTD", parser.LTSVZSTD, FileTypeLTSV},
+		{"Parquet ZSTD", parser.ParquetZSTD, FileTypeParquet},
+		{"XLSX ZSTD", parser.XLSXZSTD, FileTypeXLSX},
+		{"CSV ZLIB", parser.CSVZLIB, FileTypeCSV},
+		{"TSV ZLIB", parser.TSVZLIB, FileTypeTSV},
+		{"LTSV ZLIB", parser.LTSVZLIB, FileTypeLTSV},
+		{"Parquet ZLIB", parser.ParquetZLIB, FileTypeParquet},
+		{"XLSX ZLIB", parser.XLSXZLIB, FileTypeXLSX},
+		{"CSV SNAPPY", parser.CSVSNAPPY, FileTypeCSV},
+		{"TSV SNAPPY", parser.TSVSNAPPY, FileTypeTSV},
+		{"LTSV SNAPPY", parser.LTSVSNAPPY, FileTypeLTSV},
+		{"Parquet SNAPPY", parser.ParquetSNAPPY, FileTypeParquet},
+		{"XLSX SNAPPY", parser.XLSXSNAPPY, FileTypeXLSX},
+		{"CSV S2", parser.CSVS2, FileTypeCSV},
+		{"TSV S2", parser.TSVS2, FileTypeTSV},
+		{"LTSV S2", parser.LTSVS2, FileTypeLTSV},
+		{"Parquet S2", parser.ParquetS2, FileTypeParquet},
+		{"XLSX S2", parser.XLSXS2, FileTypeXLSX},
+		{"CSV LZ4", parser.CSVLZ4, FileTypeCSV},
+		{"TSV LZ4", parser.TSVLZ4, FileTypeTSV},
+		{"LTSV LZ4", parser.LTSVLZ4, FileTypeLTSV},
+		{"Parquet LZ4", parser.ParquetLZ4, FileTypeParquet},
+		{"XLSX LZ4", parser.XLSXLZ4, FileTypeXLSX},
+		{"JSON GZ", parser.JSONGZ, FileTypeJSON},
+		{"JSON BZ2", parser.JSONBZ2, FileTypeJSON},
+		{"JSON XZ", parser.JSONXZ, FileTypeJSON},
+		{"JSON ZSTD", parser.JSONZSTD, FileTypeJSON},
+		{"JSON ZLIB", parser.JSONZLIB, FileTypeJSON},
+		{"JSON SNAPPY", parser.JSONSNAPPY, FileTypeJSON},
+		{"JSON S2", parser.JSONS2, FileTypeJSON},
+		{"JSON LZ4", parser.JSONLZ4, FileTypeJSON},
+		{"JSONL GZ", parser.JSONLGZ, FileTypeJSONL},
+		{"JSONL BZ2", parser.JSONLBZ2, FileTypeJSONL},
+		{"JSONL XZ", parser.JSONLXZ, FileTypeJSONL},
+		{"JSONL ZSTD", parser.JSONLZSTD, FileTypeJSONL},
+		{"JSONL ZLIB", parser.JSONLZLIB, FileTypeJSONL},
+		{"JSONL SNAPPY", parser.JSONLSNAPPY, FileTypeJSONL},
+		{"JSONL S2", parser.JSONLS2, FileTypeJSONL},
+		{"JSONL LZ4", parser.JSONLLZ4, FileTypeJSONL},
 	}
 }
 
@@ -124,6 +120,26 @@ func TestParserFileType(t *testing.T) {
 		result := parserFileType(FileType(9999))
 		assert.Equal(t, parser.Unsupported, result)
 	})
+
+	// ACH and Fedwire are filesql's own formats; the parser does not handle
+	// them, so the bridge has nothing to hand it.
+	for _, ft := range []FileType{FileTypeACH, FileTypeFedWire} {
+		t.Run(ft.String(), func(t *testing.T) {
+			assert.Equal(t, parser.Unsupported, parserFileType(ft))
+		})
+	}
+}
+
+// TestParserFileType_RoundTrip pins that a format survives the trip through
+// the parser's enum and back.
+func TestParserFileType_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range parserBackedFileTypePairs() {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.filesql, filesqlFileType(parserFileType(tt.filesql)))
+		})
+	}
 }
 
 func TestFilesqlFileType(t *testing.T) {
@@ -145,6 +161,18 @@ func TestFilesqlFileType(t *testing.T) {
 		result := filesqlFileType(parser.FileType(9999))
 		assert.Equal(t, FileTypeUnsupported, result)
 	})
+}
+
+// TestFilesqlFileType_FoldsCompression checks the property the fused map used
+// to state entry by entry: a compressed parser constant answers its format.
+func TestFilesqlFileType_FoldsCompression(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range compressedParserFileTypes() {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.filesql, filesqlFileType(tt.parser))
+		})
+	}
 }
 
 func TestParserColumnType(t *testing.T) {

--- a/prep/alias.go
+++ b/prep/alias.go
@@ -7,84 +7,23 @@ import "github.com/nao1215/filesql/parser"
 type FileType = parser.FileType
 
 // File type constants re-exported from parser for backward compatibility.
+//
+// Only formats are re-exported. The parser's own enum keeps a constant for
+// every format-and-codec combination — it is the lower level, and that is the
+// honest name for what it dispatches on — but mirroring all 56 of them here
+// exposed the cross product a second time under a second spelling. A caller
+// that needs one names it through the parser package directly, and
+// parser.BaseFileType folds it back to a format.
 const (
-	FileTypeCSV         = parser.CSV
-	FileTypeTSV         = parser.TSV
-	FileTypeLTSV        = parser.LTSV
-	FileTypeParquet     = parser.Parquet
-	FileTypeXLSX        = parser.XLSX
-	FileTypeCSVGZ       = parser.CSVGZ
-	FileTypeCSVBZ2      = parser.CSVBZ2
-	FileTypeCSVXZ       = parser.CSVXZ
-	FileTypeCSVZSTD     = parser.CSVZSTD
-	FileTypeTSVGZ       = parser.TSVGZ
-	FileTypeTSVBZ2      = parser.TSVBZ2
-	FileTypeTSVXZ       = parser.TSVXZ
-	FileTypeTSVZSTD     = parser.TSVZSTD
-	FileTypeLTSVGZ      = parser.LTSVGZ
-	FileTypeLTSVBZ2     = parser.LTSVBZ2
-	FileTypeLTSVXZ      = parser.LTSVXZ
-	FileTypeLTSVZSTD    = parser.LTSVZSTD
-	FileTypeParquetGZ   = parser.ParquetGZ
-	FileTypeParquetBZ2  = parser.ParquetBZ2
-	FileTypeParquetXZ   = parser.ParquetXZ
-	FileTypeParquetZSTD = parser.ParquetZSTD
-	FileTypeXLSXGZ      = parser.XLSXGZ
-	FileTypeXLSXBZ2     = parser.XLSXBZ2
-	FileTypeXLSXXZ      = parser.XLSXXZ
-	FileTypeXLSXZSTD    = parser.XLSXZSTD
-
-	// zlib compression formats (v0.2.0+)
-	FileTypeCSVZLIB     = parser.CSVZLIB
-	FileTypeTSVZLIB     = parser.TSVZLIB
-	FileTypeLTSVZLIB    = parser.LTSVZLIB
-	FileTypeParquetZLIB = parser.ParquetZLIB
-	FileTypeXLSXZLIB    = parser.XLSXZLIB
-
-	// snappy compression formats (v0.2.0+)
-	FileTypeCSVSNAPPY     = parser.CSVSNAPPY
-	FileTypeTSVSNAPPY     = parser.TSVSNAPPY
-	FileTypeLTSVSNAPPY    = parser.LTSVSNAPPY
-	FileTypeParquetSNAPPY = parser.ParquetSNAPPY
-	FileTypeXLSXSNAPPY    = parser.XLSXSNAPPY
-
-	// s2 compression formats (v0.2.0+)
-	FileTypeCSVS2     = parser.CSVS2
-	FileTypeTSVS2     = parser.TSVS2
-	FileTypeLTSVS2    = parser.LTSVS2
-	FileTypeParquetS2 = parser.ParquetS2
-	FileTypeXLSXS2    = parser.XLSXS2
-
-	// lz4 compression formats (v0.2.0+)
-	FileTypeCSVLZ4     = parser.CSVLZ4
-	FileTypeTSVLZ4     = parser.TSVLZ4
-	FileTypeLTSVLZ4    = parser.LTSVLZ4
-	FileTypeParquetLZ4 = parser.ParquetLZ4
-	FileTypeXLSXLZ4    = parser.XLSXLZ4
+	FileTypeCSV     = parser.CSV
+	FileTypeTSV     = parser.TSV
+	FileTypeLTSV    = parser.LTSV
+	FileTypeParquet = parser.Parquet
+	FileTypeXLSX    = parser.XLSX
 
 	// JSON/JSONL file types (v0.5.0+)
 	FileTypeJSON  = parser.JSON
 	FileTypeJSONL = parser.JSONL
-
-	// JSON compression formats (v0.5.0+)
-	FileTypeJSONGZ     = parser.JSONGZ
-	FileTypeJSONBZ2    = parser.JSONBZ2
-	FileTypeJSONXZ     = parser.JSONXZ
-	FileTypeJSONZSTD   = parser.JSONZSTD
-	FileTypeJSONZLIB   = parser.JSONZLIB
-	FileTypeJSONSNAPPY = parser.JSONSNAPPY
-	FileTypeJSONS2     = parser.JSONS2
-	FileTypeJSONLZ4    = parser.JSONLZ4
-
-	// JSONL compression formats (v0.5.0+)
-	FileTypeJSONLGZ     = parser.JSONLGZ
-	FileTypeJSONLBZ2    = parser.JSONLBZ2
-	FileTypeJSONLXZ     = parser.JSONLXZ
-	FileTypeJSONLZSTD   = parser.JSONLZSTD
-	FileTypeJSONLZLIB   = parser.JSONLZLIB
-	FileTypeJSONLSNAPPY = parser.JSONLSNAPPY
-	FileTypeJSONLS2     = parser.JSONLS2
-	FileTypeJSONLLZ4    = parser.JSONLLZ4
 
 	FileTypeUnsupported = parser.Unsupported
 )

--- a/stream.go
+++ b/stream.go
@@ -2,9 +2,6 @@ package filesql
 
 import (
 	"bufio"
-	"compress/bzip2"
-	"compress/gzip"
-	"compress/zlib"
 	"context"
 	"encoding/csv"
 	"encoding/json"
@@ -17,11 +14,6 @@ import (
 	"github.com/apache/arrow/go/v18/arrow/array"
 	pqfile "github.com/apache/arrow/go/v18/parquet/file"
 	"github.com/apache/arrow/go/v18/parquet/pqarrow"
-	"github.com/klauspost/compress/s2"
-	"github.com/klauspost/compress/snappy"
-	"github.com/klauspost/compress/zstd"
-	"github.com/pierrec/lz4/v4"
-	"github.com/ulikunitz/xz"
 	"github.com/xuri/excelize/v2"
 )
 
@@ -38,9 +30,10 @@ func handleCloseError(closeFunc func() error) func() {
 // newStreamingParser creates a new streaming parser. The malformed-row policy
 // defaults to MalformedRowStop (the zero value); callers that need another
 // policy set the field after construction.
-func newStreamingParser(fileType FileType, tableName string, chunkSize int) *streamingParser {
+func newStreamingParser(fileType FileType, compression CompressionType, tableName string, chunkSize int) *streamingParser {
 	return &streamingParser{
 		fileType:    fileType,
+		compression: compression,
 		tableName:   tableName,
 		chunkSize:   NewChunkSize(chunkSize),
 		memoryPool:  NewMemoryPool(1024 * 1024), // 1MB default max buffer size
@@ -64,7 +57,7 @@ func (p *streamingParser) parseFromReader(reader io.Reader) (*table, error) {
 	}
 
 	// Parse based on base file type
-	baseType := p.fileType.baseType()
+	baseType := p.fileType
 	if isTextBaseType(baseType) {
 		decompressedReader = decodeTextReader(decompressedReader)
 	}
@@ -88,65 +81,14 @@ func (p *streamingParser) parseFromReader(reader io.Reader) (*table, error) {
 	}
 }
 
-// createDecompressedReader creates appropriate reader based on compression type
+// createDecompressedReader wraps reader with the codec the source was declared
+// to use. The per-format switch this replaced was a second implementation of
+// CompressionHandler.CreateReader, reached through the fused FileType.
+//
+// CompressionNone returns the reader unchanged with a no-op close function,
+// following CreateReader's convention that the close function is never nil.
 func (p *streamingParser) createDecompressedReader(reader io.Reader) (io.Reader, func() error, error) {
-	switch p.fileType {
-	case FileTypeCSVGZ, FileTypeTSVGZ, FileTypeLTSVGZ, FileTypeXLSXGZ, FileTypeParquetGZ,
-		FileTypeJSONGZ, FileTypeJSONLGZ:
-		gzReader, err := gzip.NewReader(reader)
-		if err != nil {
-			return nil, nil, fmt.Errorf("%w: failed to create gzip reader: %s", ErrCompression, err.Error())
-		}
-		return gzReader, gzReader.Close, nil
-
-	case FileTypeCSVBZ2, FileTypeTSVBZ2, FileTypeLTSVBZ2, FileTypeXLSXBZ2, FileTypeParquetBZ2,
-		FileTypeJSONBZ2, FileTypeJSONLBZ2:
-		bz2Reader := bzip2.NewReader(reader)
-		return bz2Reader, nil, nil
-
-	case FileTypeCSVXZ, FileTypeTSVXZ, FileTypeLTSVXZ, FileTypeXLSXXZ, FileTypeParquetXZ,
-		FileTypeJSONXZ, FileTypeJSONLXZ:
-		xzReader, err := xz.NewReader(reader)
-		if err != nil {
-			return nil, nil, fmt.Errorf("%w: failed to create xz reader: %s", ErrCompression, err.Error())
-		}
-		return xzReader, nil, nil
-
-	case FileTypeCSVZSTD, FileTypeTSVZSTD, FileTypeLTSVZSTD, FileTypeXLSXZSTD, FileTypeParquetZSTD,
-		FileTypeJSONZSTD, FileTypeJSONLZSTD:
-		decoder, err := zstd.NewReader(reader)
-		if err != nil {
-			return nil, nil, fmt.Errorf("%w: failed to create zstd reader: %s", ErrCompression, err.Error())
-		}
-		return decoder, func() error { decoder.Close(); return nil }, nil
-
-	case FileTypeCSVZLIB, FileTypeTSVZLIB, FileTypeLTSVZLIB, FileTypeXLSXZLIB, FileTypeParquetZLIB,
-		FileTypeJSONZLIB, FileTypeJSONLZLIB:
-		zlibReader, err := zlib.NewReader(reader)
-		if err != nil {
-			return nil, nil, fmt.Errorf("%w: failed to create zlib reader: %s", ErrCompression, err.Error())
-		}
-		return zlibReader, zlibReader.Close, nil
-
-	case FileTypeCSVSNAPPY, FileTypeTSVSNAPPY, FileTypeLTSVSNAPPY, FileTypeXLSXSNAPPY, FileTypeParquetSNAPPY,
-		FileTypeJSONSNAPPY, FileTypeJSONLSNAPPY:
-		snappyReader := snappy.NewReader(reader)
-		return snappyReader, nil, nil
-
-	case FileTypeCSVS2, FileTypeTSVS2, FileTypeLTSVS2, FileTypeXLSXS2, FileTypeParquetS2,
-		FileTypeJSONS2, FileTypeJSONLS2:
-		s2Reader := s2.NewReader(reader)
-		return s2Reader, nil, nil
-
-	case FileTypeCSVLZ4, FileTypeTSVLZ4, FileTypeLTSVLZ4, FileTypeXLSXLZ4, FileTypeParquetLZ4,
-		FileTypeJSONLZ4, FileTypeJSONLLZ4:
-		lz4Reader := lz4.NewReader(reader)
-		return lz4Reader, nil, nil
-
-	default:
-		// No compression
-		return reader, nil, nil
-	}
+	return NewCompressionHandler(p.compression).CreateReader(reader)
 }
 
 // parseDelimitedStream parses CSV or TSV data from reader using streaming approach
@@ -319,7 +261,7 @@ func (p *streamingParser) ProcessInChunks(reader io.Reader, processor chunkProce
 	}
 
 	// Parse based on base file type
-	baseType := p.fileType.baseType()
+	baseType := p.fileType
 	if isTextBaseType(baseType) {
 		decompressedReader = decodeTextReader(decompressedReader)
 	}

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -153,7 +153,7 @@ func (sp *streamProcessor) streamFileToDatabase(ctx context.Context, db *sql.DB,
 
 	// Create file model to determine type and table name
 	fileModel := newFile(filePath)
-	baseFileType := fileModel.getFileType().baseType()
+	baseFileType := fileModel.getFileType()
 	sp.logger.Debug("detected file type", "path", filePath, "type", baseFileType.String())
 
 	// Create decompressed reader if needed
@@ -183,9 +183,10 @@ func (sp *streamProcessor) streamFileToDatabase(ctx context.Context, db *sql.DB,
 	tableName := sanitizeTableName(tableFromFilePath(filePath))
 	sp.logger.Debug("streaming file to table", "path", filePath, logKeyTable, tableName, "type", baseFileType.String())
 	readerInput := readerInput{
-		reader:    reader, // Use decompressed reader
-		tableName: tableName,
-		fileType:  baseFileType,
+		reader:      reader, // Use decompressed reader
+		tableName:   tableName,
+		fileType:    baseFileType,
+		compression: CompressionNone, // already unwrapped above
 	}
 	return sp.streamReaderToDatabase(ctx, db, readerInput)
 }
@@ -276,7 +277,7 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db *sql.D
 	// When replacing, createTableFromChunk drops the old table before recreating it.
 
 	// Create streaming parser for chunked processing
-	parser := newStreamingParser(input.fileType, input.tableName, sp.chunkSize)
+	parser := newStreamingParser(input.fileType, input.compression, input.tableName, sp.chunkSize)
 	parser.malformedRowPolicy = sp.malformedRowPolicy
 
 	// Initialize the table schema (we need to peek at the first chunk to get headers)
@@ -459,7 +460,7 @@ func (sp *streamProcessor) insertChunkData(ctx context.Context, stmt *sql.Stmt, 
 // createEmptyTable creates an empty table for header-only files
 func (sp *streamProcessor) createEmptyTable(ctx context.Context, db *sql.DB, input readerInput) error {
 	// Parse just the header to get column information
-	tempParser := newStreamingParser(input.fileType, input.tableName, 1)
+	tempParser := newStreamingParser(input.fileType, input.compression, input.tableName, 1)
 	tempParser.malformedRowPolicy = sp.malformedRowPolicy
 	tempTable, err := tempParser.parseFromReader(input.reader)
 	if err != nil {

--- a/stream_test.go
+++ b/stream_test.go
@@ -28,7 +28,7 @@ func TestStreamingParser_ParseFromReader_CSV(t *testing.T) {
 		data := "name,age,city\nAlice,30,Tokyo\nBob,25,Osaka\n"
 		reader := strings.NewReader(data)
 
-		parser := newStreamingParser(FileTypeCSV, "users", 1024)
+		parser := newStreamingParser(FileTypeCSV, CompressionNone, "users", 1024)
 		table, err := parser.parseFromReader(reader)
 		require.NoError(t, err, "ParseFromReader() failed")
 
@@ -49,7 +49,7 @@ func TestStreamingParser_ParseFromReader_CSV(t *testing.T) {
 		t.Parallel()
 		reader := strings.NewReader("")
 
-		parser := newStreamingParser(FileTypeCSV, "empty", 1024)
+		parser := newStreamingParser(FileTypeCSV, CompressionNone, "empty", 1024)
 		_, err := parser.parseFromReader(reader)
 		if err == nil {
 			t.Error("ParseFromReader() should fail for empty data")
@@ -65,7 +65,7 @@ func TestStreamingParser_ParseFromReader_TSV(t *testing.T) {
 		data := "name\tage\tcity\nAlice\t30\tTokyo\nBob\t25\tOsaka\n"
 		reader := strings.NewReader(data)
 
-		parser := newStreamingParser(FileTypeTSV, "users", 1024)
+		parser := newStreamingParser(FileTypeTSV, CompressionNone, "users", 1024)
 		table, err := parser.parseFromReader(reader)
 		require.NoError(t, err, "ParseFromReader() failed")
 
@@ -84,7 +84,7 @@ func TestStreamingParser_ParseFromReader_LTSV(t *testing.T) {
 		data := "name:Alice\tage:30\tcity:Tokyo\nname:Bob\tage:25\tcity:Osaka\n"
 		reader := strings.NewReader(data)
 
-		parser := newStreamingParser(FileTypeLTSV, "users", 1024)
+		parser := newStreamingParser(FileTypeLTSV, CompressionNone, "users", 1024)
 		table, err := parser.parseFromReader(reader)
 		require.NoError(t, err, "ParseFromReader() failed")
 
@@ -100,7 +100,7 @@ func TestStreamingParser_ParseFromReader_LTSV(t *testing.T) {
 		// drop the first, so the parser rejects it. Ref nao1215/sqly#467.
 		reader := strings.NewReader("x:1\tx:2\n")
 
-		parser := newStreamingParser(FileTypeLTSV, "dup", 1024)
+		parser := newStreamingParser(FileTypeLTSV, CompressionNone, "dup", 1024)
 		_, err := parser.parseFromReader(reader)
 		require.Error(t, err, "duplicate LTSV label should be rejected")
 		assert.Contains(t, err.Error(), "duplicate column name")
@@ -110,7 +110,7 @@ func TestStreamingParser_ParseFromReader_LTSV(t *testing.T) {
 		t.Parallel()
 		reader := strings.NewReader("x:1\ty:a\nx:2\ty:b\n")
 
-		parser := newStreamingParser(FileTypeLTSV, "ok", 1024)
+		parser := newStreamingParser(FileTypeLTSV, CompressionNone, "ok", 1024)
 		table, err := parser.parseFromReader(reader)
 		require.NoError(t, err)
 		assert.Len(t, table.getRecords(), 2)
@@ -132,7 +132,7 @@ func TestStreamingParser_ParseFromReader_Compressed(t *testing.T) {
 
 		// Note: This will fail because the data is not actually gzip compressed
 		// but the test demonstrates the compression handling logic
-		parser := newStreamingParser(FileTypeCSV, "users", 1024) // Use uncompressed for now
+		parser := newStreamingParser(FileTypeCSV, CompressionNone, "users", 1024) // Use uncompressed for now
 		table, err := parser.parseFromReader(reader)
 		require.NoError(t, err, "ParseFromReader() failed")
 
@@ -153,10 +153,10 @@ func TestFileType_Extension(t *testing.T) {
 		{FileTypeCSV, ".csv"},
 		{FileTypeTSV, ".tsv"},
 		{FileTypeLTSV, ".ltsv"},
-		{FileTypeCSVGZ, ".csv.gz"},
-		{FileTypeTSVBZ2, ".tsv.bz2"},
-		{FileTypeLTSVXZ, ".ltsv.xz"},
-		{FileTypeCSVZSTD, ".csv.zst"},
+		{FileTypeParquet, ".parquet"},
+		{FileTypeXLSX, ".xlsx"},
+		{FileTypeJSON, ".json"},
+		{FileTypeJSONL, ".jsonl"},
 		{FileTypeUnsupported, ""},
 	}
 
@@ -164,32 +164,6 @@ func TestFileType_Extension(t *testing.T) {
 		t.Run(tt.want, func(t *testing.T) {
 			if got := tt.fileType.extension(); got != tt.want {
 				t.Errorf("FileType.extension() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestFileType_BaseType(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		fileType FileType
-		want     FileType
-	}{
-		{FileTypeCSV, FileTypeCSV},
-		{FileTypeCSVGZ, FileTypeCSV},
-		{FileTypeCSVBZ2, FileTypeCSV},
-		{FileTypeTSV, FileTypeTSV},
-		{FileTypeTSVGZ, FileTypeTSV},
-		{FileTypeLTSV, FileTypeLTSV},
-		{FileTypeLTSVXZ, FileTypeLTSV},
-		{FileTypeUnsupported, FileTypeUnsupported},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.fileType.extension(), func(t *testing.T) {
-			if got := tt.fileType.baseType(); got != tt.want {
-				t.Errorf("FileType.BaseType() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -233,7 +207,7 @@ Charlie,35,London`
 	}
 
 	// Test parseParquetStream
-	parser := newStreamingParser(FileTypeParquet, "test_stream", 1000)
+	parser := newStreamingParser(FileTypeParquet, CompressionNone, "test_stream", 1000)
 	reader := bytes.NewReader(parquetData)
 
 	table, err := parser.parseParquetStream(reader)
@@ -311,7 +285,7 @@ func TestParquetStreamingChunks(t *testing.T) {
 	}
 
 	// Test processParquetInChunks with small chunk size
-	parser := newStreamingParser(FileTypeParquet, "test_chunks", 2) // Process 2 records at a time
+	parser := newStreamingParser(FileTypeParquet, CompressionNone, "test_chunks", 2) // Process 2 records at a time
 	reader := bytes.NewReader(parquetData)
 
 	var totalRecords int
@@ -359,22 +333,49 @@ func TestParquetStreamingChunks(t *testing.T) {
 	t.Logf("Successfully processed %d records in %d chunks", totalRecords, chunkCount)
 }
 
+// TestParquetStreamingCompressed reads a gzipped Parquet file end to end. It
+// used to hand parseParquetStream a string of garbage under a fused
+// FileTypeParquetGZ, which skipped the codec entirely and only proved that
+// garbage is not Parquet.
 func TestParquetStreamingCompressed(t *testing.T) {
 	t.Parallel()
 
-	// Test compressed parquet files (which should not be supported externally)
-	parser := newStreamingParser(FileTypeParquetGZ, "compressed_test", 1000)
+	tempDir := t.TempDir()
+	csvFile := filepath.Join(tempDir, "compressed_test.csv")
+	csvContent := "name,age\nAlice,25\nBob,30\n"
+	require.NoError(t, os.WriteFile(csvFile, []byte(csvContent), 0600))
 
-	// Create some dummy compressed data (this should fail gracefully)
-	compressedData := []byte("dummy compressed parquet data")
-	reader := bytes.NewReader(compressedData)
+	db, err := Open(csvFile)
+	require.NoError(t, err)
+	defer db.Close()
 
-	_, err := parser.parseParquetStream(reader)
-	if err == nil {
-		t.Error("Expected error for compressed parquet data, but got none")
-	}
+	outputDir := filepath.Join(tempDir, "output")
+	require.NoError(t, DumpDatabase(db, outputDir, NewDumpOptions().WithFormat(OutputFormatParquet)))
 
-	t.Logf("Correctly handled compressed parquet error: %v", err)
+	parquetData, err := os.ReadFile(filepath.Join(outputDir, "compressed_test.parquet")) //nolint:gosec
+	require.NoError(t, err)
+
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	_, err = gz.Write(parquetData)
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	parser := newStreamingParser(FileTypeParquet, CompressionGZ, "compressed_test", 1000)
+	table, err := parser.parseFromReader(bytes.NewReader(compressed.Bytes()))
+	require.NoError(t, err, "a gzipped Parquet file should load")
+
+	assert.Equal(t, "compressed_test", table.getName())
+	assert.Equal(t, header{"name", "age"}, table.getHeader())
+	assert.Len(t, table.getRecords(), 2)
+
+	t.Run("truncated gzip is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		parser := newStreamingParser(FileTypeParquet, CompressionGZ, "broken", 1000)
+		_, err := parser.parseFromReader(bytes.NewReader([]byte("not gzip at all")))
+		assert.Error(t, err, "data that is not gzip should not be read as Parquet")
+	})
 }
 
 // TestColumnInferenceAdvanced tests column inference with various data types
@@ -388,7 +389,7 @@ func TestColumnInferenceAdvanced(t *testing.T) {
 		csvData := "num,text,mixed\n123,hello,456\n456.7,world,text\n789,test,123.45\n"
 		reader := strings.NewReader(csvData)
 
-		parser := newStreamingParser(FileTypeCSV, "test_infer", 1024)
+		parser := newStreamingParser(FileTypeCSV, CompressionNone, "test_infer", 1024)
 		table, err := parser.parseFromReader(reader)
 		if err != nil {
 			t.Fatalf("Failed to parse CSV: %v", err)
@@ -410,7 +411,7 @@ func TestColumnInferenceAdvanced(t *testing.T) {
 		csvData := "col1,col2,col3\n123,,456.7\n,world,\ntest,456,789\n"
 		reader := strings.NewReader(csvData)
 
-		parser := newStreamingParser(FileTypeCSV, "test_empty", 1024)
+		parser := newStreamingParser(FileTypeCSV, CompressionNone, "test_empty", 1024)
 		table, err := parser.parseFromReader(reader)
 		if err != nil {
 			t.Fatalf("Failed to parse CSV with empty values: %v", err)
@@ -437,7 +438,7 @@ func TestProcessLTSVInChunks(t *testing.T) {
 		ltsvData := "name:Alice\tage:30\tcity:Tokyo\nname:Bob\tage:25\tcity:Osaka\nname:Charlie\tage:35\tcity:Kyoto\n"
 		reader := strings.NewReader(ltsvData)
 
-		parser := newStreamingParser(FileTypeLTSV, "test_ltsv", 2) // Small chunk size
+		parser := newStreamingParser(FileTypeLTSV, CompressionNone, "test_ltsv", 2) // Small chunk size
 
 		var totalRecords int
 		processor := func(chunk *tableChunk) error {
@@ -462,7 +463,7 @@ func TestProcessLTSVInChunks(t *testing.T) {
 		ltsvData := "name:Alice\tage:30\tcity:Tokyo\nname:Bob\tage:25\n"
 		reader := strings.NewReader(ltsvData)
 
-		parser := newStreamingParser(FileTypeLTSV, "test_patterns", 1024)
+		parser := newStreamingParser(FileTypeLTSV, CompressionNone, "test_patterns", 1024)
 		table, err := parser.parseFromReader(reader)
 		if err != nil {
 			t.Fatalf("Failed to parse LTSV: %v", err)
@@ -485,7 +486,7 @@ func TestProcessLTSVInChunks(t *testing.T) {
 		// large LTSV file cannot silently drop values. Ref nao1215/sqly#467.
 		reader := strings.NewReader("x:1\tx:2\n")
 
-		parser := newStreamingParser(FileTypeLTSV, "dup_chunk", 2)
+		parser := newStreamingParser(FileTypeLTSV, CompressionNone, "dup_chunk", 2)
 		err := parser.ProcessInChunks(reader, func(*tableChunk) error { return nil })
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate column name")
@@ -534,7 +535,7 @@ func TestStreamingParser_ParseFromReader_XLSX(t *testing.T) {
 		_ = f.Close() // Ignore close error in test
 
 		// Parse using streaming parser - should process first sheet only
-		parser := newStreamingParser(FileTypeXLSX, "test_workbook", 1024)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "test_workbook", 1024)
 		table, err := parser.parseFromReader(&buf)
 		require.NoError(t, err, "ParseFromReader() failed")
 
@@ -576,7 +577,7 @@ func TestStreamingParser_ParseFromReader_XLSX(t *testing.T) {
 		}
 		_ = f.Close() // Ignore close error in test
 
-		parser := newStreamingParser(FileTypeXLSX, "empty_workbook", 1024)
+		parser := newStreamingParser(FileTypeXLSX, CompressionNone, "empty_workbook", 1024)
 		_, err := parser.parseFromReader(&buf)
 		if err == nil {
 			t.Error("Expected error for empty XLSX file, got nil")
@@ -600,28 +601,36 @@ func TestStreamingParser_ParseFromReader_XLSX(t *testing.T) {
 			t.Fatal(err)
 		}
 		_ = f.Close() // Ignore close error in test
+		workbook := buf.Bytes()
 
-		// Test with different compression types
-		compressionTypes := []FileType{FileTypeXLSXGZ, FileTypeXLSXBZ2, FileTypeXLSXXZ, FileTypeXLSXZSTD}
+		// The workbook is really compressed with each codec and read back. This
+		// used to hand the parser uncompressed bytes under a compressed FileType
+		// and log whatever happened, so it never established that a compressed
+		// XLSX loads at all. bzip2 is absent because the library has no writer
+		// for it.
+		codecs := []CompressionType{
+			CompressionGZ, CompressionXZ, CompressionZSTD, CompressionZLIB,
+			CompressionSNAPPY, CompressionS2, CompressionLZ4,
+		}
 
-		for _, compType := range compressionTypes {
-			t.Run(compType.extension(), func(t *testing.T) {
-				parser := newStreamingParser(compType, "compressed_workbook", 1024)
+		for _, codec := range codecs {
+			t.Run(codec.String(), func(t *testing.T) {
+				t.Parallel()
 
-				// For compressed types, the parser expects compressed data
-				// But since createDecompressedReader handles the decompression,
-				// we can test with uncompressed data for this unit test
-				table, err := parser.parseFromReader(&buf)
-				if err != nil {
-					t.Logf("Compression type %v failed: %v (expected for some types)", compType, err)
-					// Some compression types might not work in this test setup
-					// This is acceptable for unit testing
-					return
-				}
+				var compressed bytes.Buffer
+				w, closeWriter, err := NewCompressionHandler(codec).CreateWriter(&compressed)
+				require.NoError(t, err, "failed to create %s writer", codec)
+				_, err = w.Write(workbook)
+				require.NoError(t, err, "failed to write workbook through %s", codec)
+				require.NoError(t, closeWriter(), "failed to flush %s writer", codec)
 
-				if table != nil && table.getName() != "compressed_workbook" {
-					t.Errorf("Table name = %s, want compressed_workbook", table.getName())
-				}
+				parser := newStreamingParser(FileTypeXLSX, codec, "compressed_workbook", 1024)
+				table, err := parser.parseFromReader(bytes.NewReader(compressed.Bytes()))
+				require.NoError(t, err, "parseFromReader() failed for %s", codec)
+
+				assert.Equal(t, "compressed_workbook", table.getName(), "Table name mismatch")
+				assert.Equal(t, header{"Test"}, table.getHeader(), "Header mismatch")
+				assert.Equal(t, []Record{{"Data"}}, table.getRecords(), "Records mismatch")
 			})
 		}
 	})
@@ -635,14 +644,19 @@ func TestCreateDecompressedReader_AllCompressionTypes(t *testing.T) {
 	originalData := "name,age,city\nAlice,30,Tokyo\nBob,25,Osaka\n"
 
 	tests := []struct {
-		name      string
-		fileType  FileType
-		compress  func([]byte) ([]byte, error)
-		expectErr bool
+		name     string
+		fileType FileType
+		// compression is the codec the row's compress func produced. FileType no
+		// longer carries it, and a blanket CompressionNone here compiles and then
+		// fails at parse time on the codec's magic bytes.
+		compression CompressionType
+		compress    func([]byte) ([]byte, error)
+		expectErr   bool
 	}{
 		{
-			name:     "gzip compressed CSV",
-			fileType: FileTypeCSVGZ,
+			name:        "gzip compressed CSV",
+			fileType:    FileTypeCSV,
+			compression: CompressionGZ,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := gzip.NewWriter(&buf)
@@ -656,8 +670,9 @@ func TestCreateDecompressedReader_AllCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "zstd compressed CSV",
-			fileType: FileTypeCSVZSTD,
+			name:        "zstd compressed CSV",
+			fileType:    FileTypeCSV,
+			compression: CompressionZSTD,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w, err := zstd.NewWriter(&buf)
@@ -674,8 +689,9 @@ func TestCreateDecompressedReader_AllCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "xz compressed CSV",
-			fileType: FileTypeCSVXZ,
+			name:        "xz compressed CSV",
+			fileType:    FileTypeCSV,
+			compression: CompressionXZ,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w, err := xz.NewWriter(&buf)
@@ -692,8 +708,9 @@ func TestCreateDecompressedReader_AllCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "zlib compressed CSV",
-			fileType: FileTypeCSVZLIB,
+			name:        "zlib compressed CSV",
+			fileType:    FileTypeCSV,
+			compression: CompressionZLIB,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := zlib.NewWriter(&buf)
@@ -707,8 +724,9 @@ func TestCreateDecompressedReader_AllCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "snappy compressed CSV",
-			fileType: FileTypeCSVSNAPPY,
+			name:        "snappy compressed CSV",
+			fileType:    FileTypeCSV,
+			compression: CompressionSNAPPY,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := snappy.NewBufferedWriter(&buf)
@@ -722,8 +740,9 @@ func TestCreateDecompressedReader_AllCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "s2 compressed CSV",
-			fileType: FileTypeCSVS2,
+			name:        "s2 compressed CSV",
+			fileType:    FileTypeCSV,
+			compression: CompressionS2,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := s2.NewWriter(&buf)
@@ -737,8 +756,9 @@ func TestCreateDecompressedReader_AllCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "lz4 compressed CSV",
-			fileType: FileTypeCSVLZ4,
+			name:        "lz4 compressed CSV",
+			fileType:    FileTypeCSV,
+			compression: CompressionLZ4,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := lz4.NewWriter(&buf)
@@ -767,7 +787,7 @@ func TestCreateDecompressedReader_AllCompressionTypes(t *testing.T) {
 			compressedData, err := tt.compress([]byte(originalData))
 			require.NoError(t, err, "Failed to compress data")
 
-			parser := newStreamingParser(tt.fileType, "test", 1024)
+			parser := newStreamingParser(tt.fileType, tt.compression, "test", 1024)
 			reader := bytes.NewReader(compressedData)
 
 			table, err := parser.parseFromReader(reader)
@@ -779,13 +799,15 @@ func TestCreateDecompressedReader_AllCompressionTypes(t *testing.T) {
 			require.NoError(t, err, "parseFromReader() failed")
 			assert.Equal(t, "test", table.getName(), "Table name mismatch")
 
-			records := table.getRecords()
-			assert.Len(t, records, 2, "Records length mismatch")
-
-			// Verify first record
-			if len(records) > 0 && len(records[0]) > 0 {
-				assert.Equal(t, "Alice", records[0][0], "First record name mismatch")
-			}
+			// The header is checked as well as the rows. Snappy and s2 leave short
+			// incompressible input nearly verbatim after their frame magic, so a
+			// row that names the wrong codec still yields two plausible-looking
+			// records — only the header carries the corruption.
+			assert.Equal(t, header{"name", "age", "city"}, table.getHeader(), "Header mismatch")
+			assert.Equal(t, []Record{
+				{"Alice", "30", "Tokyo"},
+				{"Bob", "25", "Osaka"},
+			}, table.getRecords(), "Records mismatch")
 		})
 	}
 }
@@ -799,11 +821,14 @@ func TestCreateDecompressedReader_TSVCompressionTypes(t *testing.T) {
 	tests := []struct {
 		name     string
 		fileType FileType
-		compress func([]byte) ([]byte, error)
+		// compression is the codec the row's compress func produced.
+		compression CompressionType
+		compress    func([]byte) ([]byte, error)
 	}{
 		{
-			name:     "zlib compressed TSV",
-			fileType: FileTypeTSVZLIB,
+			name:        "zlib compressed TSV",
+			fileType:    FileTypeTSV,
+			compression: CompressionZLIB,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := zlib.NewWriter(&buf)
@@ -817,8 +842,9 @@ func TestCreateDecompressedReader_TSVCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "snappy compressed TSV",
-			fileType: FileTypeTSVSNAPPY,
+			name:        "snappy compressed TSV",
+			fileType:    FileTypeTSV,
+			compression: CompressionSNAPPY,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := snappy.NewBufferedWriter(&buf)
@@ -832,8 +858,9 @@ func TestCreateDecompressedReader_TSVCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "s2 compressed TSV",
-			fileType: FileTypeTSVS2,
+			name:        "s2 compressed TSV",
+			fileType:    FileTypeTSV,
+			compression: CompressionS2,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := s2.NewWriter(&buf)
@@ -847,8 +874,9 @@ func TestCreateDecompressedReader_TSVCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "lz4 compressed TSV",
-			fileType: FileTypeTSVLZ4,
+			name:        "lz4 compressed TSV",
+			fileType:    FileTypeTSV,
+			compression: CompressionLZ4,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := lz4.NewWriter(&buf)
@@ -870,7 +898,7 @@ func TestCreateDecompressedReader_TSVCompressionTypes(t *testing.T) {
 			compressedData, err := tt.compress([]byte(originalData))
 			require.NoError(t, err, "Failed to compress data")
 
-			parser := newStreamingParser(tt.fileType, "test_tsv", 1024)
+			parser := newStreamingParser(tt.fileType, tt.compression, "test_tsv", 1024)
 			reader := bytes.NewReader(compressedData)
 
 			table, err := parser.parseFromReader(reader)
@@ -878,8 +906,10 @@ func TestCreateDecompressedReader_TSVCompressionTypes(t *testing.T) {
 
 			assert.Equal(t, "test_tsv", table.getName(), "Table name mismatch")
 
-			records := table.getRecords()
-			assert.Len(t, records, 1, "Records length mismatch")
+			// The header is checked too; see the CSV table for why the rows alone
+			// do not pin the codec.
+			assert.Equal(t, header{"name", "age", "city"}, table.getHeader(), "Header mismatch")
+			assert.Equal(t, []Record{{"Alice", "30", "Tokyo"}}, table.getRecords(), "Records mismatch")
 		})
 	}
 }
@@ -893,11 +923,14 @@ func TestCreateDecompressedReader_LTSVCompressionTypes(t *testing.T) {
 	tests := []struct {
 		name     string
 		fileType FileType
-		compress func([]byte) ([]byte, error)
+		// compression is the codec the row's compress func produced.
+		compression CompressionType
+		compress    func([]byte) ([]byte, error)
 	}{
 		{
-			name:     "zlib compressed LTSV",
-			fileType: FileTypeLTSVZLIB,
+			name:        "zlib compressed LTSV",
+			fileType:    FileTypeLTSV,
+			compression: CompressionZLIB,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := zlib.NewWriter(&buf)
@@ -911,8 +944,9 @@ func TestCreateDecompressedReader_LTSVCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "snappy compressed LTSV",
-			fileType: FileTypeLTSVSNAPPY,
+			name:        "snappy compressed LTSV",
+			fileType:    FileTypeLTSV,
+			compression: CompressionSNAPPY,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := snappy.NewBufferedWriter(&buf)
@@ -926,8 +960,9 @@ func TestCreateDecompressedReader_LTSVCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "s2 compressed LTSV",
-			fileType: FileTypeLTSVS2,
+			name:        "s2 compressed LTSV",
+			fileType:    FileTypeLTSV,
+			compression: CompressionS2,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := s2.NewWriter(&buf)
@@ -941,8 +976,9 @@ func TestCreateDecompressedReader_LTSVCompressionTypes(t *testing.T) {
 			},
 		},
 		{
-			name:     "lz4 compressed LTSV",
-			fileType: FileTypeLTSVLZ4,
+			name:        "lz4 compressed LTSV",
+			fileType:    FileTypeLTSV,
+			compression: CompressionLZ4,
 			compress: func(data []byte) ([]byte, error) {
 				var buf bytes.Buffer
 				w := lz4.NewWriter(&buf)
@@ -964,7 +1000,7 @@ func TestCreateDecompressedReader_LTSVCompressionTypes(t *testing.T) {
 			compressedData, err := tt.compress([]byte(originalData))
 			require.NoError(t, err, "Failed to compress data")
 
-			parser := newStreamingParser(tt.fileType, "test_ltsv", 1024)
+			parser := newStreamingParser(tt.fileType, tt.compression, "test_ltsv", 1024)
 			reader := bytes.NewReader(compressedData)
 
 			table, err := parser.parseFromReader(reader)
@@ -972,8 +1008,13 @@ func TestCreateDecompressedReader_LTSVCompressionTypes(t *testing.T) {
 
 			assert.Equal(t, "test_ltsv", table.getName(), "Table name mismatch")
 
-			records := table.getRecords()
-			assert.Len(t, records, 2, "Records length mismatch")
+			// The labels are checked too; see the CSV table for why the rows alone
+			// do not pin the codec.
+			assert.Equal(t, header{"name", "age", "city"}, table.getHeader(), "Header mismatch")
+			assert.Equal(t, []Record{
+				{"Alice", "30", "Tokyo"},
+				{"Bob", "25", "Osaka"},
+			}, table.getRecords(), "Records mismatch")
 		})
 	}
 }
@@ -985,20 +1026,21 @@ func TestCreateDecompressedReader_InvalidData(t *testing.T) {
 	invalidData := []byte("this is not valid compressed data")
 
 	tests := []struct {
-		name     string
-		fileType FileType
+		name        string
+		fileType    FileType
+		compression CompressionType
 	}{
-		{"invalid gzip", FileTypeCSVGZ},
-		{"invalid zstd", FileTypeCSVZSTD},
-		{"invalid xz", FileTypeCSVXZ},
-		{"invalid zlib", FileTypeCSVZLIB},
+		{"invalid gzip", FileTypeCSV, CompressionGZ},
+		{"invalid zstd", FileTypeCSV, CompressionZSTD},
+		{"invalid xz", FileTypeCSV, CompressionXZ},
+		{"invalid zlib", FileTypeCSV, CompressionZLIB},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			parser := newStreamingParser(tt.fileType, "test", 1024)
+			parser := newStreamingParser(tt.fileType, tt.compression, "test", 1024)
 			reader := bytes.NewReader(invalidData)
 
 			_, err := parser.parseFromReader(reader)
@@ -1047,7 +1089,7 @@ func TestHandleCloseError(t *testing.T) {
 func TestStreamingParser_ParseFromReader_UnsupportedFormat(t *testing.T) {
 	t.Parallel()
 
-	parser := newStreamingParser(FileTypeUnsupported, "test", 1024)
+	parser := newStreamingParser(FileTypeUnsupported, CompressionNone, "test", 1024)
 	reader := strings.NewReader("test data")
 
 	_, err := parser.parseFromReader(reader)
@@ -1058,7 +1100,7 @@ func TestStreamingParser_ParseFromReader_UnsupportedFormat(t *testing.T) {
 func TestStreamingParser_ProcessInChunks_UnsupportedFormat(t *testing.T) {
 	t.Parallel()
 
-	parser := newStreamingParser(FileTypeUnsupported, "test", 1024)
+	parser := newStreamingParser(FileTypeUnsupported, CompressionNone, "test", 1024)
 	reader := strings.NewReader("test data")
 
 	err := parser.ProcessInChunks(reader, func(_ *tableChunk) error {
@@ -1076,7 +1118,7 @@ func TestParseJSONStream(t *testing.T) {
 
 		input := `[{"name":"Alice","age":30},{"name":"Bob","age":25}]`
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSON, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", DefaultRowsPerChunk)
 
 		result, err := parser.parseJSONStream(reader)
 
@@ -1092,7 +1134,7 @@ func TestParseJSONStream(t *testing.T) {
 
 		input := `{"name":"Alice","age":30}`
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSON, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", DefaultRowsPerChunk)
 
 		result, err := parser.parseJSONStream(reader)
 
@@ -1107,7 +1149,7 @@ func TestParseJSONStream(t *testing.T) {
 
 		input := `[{"id":1,"address":{"city":"Tokyo","country":"Japan"},"tags":["dev","go"]}]`
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSON, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", DefaultRowsPerChunk)
 
 		result, err := parser.parseJSONStream(reader)
 
@@ -1128,7 +1170,7 @@ func TestParseJSONStream(t *testing.T) {
 
 		input := `[{"name":"Alice"}]`
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSON, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", DefaultRowsPerChunk)
 
 		result, err := parser.parseJSONStream(reader)
 
@@ -1140,7 +1182,7 @@ func TestParseJSONStream(t *testing.T) {
 		t.Parallel()
 
 		reader := strings.NewReader("")
-		parser := newStreamingParser(FileTypeJSON, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", DefaultRowsPerChunk)
 
 		_, err := parser.parseJSONStream(reader)
 
@@ -1152,7 +1194,7 @@ func TestParseJSONStream(t *testing.T) {
 		t.Parallel()
 
 		reader := strings.NewReader("[]")
-		parser := newStreamingParser(FileTypeJSON, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", DefaultRowsPerChunk)
 
 		_, err := parser.parseJSONStream(reader)
 
@@ -1164,7 +1206,7 @@ func TestParseJSONStream(t *testing.T) {
 		t.Parallel()
 
 		reader := strings.NewReader("{invalid json}")
-		parser := newStreamingParser(FileTypeJSON, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", DefaultRowsPerChunk)
 
 		_, err := parser.parseJSONStream(reader)
 
@@ -1181,7 +1223,7 @@ func TestParseJSONLStream(t *testing.T) {
 
 		input := "{\"name\":\"Alice\",\"age\":30}\n{\"name\":\"Bob\",\"age\":25}\n{\"name\":\"Charlie\",\"age\":35}"
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSONL, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionNone, "test_jsonl", DefaultRowsPerChunk)
 
 		result, err := parser.parseJSONLStream(reader)
 
@@ -1198,7 +1240,7 @@ func TestParseJSONLStream(t *testing.T) {
 
 		input := "{\"name\":\"Alice\"}\n\n{\"name\":\"Bob\"}\n\n"
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSONL, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionNone, "test_jsonl", DefaultRowsPerChunk)
 
 		result, err := parser.parseJSONLStream(reader)
 
@@ -1211,7 +1253,7 @@ func TestParseJSONLStream(t *testing.T) {
 
 		input := `{"id":1,"address":{"city":"Tokyo"},"tags":["dev","go"]}`
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSONL, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionNone, "test_jsonl", DefaultRowsPerChunk)
 
 		result, err := parser.parseJSONLStream(reader)
 
@@ -1229,7 +1271,7 @@ func TestParseJSONLStream(t *testing.T) {
 
 		input := `{"name":"Alice"}`
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSONL, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionNone, "test_jsonl", DefaultRowsPerChunk)
 
 		result, err := parser.parseJSONLStream(reader)
 
@@ -1241,7 +1283,7 @@ func TestParseJSONLStream(t *testing.T) {
 		t.Parallel()
 
 		reader := strings.NewReader("")
-		parser := newStreamingParser(FileTypeJSONL, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionNone, "test_jsonl", DefaultRowsPerChunk)
 
 		_, err := parser.parseJSONLStream(reader)
 
@@ -1254,7 +1296,7 @@ func TestParseJSONLStream(t *testing.T) {
 
 		input := "{\"name\":\"Alice\"}\nnot valid json\n{\"name\":\"Bob\"}"
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSONL, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionNone, "test_jsonl", DefaultRowsPerChunk)
 
 		_, err := parser.parseJSONLStream(reader)
 
@@ -1269,7 +1311,7 @@ func TestParseJSONLStream(t *testing.T) {
 		line := `{"big":"` + bigValue + `"}`
 		input := line + "\n" + `{"small":"ok"}`
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSONL, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionNone, "test_jsonl", DefaultRowsPerChunk)
 
 		result, err := parser.parseJSONLStream(reader)
 
@@ -1288,7 +1330,7 @@ func TestProcessJSONInChunks(t *testing.T) {
 
 		input := `[{"name":"Alice"},{"name":"Bob"},{"name":"Charlie"}]`
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSON, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", DefaultRowsPerChunk)
 
 		var chunks []*tableChunk
 		err := parser.processJSONInChunks(reader, func(chunk *tableChunk) error {
@@ -1306,7 +1348,7 @@ func TestProcessJSONInChunks(t *testing.T) {
 
 		input := `[{"i":1},{"i":2},{"i":3},{"i":4},{"i":5}]`
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSON, "test_json", 2) // chunk size = 2
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", 2) // chunk size = 2
 
 		var chunks []*tableChunk
 		err := parser.processJSONInChunks(reader, func(chunk *tableChunk) error {
@@ -1333,7 +1375,7 @@ func TestProcessJSONInChunks(t *testing.T) {
 
 		input := `{"name":"Alice"}`
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSON, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", DefaultRowsPerChunk)
 
 		var chunks []*tableChunk
 		err := parser.processJSONInChunks(reader, func(chunk *tableChunk) error {
@@ -1350,7 +1392,7 @@ func TestProcessJSONInChunks(t *testing.T) {
 		t.Parallel()
 
 		reader := strings.NewReader("")
-		parser := newStreamingParser(FileTypeJSON, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", DefaultRowsPerChunk)
 
 		err := parser.processJSONInChunks(reader, func(_ *tableChunk) error {
 			return nil
@@ -1365,7 +1407,7 @@ func TestProcessJSONInChunks(t *testing.T) {
 
 		input := `[{"a":1}] garbage`
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSON, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionNone, "test_json", DefaultRowsPerChunk)
 
 		err := parser.processJSONInChunks(reader, func(_ *tableChunk) error {
 			return nil
@@ -1384,7 +1426,7 @@ func TestProcessJSONLInChunks(t *testing.T) {
 
 		input := "{\"name\":\"Alice\"}\n{\"name\":\"Bob\"}\n{\"name\":\"Charlie\"}"
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSONL, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionNone, "test_jsonl", DefaultRowsPerChunk)
 
 		var chunks []*tableChunk
 		err := parser.processJSONLInChunks(reader, func(chunk *tableChunk) error {
@@ -1402,7 +1444,7 @@ func TestProcessJSONLInChunks(t *testing.T) {
 
 		input := "{\"i\":1}\n{\"i\":2}\n{\"i\":3}\n{\"i\":4}\n{\"i\":5}"
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSONL, "test_jsonl", 2) // chunk size = 2
+		parser := newStreamingParser(FileTypeJSONL, CompressionNone, "test_jsonl", 2) // chunk size = 2
 
 		var chunks []*tableChunk
 		err := parser.processJSONLInChunks(reader, func(chunk *tableChunk) error {
@@ -1427,7 +1469,7 @@ func TestProcessJSONLInChunks(t *testing.T) {
 		t.Parallel()
 
 		reader := strings.NewReader("")
-		parser := newStreamingParser(FileTypeJSONL, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionNone, "test_jsonl", DefaultRowsPerChunk)
 
 		err := parser.processJSONLInChunks(reader, func(_ *tableChunk) error {
 			return nil
@@ -1442,7 +1484,7 @@ func TestProcessJSONLInChunks(t *testing.T) {
 
 		input := "{\"name\":\"Alice\"}\nnot valid json\n{\"name\":\"Bob\"}"
 		reader := strings.NewReader(input)
-		parser := newStreamingParser(FileTypeJSONL, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionNone, "test_jsonl", DefaultRowsPerChunk)
 
 		err := parser.processJSONLInChunks(reader, func(_ *tableChunk) error {
 			return nil
@@ -1496,7 +1538,7 @@ func TestStreamingParser_ParseFromReader_CompressedJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, gw.Close())
 
-		parser := newStreamingParser(FileTypeJSONGZ, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionGZ, "test_json", DefaultRowsPerChunk)
 		result, err := parser.parseFromReader(&buf)
 
 		require.NoError(t, err)
@@ -1513,7 +1555,7 @@ func TestStreamingParser_ParseFromReader_CompressedJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, gw.Close())
 
-		parser := newStreamingParser(FileTypeJSONLGZ, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionGZ, "test_jsonl", DefaultRowsPerChunk)
 		result, err := parser.parseFromReader(&buf)
 
 		require.NoError(t, err)
@@ -1531,7 +1573,7 @@ func TestStreamingParser_ParseFromReader_CompressedJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, enc.Close())
 
-		parser := newStreamingParser(FileTypeJSONZSTD, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionZSTD, "test_json", DefaultRowsPerChunk)
 		result, err := parser.parseFromReader(&buf)
 
 		require.NoError(t, err)
@@ -1548,7 +1590,7 @@ func TestStreamingParser_ParseFromReader_CompressedJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, enc.Close())
 
-		parser := newStreamingParser(FileTypeJSONLZSTD, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionZSTD, "test_jsonl", DefaultRowsPerChunk)
 		result, err := parser.parseFromReader(&buf)
 
 		require.NoError(t, err)
@@ -1564,7 +1606,7 @@ func TestStreamingParser_ParseFromReader_CompressedJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, sw.Close())
 
-		parser := newStreamingParser(FileTypeJSONSNAPPY, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionSNAPPY, "test_json", DefaultRowsPerChunk)
 		result, err := parser.parseFromReader(&buf)
 
 		require.NoError(t, err)
@@ -1580,7 +1622,7 @@ func TestStreamingParser_ParseFromReader_CompressedJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, sw.Close())
 
-		parser := newStreamingParser(FileTypeJSONLS2, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionS2, "test_jsonl", DefaultRowsPerChunk)
 		result, err := parser.parseFromReader(&buf)
 
 		require.NoError(t, err)
@@ -1596,7 +1638,7 @@ func TestStreamingParser_ParseFromReader_CompressedJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, lw.Close())
 
-		parser := newStreamingParser(FileTypeJSONLZ4, "test_json", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSON, CompressionLZ4, "test_json", DefaultRowsPerChunk)
 		result, err := parser.parseFromReader(&buf)
 
 		require.NoError(t, err)
@@ -1612,7 +1654,7 @@ func TestStreamingParser_ParseFromReader_CompressedJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, zw.Close())
 
-		parser := newStreamingParser(FileTypeJSONLZLIB, "test_jsonl", DefaultRowsPerChunk)
+		parser := newStreamingParser(FileTypeJSONL, CompressionZLIB, "test_jsonl", DefaultRowsPerChunk)
 		result, err := parser.parseFromReader(&buf)
 
 		require.NoError(t, err)
@@ -1634,7 +1676,7 @@ func TestStreamingParser_ProcessInChunks_CompressedJSON(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, gw.Close())
 
-		parser := newStreamingParser(FileTypeJSONGZ, "test_json", 2)
+		parser := newStreamingParser(FileTypeJSON, CompressionGZ, "test_json", 2)
 
 		var chunks []*tableChunk
 		err = parser.ProcessInChunks(&buf, func(chunk *tableChunk) error {

--- a/validator.go
+++ b/validator.go
@@ -55,7 +55,7 @@ func (v *validator) validateReader(reader any, tableName string, fileType FileTy
 	// For specific readers where we can safely peek without consuming, validate empty content
 	// This provides format-specific error messages at Build time
 	if stringReader, ok := reader.(*strings.Reader); ok && stringReader.Len() == 0 {
-		switch fileType.baseType() {
+		switch fileType {
 		case FileTypeCSV:
 			return fmt.Errorf("%w: empty CSV data", ErrEmptyData)
 		case FileTypeTSV:


### PR DESCRIPTION
Closes #208.

## What

`FileType` fused two independent things: the input format and the codec wrapping it. That produced the cross product, so **56 of its 65 constants named a combination rather than a format**. They were the single largest part of this package's public API — 314 exported symbols in the root package, and these were 56 of them.

The naming was also ambiguous where the two axes collided: `FileTypeJSONLZ4` was lz4-compressed **JSON**, while `FileTypeJSONLLZ4` was lz4-compressed **JSONL**. One `L` apart, and nothing in the name said which reading was right.

Only one caller needed them: `AddReader`, because an `io.Reader` carries no path and nothing can be inferred from an extension. Every other path already ignored them — `stream_processor.go` passes the base format and a reader it has already decompressed, and `parser.BaseFileType` exists precisely to fold a fused constant back to its format.

## Design

`AddReader` takes functional options, which is non-breaking:

```go
gz, _ := os.Open("users.csv.gz")
builder.AddReader(gz, "users", filesql.FileTypeCSV, filesql.WithCompression(filesql.CompressionGZ))
```

The existing three-argument call keeps compiling and behaving as before, so no README example or user code reading uncompressed bytes changes. The option pattern was chosen over a fourth positional parameter because it is non-breaking, and over an `AddReaderWithCompression` sibling because the next per-source setting — a custom delimiter, on the v1.0.0 roadmap (#28) — then has somewhere to go without another method.

## Result

- `FileType` has **10 constants instead of 65**.
- `stream.go`'s `createDecompressedReader` is one line: `return NewCompressionHandler(p.compression).CreateReader(reader)`. It was 70 lines of eight arms naming seven formats each — a second implementation of what `CompressionHandler.CreateReader` already did.
- `parser_bridge.go`'s `filesqlToParserFileTypes` has 7 entries instead of 65, and `filesqlFileType` folds compression away with `parser.BaseFileType`.
- `FileType.extension()` returns the format's extension only; the codec's suffix comes from `CompressionType.Extension()`.
- `FileType.baseType()` and the deprecated `getBaseFileType` wrapper are gone — every `FileType` is a base type.
- `file.toTable()` reads through `f.openReader()`, because the parser is now handed bytes that are already the format.

One contract change is deliberate: `createDecompressedReader` for an uncompressed source returns a **non-nil no-op** close function, because that is `CompressionHandler.CreateReader`'s convention. The old switch returned `nil`. `TestCreateDecompressedReader` now pins the new behavior and says why.

## Tests

The 259 references in `*_test.go` were not mechanical.

- **`TestParserFileType` was redesigned, not renamed.** It asserted the fused map entry by entry. It is now a round trip over the seven formats plus `TestFilesqlFileType_FoldsCompression`, a table of all 56 compressed parser constants checking that each folds to its format — the property the map used to state one row at a time.
- **The compression tables carry their codec per row.** `TestCreateDecompressedReader_{All,TSV,LTSV}CompressionTypes`, the JSON/JSONL compressed tests, and `TestCreateDecompressedReader_InvalidData` each build compressed bytes and previously named the codec through the `FileType`. A blanket `CompressionNone` compiles and then fails at parse time with `invalid character '\x1f'`, so each row was threaded individually.
- **Those tables now assert the header, not just the rows.** Verified by setting every row to `CompressionNone`: with the old assertions, the snappy and s2 rows still **passed**, because both leave short incompressible input nearly verbatim after their frame magic — only the header carried the corruption. With the header asserted, all 15 compressed rows fail under that mutation and only the genuinely-uncompressed row passes.
- **`TestFileTypeExtension_WithCompression` is new**, walking the full 7x9 grid: `format.extension() + codec.Extension()` gives the compound suffix, and that path detects back to the same pair.
- **The XLSX and Parquet "compressed" tests were fiction.** Both fed the parser uncompressed bytes under a compressed `FileType` and logged whatever happened, so neither established that a compressed workbook or Parquet file loads at all. They now really compress and read back, asserting header and records.
- **`TestDBBuilder_AddFS_Compressed` is new.** `AddFS` hands a file over still wrapped, so the codec has to travel alongside the format on the reader input — and nothing covered that. Verified it fails when the `file_processor.go` wiring is removed.

## Scope

`parser.FileType` keeps its fused constants. That package is the lower level where a format-and-codec name is the honest representation of what it dispatches on, and `parser.BaseFileType` already exists to fold one back.

`prep/alias.go` re-exported 56 of those under a second spelling, which meant the module still exposed the cross product twice. It now re-exports formats only; nothing in the repo referenced the compressed aliases.

## Verification

- `go test ./...` green across all 8 packages; `go vet ./...` clean; `golangci-lint run ./...` reports 0 issues.
- sqly built and its full suite run against this branch via `go mod edit -replace` — it does not reference `filesql.FileType` at all, so nothing there changes. The go.mod edit was not committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional compression settings for reader imports, supporting gzip, xz, zstd, zlib, snappy, s2, and lz4.
  * Added compressed-file loading through filesystem imports.
  * Added an example for loading gzip-compressed data.

* **Improvements**
  * File format and compression are now configured separately.
  * Compressed and uncompressed inputs are handled consistently, including streaming and chunked reads.

* **Breaking Changes**
  * Removed compression-specific file type constants and aliases. Use the base file format with a compression option.

* **Documentation**
  * Updated the changelog and README with the new configuration workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->