### PR TITLE
fix: keep a workbook's sheet names when overwriting it in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Overwriting an Excel workbook in place renamed its sheet, and the rename accumulated. A workbook `book.xlsx` holding a sheet `Orders` loads as the table `book_Orders`, and the save wrote the table's name back as the sheet name, so the file came back with its sheet called `book_Orders`. Loading that gave `book_book_Orders`, then `book_book_book_Orders`, growing by the file's name on every round until Excel's 31-rune sheet name limit truncated it and the sheet stopped being recognisable. A sheet now goes back under the name it came in with. The reverse mapping is not exact — `sanitizeTableName` is not injective, so `Q1 Sales` and `Q1-Sales` both load as `Q1_Sales` and only that form can be recovered — but it is stable, which is what stops the accumulation.
+
 ### Added
+- An Excel workbook of more than one sheet can be saved back to itself. Auto-save in overwrite mode refused it with "only a workbook of one sheet can be written back to itself", because the writer wrote one sheet per file; a caller who opened a two-sheet workbook with auto-save could not save at all. Every table of the workbook is now written back as its own sheet in one staged write, in a fixed order so the same workbook saved twice is the same file, and through the source's own codec when it was compressed.
 - `TestLoadMemoryFootprint`, behind the `benchmark` build tag, reports what loading a CSV actually costs, and the README's "Memory and streaming" section now carries the figure it produces. The number this package had been tracking was `B/op` from `go test -benchmem`, which counts every byte a load ever allocated, garbage included; at around 141MB for the 100,000-row fixture it says nothing about how much memory is held at once, which is the question a caller has. Measured instead: the Go heap stays flat at about 24MB whether the file is 16MB or 131MB, because loading is chunked and the parser holds roughly a chunk; resident memory grows by about 2x the file's size, because the rows live in the in-memory SQLite database rather than on the Go heap. The test prints the table the figure comes from, so it can be re-derived rather than trusted.
 
 ### Changed

--- a/autosave_overwrite_test.go
+++ b/autosave_overwrite_test.go
@@ -1,6 +1,7 @@
 package filesql
 
 import (
+	"compress/gzip"
 	"os"
 	"path/filepath"
 	"sort"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xuri/excelize/v2"
 )
 
 // autoSaveOverwrite opens path with auto-save in overwrite mode, runs stmts, and
@@ -249,20 +251,173 @@ func TestAutoSaveOverwriteXLSX(t *testing.T) {
 		assert.Equal(t, "bob", name)
 	})
 
-	t.Run("a workbook of several sheets is refused", func(t *testing.T) {
+	t.Run("a sheet keeps its name across a round trip", func(t *testing.T) {
 		t.Parallel()
 
+		ctx := t.Context()
+		dir := t.TempDir()
+		src := filepath.Join(dir, "book.xlsx")
+		writeWorkbook(t, src, map[string][][]string{
+			"Orders": {{"id", "name"}, {"1", "alice"}},
+		})
+
+		require.NoError(t, autoSaveOverwrite(t, []string{src}, "UPDATE book_Orders SET name = 'bob'"))
+
+		assert.Equal(t, []string{"Orders"}, workbookSheets(t, src),
+			"overwriting a workbook in place must not rename its sheet")
+
+		// The name has to survive repeatedly, not just once: a prefix added on
+		// every save accumulates until Excel's 31-rune sheet name limit truncates it.
+		require.NoError(t, autoSaveOverwrite(t, []string{src}, "UPDATE book_Orders SET name = 'carol'"))
+		assert.Equal(t, []string{"Orders"}, workbookSheets(t, src))
+
+		reloaded, err := OpenContext(ctx, src)
+		require.NoError(t, err)
+		defer reloaded.Close()
+		var name string
+		require.NoError(t, reloaded.QueryRowContext(ctx, "SELECT name FROM book_Orders").Scan(&name))
+		assert.Equal(t, "carol", name)
+	})
+
+	t.Run("a workbook of several sheets is written back to itself", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		dir := t.TempDir()
+		src := filepath.Join(dir, "book.xlsx")
+		writeWorkbook(t, src, map[string][][]string{
+			"Orders":    {{"id", "name"}, {"1", "alice"}},
+			"Customers": {{"id", "city"}, {"1", "tokyo"}},
+		})
+
+		require.NoError(t, autoSaveOverwrite(t, []string{src},
+			"UPDATE book_Orders SET name = 'bob'",
+			"UPDATE book_Customers SET city = 'osaka'"))
+
+		assert.Equal(t, []string{"Customers", "Orders"}, workbookSheets(t, src),
+			"every sheet has to come back, under its own name")
+		assert.Equal(t, []string{"book.xlsx"}, dirEntries(t, dir), "nothing else may be written")
+
+		reloaded, err := OpenContext(ctx, src)
+		require.NoError(t, err)
+		defer reloaded.Close()
+		var name, city string
+		require.NoError(t, reloaded.QueryRowContext(ctx, "SELECT name FROM book_Orders").Scan(&name))
+		require.NoError(t, reloaded.QueryRowContext(ctx, "SELECT city FROM book_Customers").Scan(&city))
+		assert.Equal(t, "bob", name)
+		assert.Equal(t, "osaka", city)
+	})
+
+	t.Run("a compressed workbook of several sheets round-trips", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		dir := t.TempDir()
+		plain := filepath.Join(dir, "book.xlsx")
+		writeWorkbook(t, plain, map[string][][]string{
+			"Orders":    {{"id", "name"}, {"1", "alice"}},
+			"Customers": {{"id", "city"}, {"1", "tokyo"}},
+		})
+
+		// A compressed source has to be written back through its own codec, and
+		// the workbook still has to arrive whole on the other side of it.
+		raw, err := os.ReadFile(plain) //nolint:gosec // plain is under t.TempDir()
+		require.NoError(t, err)
+		require.NoError(t, os.Remove(plain))
+
+		src := filepath.Join(dir, "book.xlsx.gz")
+		out, err := os.Create(src) //nolint:gosec // src is under t.TempDir()
+		require.NoError(t, err)
+		gz := gzip.NewWriter(out)
+		_, err = gz.Write(raw)
+		require.NoError(t, err)
+		require.NoError(t, gz.Close())
+		require.NoError(t, out.Close())
+
+		require.NoError(t, autoSaveOverwrite(t, []string{src},
+			"UPDATE book_Orders SET name = 'bob'",
+			"UPDATE book_Customers SET city = 'osaka'"))
+
+		assert.Equal(t, []string{"book.xlsx.gz"}, dirEntries(t, dir), "nothing else may be written")
+
+		reloaded, err := OpenContext(ctx, src)
+		require.NoError(t, err)
+		defer reloaded.Close()
+		var name, city string
+		require.NoError(t, reloaded.QueryRowContext(ctx, "SELECT name FROM book_Orders").Scan(&name))
+		require.NoError(t, reloaded.QueryRowContext(ctx, "SELECT city FROM book_Customers").Scan(&city))
+		assert.Equal(t, "bob", name)
+		assert.Equal(t, "osaka", city)
+	})
+
+	t.Run("a workbook read from a fixture round-trips whole", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
 		dir := t.TempDir()
 		src := filepath.Join(dir, "book.xlsx")
 		data, err := os.ReadFile(filepath.Join("testdata", "excel", "sample.xlsx"))
 		require.NoError(t, err)
 		require.NoError(t, os.WriteFile(src, data, 0o600)) //nolint:gosec // src is under t.TempDir()
 
-		err = autoSaveOverwrite(t, []string{src}, "UPDATE book_Sheet1 SET name = 'bob'")
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrUnsupportedFormat)
-		assert.Contains(t, err.Error(), "book.xlsx")
+		before := workbookSheets(t, src)
+		require.NoError(t, autoSaveOverwrite(t, []string{src}, "UPDATE book_Sheet1 SET name = 'bob'"))
 
+		assert.Equal(t, before, workbookSheets(t, src), "the sheets have to come back as they were")
 		assert.Equal(t, []string{"book.xlsx"}, dirEntries(t, dir), "nothing else may be written")
+
+		reloaded, err := OpenContext(ctx, src)
+		require.NoError(t, err)
+		defer reloaded.Close()
+		var name string
+		require.NoError(t, reloaded.QueryRowContext(ctx, "SELECT name FROM book_Sheet1").Scan(&name))
+		assert.Equal(t, "bob", name)
 	})
+}
+
+// writeWorkbook builds an xlsx at path holding the given sheets. Each sheet's
+// first row is its header.
+func writeWorkbook(t *testing.T, path string, sheets map[string][][]string) {
+	t.Helper()
+
+	f := excelize.NewFile()
+	defer func() {
+		_ = f.Close()
+	}()
+
+	names := make([]string, 0, len(sheets))
+	for name := range sheets {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if _, err := f.NewSheet(name); err != nil {
+			t.Fatal(err)
+		}
+		for r, row := range sheets[name] {
+			for c, value := range row {
+				cell, err := excelize.CoordinatesToCellName(c+1, r+1)
+				require.NoError(t, err)
+				require.NoError(t, f.SetCellValue(name, cell, value))
+			}
+		}
+	}
+	require.NoError(t, f.DeleteSheet(defaultSheetName))
+	require.NoError(t, f.SaveAs(path))
+}
+
+// workbookSheets returns the sheet names of the workbook at path, sorted.
+func workbookSheets(t *testing.T, path string) []string {
+	t.Helper()
+
+	f, err := excelize.OpenFile(path)
+	require.NoError(t, err)
+	defer func() {
+		_ = f.Close()
+	}()
+
+	names := f.GetSheetList()
+	sort.Strings(names)
+	return names
 }

--- a/filesql.go
+++ b/filesql.go
@@ -956,31 +956,90 @@ func writeParquetData(w io.Writer, columns []string, rows [][]string, nulls [][]
 	return nil
 }
 
-// writeXLSXTableData writes SQLite table data to Excel XLSX format
+// xlsxSheet is one sheet of a workbook being written. Rows are opened when the
+// sheet is reached rather than up front, because a *sql.Rows holds a cursor and
+// only one can be read at a time.
+type xlsxSheet struct {
+	// name is the sheet name, already adapted to what Excel accepts.
+	name string
+	// open yields the sheet's columns and rows.
+	open func() ([]string, *sql.Rows, error)
+}
+
+// writeXLSXTableData writes SQLite table data to Excel XLSX format as a
+// single-sheet workbook named after the table.
 func writeXLSXTableData(w io.Writer, tableName string, columns []string, rows *sql.Rows) error {
-	if len(columns) == 0 {
-		return fmt.Errorf("%w: no columns defined", ErrEmptyData)
+	// The sheet name is what a reader turns back into a table name, so it comes
+	// from the table this dump is of, adapted to what Excel accepts.
+	return writeXLSXWorkbook(w, []xlsxSheet{{
+		name: excelSheetName(tableName),
+		open: func() ([]string, *sql.Rows, error) { return columns, rows, nil },
+	}})
+}
+
+// writeXLSXWorkbook writes sheets as one workbook. A workbook overwritten in
+// place goes through here with every one of its sheets, so a file of several
+// sheets comes back whole rather than being refused or flattened to one.
+func writeXLSXWorkbook(w io.Writer, sheets []xlsxSheet) error {
+	if len(sheets) == 0 {
+		return fmt.Errorf("%w: no sheets to write", ErrEmptyData)
 	}
 
-	// Create new Excel file
 	f := excelize.NewFile()
 	defer func() {
 		_ = f.Close() // Ignore close error
 	}()
 
-	// The sheet name is what a reader turns back into a table name, so it comes
-	// from the table this dump is of, adapted to what Excel accepts.
-	sheetName := excelSheetName(tableName)
-
-	// Create new sheet (replace default Sheet1)
-	if sheetName != defaultSheetName {
-		_, err := f.NewSheet(sheetName)
-		if err != nil {
-			return fmt.Errorf("failed to create sheet %s: %w", sheetName, err)
+	for _, sheet := range sheets {
+		if err := writeXLSXSheet(f, sheet); err != nil {
+			return err
 		}
-		// Delete default sheet
-		if err := f.DeleteSheet(defaultSheetName); err != nil {
-			return fmt.Errorf("failed to delete default sheet: %w", err)
+	}
+
+	// excelize starts a workbook with a default sheet. It is only ours to remove
+	// once a sheet of our own exists, and not at all if a sheet reused its name.
+	if _, err := f.GetSheetIndex(defaultSheetName); err == nil {
+		hasOwn := false
+		for _, sheet := range sheets {
+			if sheet.name == defaultSheetName {
+				hasOwn = true
+				break
+			}
+		}
+		if !hasOwn {
+			if err := f.DeleteSheet(defaultSheetName); err != nil {
+				return fmt.Errorf("failed to delete default sheet: %w", err)
+			}
+		}
+	}
+
+	// Why Write and not SaveAs: SaveAs picks the container format from the file
+	// extension, and the caller stages the write, so the only name available here
+	// carries a temporary suffix that Excel rejects. Any compression the caller
+	// asked for is already wrapped around w.
+	if err := f.Write(w); err != nil {
+		return fmt.Errorf("%w: failed to write Excel file: %s", ErrIOOperation, err.Error())
+	}
+
+	return nil
+}
+
+// writeXLSXSheet adds one sheet to f and fills it.
+func writeXLSXSheet(f *excelize.File, sheet xlsxSheet) error {
+	columns, rows, err := sheet.open()
+	if err != nil {
+		return err
+	}
+	if rows != nil {
+		defer rows.Close()
+	}
+	if len(columns) == 0 {
+		return fmt.Errorf("%w: no columns defined", ErrEmptyData)
+	}
+
+	if sheet.name != defaultSheetName {
+		if _, err := f.NewSheet(sheet.name); err != nil {
+			return fmt.Errorf("failed to create sheet %s: %w", sheet.name, err)
 		}
 	}
 
@@ -990,7 +1049,7 @@ func writeXLSXTableData(w io.Writer, tableName string, columns []string, rows *s
 		if err != nil {
 			return fmt.Errorf("failed to generate cell name for column %d: %w", i+1, err)
 		}
-		if err := f.SetCellValue(sheetName, cell, col); err != nil {
+		if err := f.SetCellValue(sheet.name, cell, col); err != nil {
 			return fmt.Errorf("failed to set header %s: %w", col, err)
 		}
 	}
@@ -1018,7 +1077,7 @@ func writeXLSXTableData(w io.Writer, tableName string, columns []string, rows *s
 			// produce, so one table dumped twice does not disagree with itself.
 			cellValue := formatDumpValue(val)
 
-			if err := f.SetCellValue(sheetName, cell, cellValue); err != nil {
+			if err := f.SetCellValue(sheet.name, cell, cellValue); err != nil {
 				return fmt.Errorf("failed to set cell value at %s: %w", cell, err)
 			}
 		}
@@ -1027,14 +1086,6 @@ func writeXLSXTableData(w io.Writer, tableName string, columns []string, rows *s
 
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("error reading rows: %w", err)
-	}
-
-	// Why Write and not SaveAs: SaveAs picks the container format from the file
-	// extension, and the caller stages the write, so the only name available here
-	// carries a temporary suffix that Excel rejects. Any compression the caller
-	// asked for is already wrapped around w.
-	if err := f.Write(w); err != nil {
-		return fmt.Errorf("%w: failed to write Excel file: %s", ErrIOOperation, err.Error())
 	}
 
 	return nil

--- a/save.go
+++ b/save.go
@@ -6,8 +6,10 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"modernc.org/sqlite"
@@ -578,20 +580,11 @@ func (c *autoSaveConnection) overwriteOriginalFile(ctx context.Context, db *sql.
 	factory := NewCompressionFactory()
 	options := DumpOptions{Format: format, Compression: factory.DetectCompressionType(path)}
 
-	// An Excel workbook holds a table per sheet, and the writer holds one sheet
-	// per file, so only a workbook that came in as a single table can go back out
-	// as one. The tables of a workbook are named after it, which is how the ones
-	// belonging to this path are found.
+	// An Excel workbook holds a table per sheet, so all of them are written back
+	// together into the one file. The tables of a workbook are named after it,
+	// which is how the ones belonging to this path are found.
 	if format == OutputFormatXLSX {
-		tables, err := tablesFromWorkbook(db, baseTableName)
-		if err != nil {
-			return err
-		}
-		if len(tables) != 1 {
-			return fmt.Errorf("%w: %s holds %d sheets, and only a workbook of one sheet can be written back to itself; save to a directory instead",
-				ErrUnsupportedFormat, path, len(tables))
-		}
-		baseTableName = tables[0]
+		return overwriteWorkbookAtPath(db, path, baseTableName, options)
 	}
 
 	return overwriteTableAtPath(db, path, baseTableName, options)
@@ -618,6 +611,75 @@ func overwriteFormatFor(path string) (OutputFormat, error) {
 		return 0, fmt.Errorf("%w: %s cannot be written back because this package reads that format but does not write it; save to a directory with a format it writes instead",
 			ErrUnsupportedFormat, path)
 	}
+}
+
+// overwriteWorkbookAtPath writes every table of a workbook back to it, one sheet
+// per table, in a single staged write.
+//
+// A workbook of more than one sheet used to be refused here, because the writer
+// wrote one sheet per file and so could not represent the rest. Refusing meant a
+// caller who opened a two-sheet workbook with auto-save could not save at all.
+func overwriteWorkbookAtPath(db *sql.DB, path, baseTableName string, options DumpOptions) error {
+	tables, err := tablesFromWorkbook(db, baseTableName)
+	if err != nil {
+		return err
+	}
+	if len(tables) == 0 {
+		return fmt.Errorf("%w: no table for %s remains", ErrEmptyData, path)
+	}
+	// The sheets go back in a fixed order rather than whatever the catalogue
+	// happens to list, so the same workbook saved twice is the same file.
+	sort.Strings(tables)
+
+	sheets := make([]xlsxSheet, 0, len(tables))
+	for _, tableName := range tables {
+		sheets = append(sheets, xlsxSheet{
+			name: xlsxSheetNameForTable(baseTableName, tableName),
+			open: func() ([]string, *sql.Rows, error) {
+				columns, declTypes, err := getSQLiteTableColumns(db, tableName)
+				if err != nil {
+					return nil, nil, fmt.Errorf("%w: failed to get columns for table %s: %s", ErrDatabaseOperation, tableName, err.Error())
+				}
+				if len(columns) == 0 {
+					return nil, nil, fmt.Errorf("%w: table %s for %s no longer exists", ErrEmptyData, tableName, path)
+				}
+				query := fmt.Sprintf("SELECT %s FROM `%s`", dumpSelectList(columns, declTypes), tableName) //nolint:gosec // Table and column names are quoted and come from database metadata
+				rows, err := db.QueryContext(context.Background(), query)
+				if err != nil {
+					return nil, nil, err
+				}
+				return columns, rows, nil
+			},
+		})
+	}
+
+	if err := writeFileAtomically(path, func(w io.Writer) error {
+		return writeXLSXWorkbookCompressed(w, path, sheets, options.Compression)
+	}); err != nil {
+		return fmt.Errorf("%w: failed to overwrite %s: %w", ErrIOOperation, path, err)
+	}
+	return nil
+}
+
+// writeXLSXWorkbookCompressed writes sheets to w through the requested codec.
+//
+// The named return lets the deferred close report its own failure. A compressor
+// writes its trailer on Close, so an archive that failed to finish is only
+// detectable there; dropping that error would commit a truncated file over the
+// caller's workbook. A write error already in flight wins, because it is the one
+// that explains the failure.
+func writeXLSXWorkbookCompressed(w io.Writer, path string, sheets []xlsxSheet, compression CompressionType) (err error) {
+	writer, closeWriter, err := createCompressedWriter(w, compression)
+	if err != nil {
+		return fmt.Errorf("%w: failed to create writer: %s", ErrCompression, err.Error())
+	}
+	defer func() {
+		if closeErr := closeWriter(); closeErr != nil && err == nil {
+			err = fmt.Errorf("%w: failed to finish writing %s: %s", ErrCompression, path, closeErr.Error())
+		}
+	}()
+
+	return writeXLSXWorkbook(writer, sheets)
 }
 
 // tablesFromWorkbook lists the tables an Excel workbook was loaded as. A sheet

--- a/table.go
+++ b/table.go
@@ -186,6 +186,31 @@ func xlsxSheetTableName(baseTableName, sheetName string) string {
 	return baseTableName + "_" + sanitized
 }
 
+// xlsxSheetNameForTable undoes xlsxSheetTableName: it is the sheet a table of
+// this workbook goes back into when the workbook is overwritten in place.
+//
+// Naming the sheet after the table instead prefixed the file's name onto it on
+// every save. A workbook "book.xlsx" holding a sheet "Orders" loads as the table
+// "book_Orders", and writing that table's name back made the sheet "book_Orders";
+// loading again gave "book_book_Orders", and the prefix accumulated on each round
+// until Excel's 31-rune sheet name limit truncated it away.
+//
+// The reverse is not exact, because sanitizeTableName is not injective — a sheet
+// named "Q1 Sales" and one named "Q1-Sales" both load as "Q1_Sales", and only the
+// sanitized form can be recovered. What it does guarantee is that the mapping is
+// stable: the name a save writes is the one the next load reads back to the same
+// table, so nothing accumulates and no sheet is lost.
+func xlsxSheetNameForTable(baseTableName, tableName string) string {
+	if tableName == baseTableName {
+		return excelSheetName(baseTableName)
+	}
+	if suffix, ok := strings.CutPrefix(tableName, baseTableName+"_"); ok && suffix != "" {
+		return excelSheetName(suffix)
+	}
+	// A table that is not this workbook's is not this function's to rename.
+	return excelSheetName(tableName)
+}
+
 // identifierRunes maps a derived name onto the characters an identifier may
 // carry: spaces, hyphens, and dots become underscores, and every remaining
 // character that is not a letter, a digit, a combining mark, or an underscore is


### PR DESCRIPTION
Started as the "multi-sheet Excel writeback" item on the v1.0.0 list and found a bug in the single-sheet path that was supposed to already work.

## The bug: sheet names accumulate the file's name

A workbook `book.xlsx` holding a sheet `Orders` loads as the table `book_Orders` — that is `xlsxSheetTableName` prefixing the file's name. The overwrite path then wrote **the table's name** back as the sheet name, so the file came back with its sheet called `book_Orders`.

Loading that file gives `book_book_Orders`. Saving it again writes that. Measured over four rounds of load-and-save:

```
tables after load: [book_Orders]
round 1: sheets = [book_Orders]        tables = [book_book_Orders]
round 2: sheets = [book_book_Orders]   tables = [book_book_book_Orders]
round 3: sheets = [book_book_book_Orders]  tables = [book_book_book_book_Orders]
final sheets: [book_book_book_book_Orders]
```

It grows by the file's name every time, and Excel's sheet name limit is 31 runes, so a long enough name reaches truncation and the sheet stops being recognisable at all.

### Why no test caught it

`TestAutoSaveOverwriteXLSX` did cover single-sheet writeback, but its workbook came from a dump — one table per file, sheet already named after the file. `xlsxSheetTableName("book", "book")` returns `"book"` with no prefix, so nothing accumulates. A workbook whose sheet name differs from its file name is the ordinary hand-made case and had no test.

### The fix

`xlsxSheetNameForTable` undoes `xlsxSheetTableName`: table `book_Orders` in workbook `book` goes back into sheet `Orders`.

The reverse is not exact, and the comment says so — `sanitizeTableName` is not injective, so a sheet named `Q1 Sales` and one named `Q1-Sales` both load as `Q1_Sales` and only the sanitized form can be recovered. What it does guarantee is that the mapping is **stable**: the name a save writes is the one the next load reads back to the same table. Stability is what stops the accumulation; exactness was never available.

## The feature: a workbook of several sheets can be saved

This was the item on the list. It was refused outright:

```
filesql: unsupported format: book.xlsx holds 2 sheets, and only a workbook
of one sheet can be written back to itself; save to a directory instead
```

The cause was the writer, not the design: `writeXLSXTableData` built a one-sheet workbook, so the rest had nowhere to go. A caller who opened a two-sheet workbook with auto-save could not save at all.

`writeXLSXWorkbook` now takes the sheets together, and `overwriteWorkbookAtPath` gives it every table of the workbook in one staged, atomic write. Two details worth naming:

- Tables are written in **sorted order**, not whatever the catalogue happens to list, so the same workbook saved twice is the same file.
- Each sheet's rows are opened **when that sheet is reached**, because a `*sql.Rows` holds a cursor and only one can be read at a time.

The `ErrUnsupportedFormat` branch and the subtest asserting it are gone. That subtest is replaced by one asserting the fixture workbook now round-trips whole.

## Tests

Written before the fix and confirmed failing against it:

- **`a sheet keeps its name across a round trip`** — saves twice and asserts the sheet is still `Orders` both times, since a single save would not show an accumulating prefix.
- **`a workbook of several sheets is written back to itself`** — two sheets, both edited, both asserted back under their own names, and nothing else written to the directory.
- **`a compressed workbook of several sheets round-trips`** — a `.xlsx.gz` source, to pin that the new write path goes through the source's codec and still produces a whole workbook.
- **`a workbook read from a fixture round-trips whole`** — replaces the "several sheets is refused" subtest.

Verified the suite catches a regression: removing the prefix-stripping branch from `xlsxSheetNameForTable` — reverting to the old behaviour — makes `TestAutoSaveOverwriteXLSX` fail.

## Verification

- `go test ./...` green across all 8 packages; `go vet ./...` clean; `golangci-lint run ./...` reports 0 issues.
- sqly built and its full suite run against this branch via `go mod edit -replace`. The go.mod edit was not committed.

Refs #28.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export workbooks with multiple Excel sheets.
  * Save multi-sheet workbooks back to the same file.
  * Support round trips for compressed workbooks.
  * Preserve stable and readable Excel sheet names during saves.

* **Bug Fixes**
  * Improved workbook preservation during in-place saves.
  * Prevented loss or unintended changes to existing sheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->