### PR TITLE
chore: prepare v0.30.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- `errors.Is` reached only one of the sentinels an error named. A failure was wrapped as `fmt.Errorf("%w: ...: %s", Sentinel, err.Error())` in 115 places, so the `%s` rendered everything below that frame to text: a save that failed because bzip2 has no writer ended its message with "filesql: unsupported file format: bzip2 compression is not supported for writing" and yet did not satisfy `errors.Is(err, ErrUnsupportedFormat)`, leaving a caller to match on the string to tell "this codec cannot be written" from "the compressor failed". Which sentinel survived depended on which frame happened to be outermost, which is not something a caller can reason about. Those sites now wrap with `%w`. No message changes: `fmt` renders `%w` through the error's own `Error` method, so the text is identical — the whole suite passed unaltered except the one assertion that had been pinning the old behavior on purpose.
+## [0.30.0] - 2026-08-02
+
+### Breaking Changes
+
+The public API of the root package went from 159 top-level declarations to 123, and the `FileType` constants from 65 to 10. Everything removed was either unreachable from outside the package or reachable and unusable; nothing that a caller could act on was taken away.
+
+- **The 56 fused `FileType` constants are gone.** `FileTypeCSVGZ`, `FileTypeTSVBZ2`, `FileTypeJSONLLZ4` and the rest named a format-and-codec combination. `FileType` now names formats only: `FileTypeCSV`, `FileTypeTSV`, `FileTypeLTSV`, `FileTypeParquet`, `FileTypeXLSX`, `FileTypeJSON`, `FileTypeJSONL`, `FileTypeACH`, `FileTypeFedWire`, `FileTypeUnsupported`.
+- **`prep` no longer re-exports the parser's 56 compressed constants**; it re-exports formats only. `parser.FileType` is unchanged and still has them.
+- **`MemoryPool`, `MemoryLimit`, `MemoryStatus`, `MemoryInfo`, `Record`, `TableName`, `ChunkSize`, `NewTableName`, `NewChunkSize`** and their methods are unexported. None appeared in any exported signature or struct field, so no call could have passed one in.
+- **`ErrorContext`, `NewErrorContext`, `WithTable`, `WithDetails`, `ErrorContext.Error` are removed.** No error this package returns was built through them.
+- **`ValidationPeekSize`, `MaxSampleSize`, `MinConfidenceThreshold`, `EarlyTerminationThreshold`, `MinDatetimeLength`, `MaxDatetimeLength`, `SamplingStratificationFactor`, `MinRealThreshold`** are unexported. `DefaultRowsPerChunk`, `DefaultChunkSize`, and `MinChunkSize` remain — they document what `SetDefaultChunkSize` does with its argument.
+
+### Migration Notes
+
+For users upgrading from v0.29.x:
+
+1. **`AddReader` with a compressed source.** Replace the fused constant with the format plus `WithCompression`. The three-argument call is unchanged, so a reader of uncompressed bytes needs no edit.
+
+   ```go
+   // before
+   builder.AddReader(gz, "users", filesql.FileTypeCSVGZ)
+
+   // after
+   builder.AddReader(gz, "users", filesql.FileTypeCSV, filesql.WithCompression(filesql.CompressionGZ))
+   ```
+
+2. **File paths are unaffected.** `AddPath("data.csv.gz")` and `Open("data.csv.gz")` still infer both format and codec from the name.
+
+3. **`errors.Is` now reaches every sentinel an error names.** Code that matched on message text to work around this can use `errors.Is` instead. Nothing that worked before stops working: the messages are unchanged.
+
+4. **Excel workbooks of several sheets can now be saved back in place.** A save that previously failed with "only a workbook of one sheet can be written back to itself" now succeeds. A save whose tables would collide on one sheet name is refused rather than silently dropping a table.
 
 ### Fixed
+- `errors.Is` reached only one of the sentinels an error named. A failure was wrapped as `fmt.Errorf("%w: ...: %s", Sentinel, err.Error())` in 115 places, so the `%s` rendered everything below that frame to text: a save that failed because bzip2 has no writer ended its message with "filesql: unsupported file format: bzip2 compression is not supported for writing" and yet did not satisfy `errors.Is(err, ErrUnsupportedFormat)`, leaving a caller to match on the string to tell "this codec cannot be written" from "the compressor failed". Which sentinel survived depended on which frame happened to be outermost, which is not something a caller can reason about. Those sites now wrap with `%w`. No message changes: `fmt` renders `%w` through the error's own `Error` method, so the text is identical — the whole suite passed unaltered except the one assertion that had been pinning the old behavior on purpose.
 - Saving a workbook whose tables collide on a sheet name lost one of them without saying so. Excel caps a sheet name at 31 runes, so two tables of a workbook whose names agree for the first 31 and differ after arrive at the same sheet; excelize answers `NewSheet` for an existing name with that sheet's index rather than an error, so the second table overwrote the first's sheet, one table's rows were gone from the file, and the save reported success. The collision is now refused with an error naming both tables and the sheet, and the workbook is left as it was — the same stance overwrite mode already takes for a format it cannot write.
 - Overwriting an Excel workbook in place renamed its sheet, and the rename accumulated. A workbook `book.xlsx` holding a sheet `Orders` loads as the table `book_Orders`, and the save wrote the table's name back as the sheet name, so the file came back with its sheet called `book_Orders`. Loading that gave `book_book_Orders`, then `book_book_book_Orders`, growing by the file's name on every round until Excel's 31-rune sheet name limit truncated it and the sheet stopped being recognizable. A sheet now goes back under the name it came in with. The reverse mapping is not exact — `sanitizeTableName` is not injective, so `Q1 Sales` and `Q1-Sales` both load as `Q1_Sales` and only that form can be recovered — but it is stable, which is what stops the accumulation.
 
@@ -873,7 +903,8 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.30.0...HEAD
+[0.30.0]: https://github.com/nao1215/filesql/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/nao1215/filesql/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/nao1215/filesql/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/nao1215/filesql/compare/v0.26.0...v0.27.0


### PR DESCRIPTION
Rolls the Unreleased entries into **v0.30.0**, with the Breaking Changes and Migration Notes a release that removes 56 exported constants owes its users.

## What is in the release

Eight PRs since v0.29.0: #209, #211, #212, #213, #214, #215, #217, #218.

**API inventory.** The root package goes from **159 top-level declarations to 123**, and the `FileType` constants from **65 to 10**. Everything removed was either unreachable from outside the package or reachable and unusable:

- the 56 fused `FileType` constants had exactly one caller, `AddReader`, which now takes `WithCompression`;
- `MemoryPool`, `MemoryLimit`, `Record`, `TableName`, `ChunkSize` and friends appeared in no exported signature and no exported struct field, so nothing could be passed one;
- `ErrorContext` built no error this package returns.

**Three bugs found while exploring**, each reproduced before it was fixed:

- an Excel sheet was renamed on every in-place save, accumulating the file's name (`Orders` → `book_Orders` → `book_book_Orders` → …) until Excel's 31-rune limit truncated it;
- two tables of a workbook whose names collide after truncation collapsed into one sheet, losing a table's rows while the save reported success;
- `errors.Is` reached only one sentinel, so an error whose message said "unsupported file format" did not satisfy `errors.Is(err, ErrUnsupportedFormat)`.

**One measurement corrected.** The large-file figure this project tracked (161MB/op, 285MB/op) was `B/op` — cumulative allocation, not footprint. Measured properly: the Go heap stays flat at ~24MB from 16MB to 131MB files, and resident memory grows at ~2× the file size.

## Version choice

`0.29.0` → `0.30.0`. Pre-1.0, so a minor bump is what signals breaking changes under semver; there is no major to bump that would say more.

## The migration notes were run, not written

Every claim in the Migration Notes section was executed as a program against this tree, in a module importing filesql by path:

```
note 1 (AddReader + WithCompression): alice
note 2 (AddPath/Open infers codec):   alice
note 3 (errors.Is ErrUnsupportedFormat): true
```

And the removals were confirmed to actually break compilation, rather than assumed:

```
./old.go:7:17: undefined: filesql.FileTypeCSVGZ
./old.go:8:17: undefined: filesql.NewMemoryPool
./old.go:9:17: undefined: filesql.NewErrorContext
```

## Verification

- `go test ./...` green across all 8 packages; `go vet ./...` clean; `golangci-lint run ./...` reports 0 issues.
- sqly built against this tree and run through its full atago suite: **645 + 11 scenarios, 0 failed**.
- CHANGELOG link refs updated (`[Unreleased]` now compares from `v0.30.0`, `[0.30.0]` added).

## After merge

Tag `v0.30.0` on main and push it; `.github/workflows/release.yml` fires on `v*`, extracts this version's CHANGELOG section, and creates the GitHub release.

Refs #28.