### PR TITLE
feat: support loading into caller transactions

### DIFF
--- a/ach.go
+++ b/ach.go
@@ -401,7 +401,7 @@ func IsACHBaseTableName(tableName string) (baseName string, isACH bool) {
 }
 
 // streamACHFileToDatabase streams an ACH file to the database as multiple tables
-func streamACHFileToDatabase(ctx context.Context, db *sql.DB, reader io.Reader, filePath string, replaceExisting bool) error {
+func streamACHFileToDatabase(ctx context.Context, db DBTX, reader io.Reader, filePath string, replaceExisting bool) error {
 	baseTableName := sanitizeTableName(tableFromFilePath(filePath))
 
 	tables, tableSet, err := parseACHFile(reader, baseTableName)
@@ -450,7 +450,7 @@ func streamACHFileToDatabase(ctx context.Context, db *sql.DB, reader io.Reader, 
 }
 
 // createTableFromColumnInfo creates a SQLite table with the given columns
-func createTableFromColumnInfo(ctx context.Context, db *sql.DB, tableName string, columnInfo []columnInfo) error {
+func createTableFromColumnInfo(ctx context.Context, db DBTX, tableName string, columnInfo []columnInfo) error {
 	columns := make([]string, 0, len(columnInfo))
 	for _, col := range columnInfo {
 		columns = append(columns, fmt.Sprintf(`"%s" %s`, col.Name, col.Type.string()))
@@ -467,7 +467,7 @@ func createTableFromColumnInfo(ctx context.Context, db *sql.DB, tableName string
 }
 
 // insertRecordsIntoTable inserts records into the specified table
-func insertRecordsIntoTable(ctx context.Context, db *sql.DB, tableName string, headers header, records []record) error {
+func insertRecordsIntoTable(ctx context.Context, db DBTX, tableName string, headers header, records []record) error {
 	placeholders := make([]string, len(headers))
 	for i := range placeholders {
 		placeholders[i] = "?"

--- a/builder.go
+++ b/builder.go
@@ -637,6 +637,34 @@ func (b *DBBuilder) LoadInto(ctx context.Context, db *sql.DB) error {
 	b.streamProcessor.replaceExisting = true
 	defer func() { b.streamProcessor.replaceExisting = false }()
 
+	return b.loadIntoExecutor(ctx, db)
+}
+
+// LoadIntoTx loads the builder's inputs into an existing transaction. No
+// transaction is started or committed by this method; the caller owns the
+// transaction and decides whether all changes are committed or rolled back.
+// This is intended for callers that need several files, including table
+// replacement and empty-table creation, to be one atomic operation.
+func (b *DBBuilder) LoadIntoTx(ctx context.Context, tx *sql.Tx) error {
+	if tx == nil {
+		return fmt.Errorf("%w: target transaction is nil", ErrDatabaseOperation)
+	}
+	if b.autoSaveConfig != nil && b.autoSaveConfig.enabled {
+		return fmt.Errorf("%w: auto-save is not supported by LoadIntoTx", ErrDatabaseOperation)
+	}
+	if err := b.validator.validateInputsAvailable(b.collectedPaths, b.readers); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	b.collectedPaths = b.fileProcessor.deduplicateCompressedFiles(b.collectedPaths)
+	b.streamProcessor.replaceExisting = true
+	defer func() { b.streamProcessor.replaceExisting = false }()
+	return b.loadIntoExecutor(ctx, tx)
+}
+
+func (b *DBBuilder) loadIntoExecutor(ctx context.Context, db DBTX) error {
 	if err := b.streamProcessor.streamAllFilesToDatabase(ctx, db, b.collectedPaths); err != nil {
 		return err
 	}

--- a/dbtx.go
+++ b/dbtx.go
@@ -1,0 +1,16 @@
+package filesql
+
+import (
+	"context"
+	"database/sql"
+)
+
+// DBTX is the common execution surface implemented by *sql.DB and *sql.Tx.
+// It lets callers keep several file loads inside one transaction without
+// forcing the loader to start a nested transaction.
+type DBTX interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+	PrepareContext(context.Context, string) (*sql.Stmt, error)
+}

--- a/load_into_test.go
+++ b/load_into_test.go
@@ -68,6 +68,26 @@ func TestLoadInto_PackageFunc_CSV(t *testing.T) {
 	assert.Equal(t, "John Doe", name)
 }
 
+func TestDBBuilder_LoadIntoTxUsesCallerTransaction(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTempCSV(t, dir, "tx.csv", "id\n1\n")
+	db := newCallerDB(t)
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+
+	builder, err := NewBuilder().AddPath(path).Build(context.Background())
+	require.NoError(t, err)
+	require.NoError(t, builder.LoadIntoTx(context.Background(), tx))
+
+	var count int
+	require.NoError(t, tx.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM tx`).Scan(&count))
+	assert.Equal(t, 1, count)
+	// The API must not commit the caller's transaction itself.
+	assert.NoError(t, tx.Rollback())
+	_, err = db.ExecContext(context.Background(), `SELECT * FROM tx`)
+	assert.Error(t, err)
+}
+
 func TestLoadInto_PreservesExistingCallerTables(t *testing.T) {
 	db := newCallerDB(t)
 	_, err := db.ExecContext(context.Background(), `CREATE TABLE app (k TEXT); INSERT INTO app VALUES ('keep')`)

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -41,7 +41,7 @@ type streamProcessor struct {
 // dropIfReplacing drops a same-named table when replaceExisting is set, so the
 // following CREATE installs the file's schema and rows in place of any prior
 // table. It is a no-op in Open mode.
-func (sp *streamProcessor) dropIfReplacing(ctx context.Context, db *sql.DB, tableName string) error {
+func (sp *streamProcessor) dropIfReplacing(ctx context.Context, db DBTX, tableName string) error {
 	if !sp.replaceExisting {
 		return nil
 	}
@@ -67,7 +67,7 @@ func (sp *streamProcessor) setLogger(logger Logger) {
 }
 
 // streamAllFilesToDatabase streams all collected file paths to the database
-func (sp *streamProcessor) streamAllFilesToDatabase(ctx context.Context, db *sql.DB, collectedPaths []string) error {
+func (sp *streamProcessor) streamAllFilesToDatabase(ctx context.Context, db DBTX, collectedPaths []string) error {
 	sp.logger.Info("starting file streaming", "file_count", len(collectedPaths))
 	for i, path := range collectedPaths {
 		sp.logger.Debug("streaming file", "path", path, "index", i+1, "total", len(collectedPaths))
@@ -84,7 +84,7 @@ func (sp *streamProcessor) streamAllFilesToDatabase(ctx context.Context, db *sql
 }
 
 // streamAllReadersToDatabase streams all reader inputs to the database
-func (sp *streamProcessor) streamAllReadersToDatabase(ctx context.Context, db *sql.DB, readers []readerInput) error {
+func (sp *streamProcessor) streamAllReadersToDatabase(ctx context.Context, db DBTX, readers []readerInput) error {
 	if len(readers) == 0 {
 		return nil
 	}
@@ -112,7 +112,7 @@ func (sp *streamProcessor) closeReaderInput(ri readerInput) {
 }
 
 // streamFileToDatabase streams data from a file path directly to SQLite database using chunked processing
-func (sp *streamProcessor) streamFileToDatabase(ctx context.Context, db *sql.DB, filePath string) error {
+func (sp *streamProcessor) streamFileToDatabase(ctx context.Context, db DBTX, filePath string) error {
 	// Check if file is ACH format
 	if isACHFile(filePath) {
 		sp.logger.Debug("detected ACH file format", "path", filePath)
@@ -192,7 +192,7 @@ func (sp *streamProcessor) streamFileToDatabase(ctx context.Context, db *sql.DB,
 }
 
 // streamACHFileToDatabase handles ACH files by creating multiple tables
-func (sp *streamProcessor) streamACHFileToDatabase(ctx context.Context, db *sql.DB, filePath string) error {
+func (sp *streamProcessor) streamACHFileToDatabase(ctx context.Context, db DBTX, filePath string) error {
 	sp.logger.Debug("processing ACH file", "path", filePath)
 
 	// Open the file
@@ -219,7 +219,7 @@ func (sp *streamProcessor) streamACHFileToDatabase(ctx context.Context, db *sql.
 }
 
 // streamFedWireFileToDatabase handles Fedwire files by creating a single message table
-func (sp *streamProcessor) streamFedWireFileToDatabase(ctx context.Context, db *sql.DB, filePath string) error {
+func (sp *streamProcessor) streamFedWireFileToDatabase(ctx context.Context, db DBTX, filePath string) error {
 	sp.logger.Debug("processing Fedwire file", "path", filePath)
 
 	// Open the file
@@ -246,7 +246,7 @@ func (sp *streamProcessor) streamFedWireFileToDatabase(ctx context.Context, db *
 }
 
 // streamReaderToDatabase streams data from io.Reader directly to SQLite database
-func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db *sql.DB, input readerInput) error {
+func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, input readerInput) error {
 	// Route ACH/Fedwire readers to dedicated handlers
 	if input.fileType == FileTypeACH {
 		return streamACHFileToDatabase(ctx, db, input.reader, input.tableName+extACH, sp.replaceExisting)
@@ -284,6 +284,7 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db *sql.D
 	var tableCreated bool
 	var insertStmt *sql.Stmt
 	var tx *sql.Tx
+	ownTx := false
 
 	// Process data in chunks with transaction batching for performance
 	var chunkCount int
@@ -300,15 +301,26 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db *sql.D
 			// Start transaction for bulk inserts - significantly improves performance
 			// by reducing disk sync operations
 			var err error
-			tx, err = db.BeginTx(ctx, nil)
-			if err != nil {
-				return fmt.Errorf("%w: failed to begin transaction: %w", ErrDatabaseOperation, err)
+			if existingTx, ok := db.(*sql.Tx); ok {
+				tx = existingTx
+			} else {
+				dbConn, ok := db.(*sql.DB)
+				if !ok {
+					return fmt.Errorf("%w: unsupported database executor %T", ErrDatabaseOperation, db)
+				}
+				tx, err = dbConn.BeginTx(ctx, nil)
+				if err != nil {
+					return fmt.Errorf("%w: failed to begin transaction: %w", ErrDatabaseOperation, err)
+				}
+				ownTx = true
 			}
 
 			// Prepare insert statement within transaction
 			insertStmt, err = sp.prepareInsertStatementTx(ctx, tx, chunk) //nolint:sqlclosecheck // Statement is closed after processing
 			if err != nil {
-				_ = tx.Rollback() //nolint:errcheck // Ignore rollback error during error handling
+				if ownTx {
+					_ = tx.Rollback() //nolint:errcheck // Ignore rollback error during error handling
+				}
 				return fmt.Errorf("%w: failed to prepare insert statement: %w", ErrDatabaseOperation, err)
 			}
 
@@ -328,7 +340,7 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db *sql.D
 	})
 
 	// Handle transaction commit/rollback
-	if tx != nil {
+	if tx != nil && ownTx {
 		if err != nil {
 			sp.logger.Debug("rolling back transaction", logKeyTable, input.tableName, "error", err)
 			_ = tx.Rollback() //nolint:errcheck // Ignore rollback error during error handling
@@ -369,7 +381,7 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db *sql.D
 }
 
 // createTableFromChunk creates a SQLite table from a tableChunk
-func (sp *streamProcessor) createTableFromChunk(ctx context.Context, db *sql.DB, chunk *tableChunk) error {
+func (sp *streamProcessor) createTableFromChunk(ctx context.Context, db DBTX, chunk *tableChunk) error {
 	columnInfo := chunk.getColumnInfo()
 	columns := make([]string, 0, len(columnInfo))
 	for _, col := range columnInfo {
@@ -391,7 +403,7 @@ func (sp *streamProcessor) createTableFromChunk(ctx context.Context, db *sql.DB,
 }
 
 // prepareInsertStatement prepares an insert statement for the table
-func (sp *streamProcessor) prepareInsertStatement(ctx context.Context, db *sql.DB, chunk *tableChunk) (*sql.Stmt, error) {
+func (sp *streamProcessor) prepareInsertStatement(ctx context.Context, db DBTX, chunk *tableChunk) (*sql.Stmt, error) {
 	query := sp.buildInsertQuery(chunk)
 	return db.PrepareContext(ctx, query)
 }
@@ -458,7 +470,7 @@ func (sp *streamProcessor) insertChunkData(ctx context.Context, stmt *sql.Stmt, 
 }
 
 // createEmptyTable creates an empty table for header-only files
-func (sp *streamProcessor) createEmptyTable(ctx context.Context, db *sql.DB, input readerInput) error {
+func (sp *streamProcessor) createEmptyTable(ctx context.Context, db DBTX, input readerInput) error {
 	// Parse just the header to get column information
 	tempParser := newStreamingParser(input.fileType, input.compression, input.tableName, 1)
 	tempParser.malformedRowPolicy = sp.malformedRowPolicy
@@ -511,7 +523,7 @@ func (sp *streamProcessor) createEmptyTable(ctx context.Context, db *sql.DB, inp
 }
 
 // createTableFromHeaders creates table from header information only (fallback method)
-func (sp *streamProcessor) createTableFromHeaders(ctx context.Context, db *sql.DB, input readerInput) error {
+func (sp *streamProcessor) createTableFromHeaders(ctx context.Context, db DBTX, input readerInput) error {
 	// Create a fallback table structure
 	query := fmt.Sprintf(
 		`CREATE TABLE IF NOT EXISTS "%s" (column1 TEXT)`,
@@ -541,7 +553,7 @@ func (sp *streamProcessor) createDecompressedReader(file *os.File, filePath stri
 }
 
 // streamXLSXFileToDatabase handles XLSX files by creating separate tables for each sheet
-func (sp *streamProcessor) streamXLSXFileToDatabase(ctx context.Context, db *sql.DB, reader io.Reader, filePath string) error {
+func (sp *streamProcessor) streamXLSXFileToDatabase(ctx context.Context, db DBTX, reader io.Reader, filePath string) error {
 	sp.logger.Debug("reading XLSX data into memory", "path", filePath)
 
 	// Read all data into memory (XLSX requires random access)

--- a/wire.go
+++ b/wire.go
@@ -157,7 +157,7 @@ func IsWireBaseTableName(tableName string) (baseName string, isWire bool) {
 }
 
 // streamWireFileToDatabase streams a Fedwire file to the database as a single table.
-func streamWireFileToDatabase(ctx context.Context, db *sql.DB, reader io.Reader, filePath string, replaceExisting bool) error {
+func streamWireFileToDatabase(ctx context.Context, db DBTX, reader io.Reader, filePath string, replaceExisting bool) error {
 	baseTableName := sanitizeTableName(tableFromFilePath(filePath))
 
 	tables, tableSet, err := parseFedWireFile(reader, baseTableName)


### PR DESCRIPTION
## Summary

Add caller-transaction support for loading files into an existing SQLite transaction.

## Changes

- Add the exported `DBTX` execution interface shared by `*sql.DB` and `*sql.Tx`.
- Add `DBBuilder.LoadIntoTx`, preserving the caller's transaction boundary.
- Route CSV, TSV, LTSV, JSON, JSONL, XLSX, ACH, and FedWire writes through the caller transaction.
- Avoid opening nested transactions when the loader is given `*sql.Tx`; standalone `LoadInto` keeps its existing behavior.
- Add a regression test proving the caller controls commit and rollback.

This API is consumed by sqly PR #800 to make a multi-file import one atomic operation.

## Verification

- `go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading configured data into a caller-provided database transaction.
  * Data loaded within a transaction can be reviewed before being committed or rolled back.
  * Database loading now works with both standard connections and compatible transaction-based implementations.

* **Bug Fixes**
  * Improved transaction handling to avoid committing or rolling back transactions owned by the caller.
  * Preserved existing table replacement, streaming, compressed-file deduplication, and specialized file-loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->