### PR TITLE
fix: publish ACH and Fedwire registries after commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1] - 2026-08-02
+
+### Added
+
+- **Caller-controlled transactions for loading.** `DBBuilder.LoadIntoTx` loads CSV, TSV, LTSV, JSON, JSONL, XLSX, ACH, and FedWire inputs into a caller-provided `*sql.Tx`. The loader does not commit or open nested transactions, so callers can combine multiple loads with their own schema changes and roll everything back together. Existing `LoadInto` behavior for standalone database loads is unchanged.
+
 ## [0.30.0] - 2026-08-02
 
 ### Breaking Changes
@@ -903,7 +909,8 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.30.0...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.30.1...HEAD
+[0.30.1]: https://github.com/nao1215/filesql/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/nao1215/filesql/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/nao1215/filesql/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/nao1215/filesql/compare/v0.27.0...v0.28.0

--- a/ach.go
+++ b/ach.go
@@ -401,7 +401,7 @@ func IsACHBaseTableName(tableName string) (baseName string, isACH bool) {
 }
 
 // streamACHFileToDatabase streams an ACH file to the database as multiple tables
-func streamACHFileToDatabase(ctx context.Context, db DBTX, reader io.Reader, filePath string, replaceExisting bool) error {
+func streamACHFileToDatabase(ctx context.Context, db DBTX, reader io.Reader, filePath string, replaceExisting bool, pending *PendingRegistries) error {
 	baseTableName := sanitizeTableName(tableFromFilePath(filePath))
 
 	tables, tableSet, err := parseACHFile(reader, baseTableName)
@@ -409,8 +409,8 @@ func streamACHFileToDatabase(ctx context.Context, db DBTX, reader io.Reader, fil
 		return err
 	}
 
-	// Store the TableSet in the registry for later use by DumpACH
-	registerACHTableSet(baseTableName, tableSet)
+	// Keep the TableSet private until the caller commits the transaction.
+	pending.addACH(baseTableName, tableSet)
 
 	for _, t := range tables {
 		// Check if table already exists

--- a/builder.go
+++ b/builder.go
@@ -496,13 +496,14 @@ func (b *DBBuilder) Open(ctx context.Context) (*sql.DB, error) {
 	}
 
 	// Use stream processor for all streaming operations (now includes XLSX support)
-	if err := b.streamProcessor.streamAllFilesToDatabase(ctx, db, b.collectedPaths); err != nil {
+	pending := newPendingRegistries()
+	if err := b.streamProcessor.streamAllFilesToDatabase(ctx, db, b.collectedPaths, pending); err != nil {
 		b.logger.Error("failed to stream files", "error", err)
 		_ = db.Close() // Ignore close error during error handling
 		return nil, err
 	}
 
-	if err := b.streamProcessor.streamAllReadersToDatabase(ctx, db, b.readers); err != nil {
+	if err := b.streamProcessor.streamAllReadersToDatabase(ctx, db, b.readers, pending); err != nil {
 		b.logger.Error("failed to stream readers", "error", err)
 		_ = db.Close() // Ignore close error during error handling
 		return nil, err
@@ -513,7 +514,7 @@ func (b *DBBuilder) Open(ctx context.Context) (*sql.DB, error) {
 		return nil, err
 	}
 
-	db, err = b.setupAutoSaveIfNeeded(ctx, db)
+	db, err = b.setupAutoSaveIfNeeded(ctx, db, pending)
 	if err != nil {
 		return nil, err
 	}
@@ -522,6 +523,7 @@ func (b *DBBuilder) Open(ctx context.Context) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	pending.PublishRegistries()
 
 	b.logger.Info("database opened successfully")
 	return db, nil
@@ -637,7 +639,12 @@ func (b *DBBuilder) LoadInto(ctx context.Context, db *sql.DB) error {
 	b.streamProcessor.replaceExisting = true
 	defer func() { b.streamProcessor.replaceExisting = false }()
 
-	return b.loadIntoExecutor(ctx, db)
+	pending := newPendingRegistries()
+	if err := b.loadIntoExecutor(ctx, db, pending); err != nil {
+		return err
+	}
+	pending.PublishRegistries()
+	return nil
 }
 
 // LoadIntoTx loads the builder's inputs into an existing transaction. No
@@ -646,29 +653,42 @@ func (b *DBBuilder) LoadInto(ctx context.Context, db *sql.DB) error {
 // This is intended for callers that need several files, including table
 // replacement and empty-table creation, to be one atomic operation.
 func (b *DBBuilder) LoadIntoTx(ctx context.Context, tx *sql.Tx) error {
+	_, err := b.LoadIntoTxWithPending(ctx, tx)
+	return err
+}
+
+// LoadIntoTxWithPending loads the builder's inputs into an existing
+// transaction and returns registry metadata that must be published only after
+// the caller successfully commits that transaction. If loading fails, the
+// returned metadata must be discarded with the transaction.
+func (b *DBBuilder) LoadIntoTxWithPending(ctx context.Context, tx *sql.Tx) (*PendingRegistries, error) {
 	if tx == nil {
-		return fmt.Errorf("%w: target transaction is nil", ErrDatabaseOperation)
+		return nil, fmt.Errorf("%w: target transaction is nil", ErrDatabaseOperation)
 	}
 	if b.autoSaveConfig != nil && b.autoSaveConfig.enabled {
-		return fmt.Errorf("%w: auto-save is not supported by LoadIntoTx", ErrDatabaseOperation)
+		return nil, fmt.Errorf("%w: auto-save is not supported by LoadIntoTx", ErrDatabaseOperation)
 	}
 	if err := b.validator.validateInputsAvailable(b.collectedPaths, b.readers); err != nil {
-		return err
+		return nil, err
 	}
 	if err := ctx.Err(); err != nil {
-		return err
+		return nil, err
 	}
 	b.collectedPaths = b.fileProcessor.deduplicateCompressedFiles(b.collectedPaths)
 	b.streamProcessor.replaceExisting = true
 	defer func() { b.streamProcessor.replaceExisting = false }()
-	return b.loadIntoExecutor(ctx, tx)
+	pending := newPendingRegistries()
+	if err := b.loadIntoExecutor(ctx, tx, pending); err != nil {
+		return nil, err
+	}
+	return pending, nil
 }
 
-func (b *DBBuilder) loadIntoExecutor(ctx context.Context, db DBTX) error {
-	if err := b.streamProcessor.streamAllFilesToDatabase(ctx, db, b.collectedPaths); err != nil {
+func (b *DBBuilder) loadIntoExecutor(ctx context.Context, db DBTX, pending *PendingRegistries) error {
+	if err := b.streamProcessor.streamAllFilesToDatabase(ctx, db, b.collectedPaths, pending); err != nil {
 		return err
 	}
-	if err := b.streamProcessor.streamAllReadersToDatabase(ctx, db, b.readers); err != nil {
+	if err := b.streamProcessor.streamAllReadersToDatabase(ctx, db, b.readers, pending); err != nil {
 		return err
 	}
 	return nil
@@ -735,7 +755,7 @@ func (b *DBBuilder) validateDatabaseConnection(ctx context.Context, db *sql.DB) 
 }
 
 // setupAutoSaveIfNeeded sets up auto-save functionality if enabled.
-func (b *DBBuilder) setupAutoSaveIfNeeded(ctx context.Context, db *sql.DB) (*sql.DB, error) {
+func (b *DBBuilder) setupAutoSaveIfNeeded(ctx context.Context, db *sql.DB, pending *PendingRegistries) (*sql.DB, error) {
 	if b.autoSaveConfig == nil || !b.autoSaveConfig.enabled {
 		return db, nil
 	}
@@ -758,12 +778,12 @@ func (b *DBBuilder) setupAutoSaveIfNeeded(ctx context.Context, db *sql.DB) (*sql
 	db = sql.OpenDB(connector)
 
 	// Use stream processor for all streaming operations (now includes XLSX support)
-	if err := b.streamProcessor.streamAllFilesToDatabase(ctx, db, b.collectedPaths); err != nil {
+	if err := b.streamProcessor.streamAllFilesToDatabase(ctx, db, b.collectedPaths, pending); err != nil {
 		_ = db.Close() // Ignore close error during error handling
 		return nil, err
 	}
 
-	if err := b.streamProcessor.streamAllReadersToDatabase(ctx, db, b.readers); err != nil {
+	if err := b.streamProcessor.streamAllReadersToDatabase(ctx, db, b.readers, pending); err != nil {
 		_ = db.Close() // Ignore close error during error handling
 		return nil, err
 	}

--- a/load_into_test.go
+++ b/load_into_test.go
@@ -88,6 +88,66 @@ func TestDBBuilder_LoadIntoTxUsesCallerTransaction(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestDBBuilder_LoadIntoTxWithPendingPublishesOnlyAfterCommit(t *testing.T) {
+	ClearACHTableSetRegistry()
+	defer ClearACHTableSetRegistry()
+
+	db := newCallerDB(t)
+	builder, err := NewBuilder().AddPath(filepath.Join("testdata", "ppd-debit.ach")).Build(context.Background())
+	require.NoError(t, err)
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+
+	pending, err := builder.LoadIntoTxWithPending(context.Background(), tx)
+	require.NoError(t, err)
+	assert.Empty(t, GetACHTableInfos(), "registry must not change before commit")
+	require.NoError(t, tx.Commit())
+	pending.PublishRegistries()
+	assert.Contains(t, GetACHTableInfos(), ACHTableInfo{BaseName: "ppd_debit"})
+}
+
+func TestDBBuilder_LoadIntoTxWithPendingDiscardsRegistriesOnFailure(t *testing.T) {
+	ClearACHTableSetRegistry()
+	defer ClearACHTableSetRegistry()
+
+	dir := t.TempDir()
+	bad := writeTempCSV(t, dir, "broken.json", "[")
+	db := newCallerDB(t)
+	builder, err := NewBuilder().
+		AddPath(filepath.Join("testdata", "ppd-debit.ach")).
+		AddPath(bad).
+		Build(context.Background())
+	require.NoError(t, err)
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	_, err = builder.LoadIntoTxWithPending(context.Background(), tx)
+	require.Error(t, err)
+	assert.Empty(t, GetACHTableInfos(), "failed load must not publish registry metadata")
+	require.NoError(t, tx.Rollback())
+	assert.Empty(t, listTables(t, db), "failed load must be rolled back")
+}
+
+func TestDBBuilder_LoadIntoTxWithPendingDiscardsFedwireRegistryOnFailure(t *testing.T) {
+	ClearWireTableSetRegistry()
+	defer ClearWireTableSetRegistry()
+
+	dir := t.TempDir()
+	bad := writeTempCSV(t, dir, "broken.json", "[")
+	db := newCallerDB(t)
+	builder, err := NewBuilder().
+		AddPath(filepath.Join("testdata", "customer-transfer.fed")).
+		AddPath(bad).
+		Build(context.Background())
+	require.NoError(t, err)
+	tx, err := db.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	_, err = builder.LoadIntoTxWithPending(context.Background(), tx)
+	require.Error(t, err)
+	assert.Empty(t, GetWireTableInfos(), "failed load must not publish registry metadata")
+	require.NoError(t, tx.Rollback())
+	assert.Empty(t, listTables(t, db), "failed load must be rolled back")
+}
+
 func TestLoadInto_PreservesExistingCallerTables(t *testing.T) {
 	db := newCallerDB(t)
 	_, err := db.ExecContext(context.Background(), `CREATE TABLE app (k TEXT); INSERT INTO app VALUES ('keep')`)

--- a/malformed_row.go
+++ b/malformed_row.go
@@ -22,9 +22,8 @@ const (
 	// header and imports the remaining well-formed records.
 	MalformedRowSkip
 
-	// MalformedRowFill keeps every record, padding a short record with empty
-	// strings and truncating the extra trailing fields of a long record so it
-	// matches the header width.
+	// MalformedRowFill keeps every short record by padding it with empty strings.
+	// A long record is rejected so source data is never silently discarded.
 	MalformedRowFill
 )
 
@@ -55,14 +54,17 @@ func reconcileFieldCount(record []string, want, rowNum int, policy MalformedRowP
 	case MalformedRowSkip:
 		return nil, true, nil
 	case MalformedRowFill:
+		if len(record) > want {
+			return nil, false, fmt.Errorf("%w: row %d has %d fields, want at most %d", ErrColumnMismatch, rowNum, len(record), want)
+		}
 		return fitRecord(record, want), false, nil
 	default: // MalformedRowStop
 		return nil, false, fmt.Errorf("%w: row %d has %d fields, want %d", ErrColumnMismatch, rowNum, len(record), want)
 	}
 }
 
-// fitRecord returns a copy of record resized to exactly want fields: a short
-// record is padded with empty strings and a long record is truncated.
+// fitRecord returns a copy of a short record resized to exactly want fields by
+// padding missing values with empty strings.
 func fitRecord(record []string, want int) []string {
 	out := make([]string, want)
 	copy(out, record)

--- a/malformed_row_test.go
+++ b/malformed_row_test.go
@@ -151,17 +151,15 @@ func TestMalformedRowPolicy_Fill(t *testing.T) {
 		}
 	})
 
-	t.Run("long rows are truncated to the header width", func(t *testing.T) {
+	t.Run("long rows are rejected instead of truncated", func(t *testing.T) {
 		t.Parallel()
 		const csv = "id,name\n1,alice\n2,bob,extra\n"
 		db, err := openWithPolicy(t, csv, FileTypeCSV, MalformedRowFill)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		if db != nil {
+			defer db.Close()
 		}
-		defer db.Close()
-		names := queryColumn(t, db, `SELECT name FROM t ORDER BY id`)
-		if strings.Join(names, ",") != "alice,bob" {
-			t.Fatalf("names = %v, want [alice bob]", names)
+		if !errors.Is(err, ErrColumnMismatch) {
+			t.Fatalf("expected ErrColumnMismatch, got %v", err)
 		}
 	})
 }

--- a/pending_registry.go
+++ b/pending_registry.go
@@ -1,0 +1,56 @@
+package filesql
+
+import (
+	"sync"
+
+	achconv "github.com/nao1215/filesql/parser/ach"
+	wireconv "github.com/nao1215/filesql/parser/wire"
+)
+
+// PendingRegistries contains ACH and Fedwire metadata produced by a load.
+//
+// A loader must publish this metadata only after the transaction containing the
+// corresponding tables has committed. Keeping it separate from the process
+// registries prevents a rollback from leaving write-back metadata for tables
+// that do not exist.
+type PendingRegistries struct {
+	ach  map[string]*achconv.TableSet
+	wire map[string]*wireconv.TableSet
+	once sync.Once
+}
+
+func newPendingRegistries() *PendingRegistries {
+	return &PendingRegistries{
+		ach:  make(map[string]*achconv.TableSet),
+		wire: make(map[string]*wireconv.TableSet),
+	}
+}
+
+func (p *PendingRegistries) addACH(baseName string, tableSet *achconv.TableSet) {
+	if p != nil {
+		p.ach[baseName] = tableSet
+	}
+}
+
+func (p *PendingRegistries) addWire(baseName string, tableSet *wireconv.TableSet) {
+	if p != nil {
+		p.wire[baseName] = tableSet
+	}
+}
+
+// PublishRegistries makes the metadata visible to DumpACH and DumpFedWire.
+// Call it only after the transaction that loaded the corresponding tables has
+// committed successfully. It is safe to call more than once.
+func (p *PendingRegistries) PublishRegistries() {
+	if p == nil {
+		return
+	}
+	p.once.Do(func() {
+		for baseName, tableSet := range p.ach {
+			registerACHTableSet(baseName, tableSet)
+		}
+		for baseName, tableSet := range p.wire {
+			registerWireTableSet(baseName, tableSet)
+		}
+	})
+}

--- a/stream.go
+++ b/stream.go
@@ -1295,13 +1295,9 @@ func (p *streamingParser) processJSONLInChunks(reader io.Reader, processor chunk
 	var chunkRecords []record
 	lineNum := 0
 	totalRecords := 0
-	sawInput := false
 
 	for {
 		rawLine, err := br.ReadBytes('\n')
-		if len(rawLine) > 0 {
-			sawInput = true
-		}
 		lineNum++
 		line := strings.TrimSpace(string(rawLine))
 		if line != "" {
@@ -1347,10 +1343,7 @@ func (p *streamingParser) processJSONLInChunks(reader io.Reader, processor chunk
 	}
 
 	if totalRecords == 0 {
-		if !sawInput {
-			return fmt.Errorf("%w: empty JSONL data", ErrEmptyData)
-		}
-		return processor(&tableChunk{tableName: p.tableName, headers: h, columnInfo: colInfo})
+		return fmt.Errorf("%w: empty JSONL data", ErrEmptyData)
 	}
 
 	return nil

--- a/stream.go
+++ b/stream.go
@@ -1148,13 +1148,12 @@ func (p *streamingParser) parseJSONLStream(reader io.Reader) (*table, error) {
 func (p *streamingParser) processJSONInChunks(reader io.Reader, processor chunkProcessor) error {
 	// Use bufio.Reader to peek at the first non-whitespace byte and decide the strategy.
 	br := bufio.NewReader(reader)
+	h := newHeader([]string{jsonDataHeader})
+	colInfo := []columnInfo{newColumnInfoWithType(jsonDataHeader)}
 	isArray, err := peekJSONIsArray(br)
 	if err != nil {
 		return err
 	}
-
-	h := newHeader([]string{jsonDataHeader})
-	colInfo := []columnInfo{newColumnInfoWithType(jsonDataHeader)}
 
 	if isArray {
 		// Stream array elements one by one via json.Decoder.
@@ -1260,7 +1259,7 @@ func (p *streamingParser) processJSONArrayChunks(
 	}
 
 	if totalRecords == 0 {
-		return fmt.Errorf("%w: empty JSON array", ErrEmptyData)
+		return processor(&tableChunk{tableName: p.tableName, headers: h, columnInfo: colInfo})
 	}
 
 	// Process remaining records
@@ -1296,9 +1295,13 @@ func (p *streamingParser) processJSONLInChunks(reader io.Reader, processor chunk
 	var chunkRecords []record
 	lineNum := 0
 	totalRecords := 0
+	sawInput := false
 
 	for {
 		rawLine, err := br.ReadBytes('\n')
+		if len(rawLine) > 0 {
+			sawInput = true
+		}
 		lineNum++
 		line := strings.TrimSpace(string(rawLine))
 		if line != "" {
@@ -1344,7 +1347,10 @@ func (p *streamingParser) processJSONLInChunks(reader io.Reader, processor chunk
 	}
 
 	if totalRecords == 0 {
-		return fmt.Errorf("%w: empty JSONL data", ErrEmptyData)
+		if !sawInput {
+			return fmt.Errorf("%w: empty JSONL data", ErrEmptyData)
+		}
+		return processor(&tableChunk{tableName: p.tableName, headers: h, columnInfo: colInfo})
 	}
 
 	return nil

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -67,11 +67,11 @@ func (sp *streamProcessor) setLogger(logger Logger) {
 }
 
 // streamAllFilesToDatabase streams all collected file paths to the database
-func (sp *streamProcessor) streamAllFilesToDatabase(ctx context.Context, db DBTX, collectedPaths []string) error {
+func (sp *streamProcessor) streamAllFilesToDatabase(ctx context.Context, db DBTX, collectedPaths []string, pending *PendingRegistries) error {
 	sp.logger.Info("starting file streaming", "file_count", len(collectedPaths))
 	for i, path := range collectedPaths {
 		sp.logger.Debug("streaming file", "path", path, "index", i+1, "total", len(collectedPaths))
-		if err := sp.streamFileToDatabase(ctx, db, path); err != nil {
+		if err := sp.streamFileToDatabase(ctx, db, path, pending); err != nil {
 			sp.logger.Error("failed to stream file", "path", path, "error", err)
 			// Wrap the underlying error with %w as well so a sentinel it carries
 			// (for example ErrColumnMismatch from the malformed-row policy) stays
@@ -84,14 +84,14 @@ func (sp *streamProcessor) streamAllFilesToDatabase(ctx context.Context, db DBTX
 }
 
 // streamAllReadersToDatabase streams all reader inputs to the database
-func (sp *streamProcessor) streamAllReadersToDatabase(ctx context.Context, db DBTX, readers []readerInput) error {
+func (sp *streamProcessor) streamAllReadersToDatabase(ctx context.Context, db DBTX, readers []readerInput, pending *PendingRegistries) error {
 	if len(readers) == 0 {
 		return nil
 	}
 	sp.logger.Info("starting reader streaming", "reader_count", len(readers))
 	for i, ri := range readers {
 		sp.logger.Debug("streaming reader", logKeyTable, ri.tableName, "file_type", ri.fileType.String(), "index", i+1, "total", len(readers))
-		if err := sp.streamReaderToDatabase(ctx, db, ri); err != nil {
+		if err := sp.streamReaderToDatabase(ctx, db, ri, pending); err != nil {
 			sp.closeReaderInput(ri)
 			sp.logger.Error("failed to stream reader", logKeyTable, ri.tableName, "error", err)
 			return streamError(ErrParsing, "failed to stream reader input for table '%s': %w", ri.tableName, err)
@@ -112,17 +112,17 @@ func (sp *streamProcessor) closeReaderInput(ri readerInput) {
 }
 
 // streamFileToDatabase streams data from a file path directly to SQLite database using chunked processing
-func (sp *streamProcessor) streamFileToDatabase(ctx context.Context, db DBTX, filePath string) error {
+func (sp *streamProcessor) streamFileToDatabase(ctx context.Context, db DBTX, filePath string, pending *PendingRegistries) error {
 	// Check if file is ACH format
 	if isACHFile(filePath) {
 		sp.logger.Debug("detected ACH file format", "path", filePath)
-		return sp.streamACHFileToDatabase(ctx, db, filePath)
+		return sp.streamACHFileToDatabase(ctx, db, filePath, pending)
 	}
 
 	// Check if file is Fedwire format
 	if isFedWireFile(filePath) {
 		sp.logger.Debug("detected Fedwire file format", "path", filePath)
-		return sp.streamFedWireFileToDatabase(ctx, db, filePath)
+		return sp.streamFedWireFileToDatabase(ctx, db, filePath, pending)
 	}
 
 	// Check if file is supported
@@ -176,7 +176,7 @@ func (sp *streamProcessor) streamFileToDatabase(ctx context.Context, db DBTX, fi
 	// Handle XLSX files specially - each sheet becomes a separate table
 	if baseFileType == FileTypeXLSX {
 		sp.logger.Debug("processing XLSX file with multiple sheets", "path", filePath)
-		return sp.streamXLSXFileToDatabase(ctx, db, reader, filePath)
+		return sp.streamXLSXFileToDatabase(ctx, db, reader, filePath, pending)
 	}
 
 	// Create reader input for streaming
@@ -188,11 +188,11 @@ func (sp *streamProcessor) streamFileToDatabase(ctx context.Context, db DBTX, fi
 		fileType:    baseFileType,
 		compression: CompressionNone, // already unwrapped above
 	}
-	return sp.streamReaderToDatabase(ctx, db, readerInput)
+	return sp.streamReaderToDatabase(ctx, db, readerInput, pending)
 }
 
 // streamACHFileToDatabase handles ACH files by creating multiple tables
-func (sp *streamProcessor) streamACHFileToDatabase(ctx context.Context, db DBTX, filePath string) error {
+func (sp *streamProcessor) streamACHFileToDatabase(ctx context.Context, db DBTX, filePath string, pending *PendingRegistries) error {
 	sp.logger.Debug("processing ACH file", "path", filePath)
 
 	// Open the file
@@ -215,11 +215,11 @@ func (sp *streamProcessor) streamACHFileToDatabase(ctx context.Context, db DBTX,
 	}
 
 	sp.logger.Debug("streaming ACH file to database", "path", filePath, "size", fileInfo.Size())
-	return streamACHFileToDatabase(ctx, db, file, filePath, sp.replaceExisting)
+	return streamACHFileToDatabase(ctx, db, file, filePath, sp.replaceExisting, pending)
 }
 
 // streamFedWireFileToDatabase handles Fedwire files by creating a single message table
-func (sp *streamProcessor) streamFedWireFileToDatabase(ctx context.Context, db DBTX, filePath string) error {
+func (sp *streamProcessor) streamFedWireFileToDatabase(ctx context.Context, db DBTX, filePath string, pending *PendingRegistries) error {
 	sp.logger.Debug("processing Fedwire file", "path", filePath)
 
 	// Open the file
@@ -242,17 +242,17 @@ func (sp *streamProcessor) streamFedWireFileToDatabase(ctx context.Context, db D
 	}
 
 	sp.logger.Debug("streaming Fedwire file to database", "path", filePath, "size", fileInfo.Size())
-	return streamWireFileToDatabase(ctx, db, file, filePath, sp.replaceExisting)
+	return streamWireFileToDatabase(ctx, db, file, filePath, sp.replaceExisting, pending)
 }
 
 // streamReaderToDatabase streams data from io.Reader directly to SQLite database
-func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, input readerInput) error {
+func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, input readerInput, pending *PendingRegistries) error {
 	// Route ACH/Fedwire readers to dedicated handlers
 	if input.fileType == FileTypeACH {
-		return streamACHFileToDatabase(ctx, db, input.reader, input.tableName+extACH, sp.replaceExisting)
+		return streamACHFileToDatabase(ctx, db, input.reader, input.tableName+extACH, sp.replaceExisting, pending)
 	}
 	if input.fileType == FileTypeFedWire {
-		return streamWireFileToDatabase(ctx, db, input.reader, input.tableName+extFED, sp.replaceExisting)
+		return streamWireFileToDatabase(ctx, db, input.reader, input.tableName+extFED, sp.replaceExisting, pending)
 	}
 
 	// Reader should already be validated at Build time, but ensure it's buffered
@@ -553,7 +553,7 @@ func (sp *streamProcessor) createDecompressedReader(file *os.File, filePath stri
 }
 
 // streamXLSXFileToDatabase handles XLSX files by creating separate tables for each sheet
-func (sp *streamProcessor) streamXLSXFileToDatabase(ctx context.Context, db DBTX, reader io.Reader, filePath string) error {
+func (sp *streamProcessor) streamXLSXFileToDatabase(ctx context.Context, db DBTX, reader io.Reader, filePath string, pending *PendingRegistries) error {
 	sp.logger.Debug("reading XLSX data into memory", "path", filePath)
 
 	// Read all data into memory (XLSX requires random access)

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -139,21 +140,24 @@ func (sp *streamProcessor) streamFileToDatabase(ctx context.Context, db DBTX, fi
 	}
 	defer file.Close()
 
-	// Check if file is empty before processing
+	// Determine the type before checking size so empty JSON/JSONL inputs can be
+	// represented as zero-row tables by the same streaming load path.
+	fileModel := newFile(filePath)
+	baseFileType := fileModel.getFileType()
+
+	// Check if file is empty before processing. JSON and JSONL are allowed to
+	// reach their parser because their empty input is a valid zero-row table.
 	fileInfo, err := file.Stat()
 	if err != nil {
 		sp.logger.Error("failed to get file info", "path", filePath, "error", err)
 		return fmt.Errorf("%w: failed to get file info for %s: %w", ErrIOOperation, filePath, err)
 	}
-	if fileInfo.Size() == 0 {
+	if fileInfo.Size() == 0 && baseFileType != FileTypeJSON && baseFileType != FileTypeJSONL {
 		sp.logger.Warn("empty file detected", "path", filePath)
 		return fmt.Errorf("%w: file is empty", ErrEmptyData)
 	}
 	sp.logger.Debug("file opened", "path", filePath, "size", fileInfo.Size())
 
-	// Create file model to determine type and table name
-	fileModel := newFile(filePath)
-	baseFileType := fileModel.getFileType()
 	sp.logger.Debug("detected file type", "path", filePath, "type", baseFileType.String())
 
 	// Create decompressed reader if needed
@@ -338,6 +342,20 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, 
 
 		return nil
 	})
+	if err != nil && !tableCreated && (input.fileType == FileTypeJSON || input.fileType == FileTypeJSONL) && errors.Is(err, ErrEmptyData) {
+		// Empty JSON/JSONL is a valid zero-row input. The parser has already
+		// consumed the only input stream, so create the known one-column JSON
+		// schema directly instead of opening the file a second time.
+		if createErr := sp.createTableFromChunk(ctx, db, &tableChunk{
+			tableName:  input.tableName,
+			headers:    newHeader([]string{jsonDataHeader}),
+			columnInfo: []columnInfo{newColumnInfoWithType(jsonDataHeader)},
+		}); createErr != nil {
+			return fmt.Errorf("%w: failed to create empty JSON table: %w", ErrDatabaseOperation, createErr)
+		}
+		tableCreated = true
+		err = nil
+	}
 
 	// Handle transaction commit/rollback
 	if tx != nil && ownTx {

--- a/wire.go
+++ b/wire.go
@@ -157,7 +157,7 @@ func IsWireBaseTableName(tableName string) (baseName string, isWire bool) {
 }
 
 // streamWireFileToDatabase streams a Fedwire file to the database as a single table.
-func streamWireFileToDatabase(ctx context.Context, db DBTX, reader io.Reader, filePath string, replaceExisting bool) error {
+func streamWireFileToDatabase(ctx context.Context, db DBTX, reader io.Reader, filePath string, replaceExisting bool, pending *PendingRegistries) error {
 	baseTableName := sanitizeTableName(tableFromFilePath(filePath))
 
 	tables, tableSet, err := parseFedWireFile(reader, baseTableName)
@@ -165,8 +165,8 @@ func streamWireFileToDatabase(ctx context.Context, db DBTX, reader io.Reader, fi
 		return err
 	}
 
-	// Store the TableSet in the registry for later use by DumpFedWire
-	registerWireTableSet(baseTableName, tableSet)
+	// Keep the TableSet private until the caller commits the transaction.
+	pending.addWire(baseTableName, tableSet)
 
 	for _, t := range tables {
 		// Check if table already exists


### PR DESCRIPTION
## Summary
- defer ACH/Fedwire registry publication until the owning load transaction commits
- add LoadIntoTxWithPending for callers that own the transaction
- make pad reject long CSV/TSV rows instead of truncating source fields
- create empty JSON/JSONL tables in the same streaming load path

## Verification
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added caller-controlled transaction loading with metadata published only after a successful commit.
  * Added support for staging ACH and Fedwire metadata during transactional imports.

* **Bug Fixes**
  * Oversized records now return a column mismatch error instead of being truncated.
  * Empty JSON arrays are processed correctly, while whitespace-only JSONL still reports empty input.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->