### PR TITLE
fix: report cleanup failures instead of discarding them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report a prepared statement that fails to close. It holds a connection, so the
   effect used to surface later as an unrelated stall rather than as this load's
   failure.
-- Treat a rollback that reports `sql.ErrTxDone` under a cancelled context as
+- Treat a rollback that reports `sql.ErrTxDone` under a canceled context as
   cancellation rather than a broken transaction, since `database/sql` has
   already rolled the transaction back in that case.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Report a failed rollback instead of discarding it. A load that fails and then
+  cannot be undone previously returned only the parse or schema error, so a
+  caller could not tell that the database had been left mid-load. The rollback
+  failure is now joined onto the cause and both are reachable with `errors.Is`
+  and `errors.As`.
+- End a load's transaction exactly once. A failure while preparing an insert
+  statement rolled the transaction back and then let the outer handler roll it
+  back again; the second call could only report `sql.ErrTxDone`, which was
+  discarded.
+- Report a prepared statement that fails to close. It holds a connection, so the
+  effect used to surface later as an unrelated stall rather than as this load's
+  failure.
+- Treat a rollback that reports `sql.ErrTxDone` under a cancelled context as
+  cancellation rather than a broken transaction, since `database/sql` has
+  already rolled the transaction back in that case.
+
+### Added
+
+- `ErrCleanup`, the sentinel marking a failure that happened while releasing or
+  undoing something after an operation finished. Use `errors.Is(err,
+  filesql.ErrCleanup)` to tell "the load failed" from "the load failed and
+  something was left behind".
+
+## [0.30.2] - 2026-08-02
+
+### Fixed
+
 - Defer ACH and Fedwire registry publication until the transaction that creates
   their SQLite tables commits successfully.
 - Make `MalformedRowFill` pad short CSV/TSV rows while rejecting long rows

--- a/cleanup.go
+++ b/cleanup.go
@@ -1,0 +1,34 @@
+package filesql
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrCleanup marks a failure that happened while releasing or undoing something
+// after an operation finished: rolling back a transaction, closing a prepared
+// statement, detaching a database.
+//
+// It is joined onto the error that the operation itself returned rather than
+// replacing it, because the two answer different questions — "did the load do
+// what I asked" and "is anything left over". A caller can test for either with
+// errors.Is.
+//
+// The rule this replaces was written by hand at each site as `_ = tx.Rollback()`
+// or "assign the cleanup error only when the primary error is nil". Both drop
+// the cleanup failure exactly when it matters most: a rollback runs because the
+// load already failed, so its own failure — the one that says the database is
+// now in a state neither the caller's intent nor the starting point describes —
+// was the one guaranteed to be discarded.
+var ErrCleanup = errors.New("filesql: cleanup failed")
+
+// joinCleanup attaches a cleanup failure to the primary error of an operation.
+// A nil cleanupErr returns primary unchanged, so callers can call it
+// unconditionally. what names the step for the message ("rollback import
+// transaction").
+func joinCleanup(primary, cleanupErr error, what string) error {
+	if cleanupErr == nil {
+		return primary
+	}
+	return errors.Join(primary, fmt.Errorf("%w: %s: %w", ErrCleanup, what, cleanupErr))
+}

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -240,7 +240,7 @@ func TestLoadIntoTxPendingRegistriesStayUnpublished(t *testing.T) {
 	_ = pending
 }
 
-// TestStreamProcessorContextCancelLeavesNoTable checks that cancelling mid-load
+// TestStreamProcessorContextCancelLeavesNoTable checks that canceling mid-load
 // does not leave a half-populated table behind, and that the cancellation is
 // reported as such rather than as a lifecycle defect.
 func TestStreamProcessorContextCancelLeavesNoTable(t *testing.T) {
@@ -263,7 +263,7 @@ func TestStreamProcessorContextCancelLeavesNoTable(t *testing.T) {
 	db, err := OpenContext(ctx, csvPath)
 	if err == nil {
 		_ = db.Close()
-		t.Fatal("OpenContext with a cancelled context = nil error, want a failure")
+		t.Fatal("OpenContext with a canceled context = nil error, want a failure")
 	}
 	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "context canceled") {
 		t.Errorf("err = %v, want it to report the cancellation", err)

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -1,0 +1,271 @@
+package filesql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestJoinCleanupKeepsBothErrors pins the rule the package uses everywhere it
+// releases something. The variant it replaced — dropping the cleanup error, or
+// keeping it only when the primary error was nil — discarded it in the very
+// case that produces one, because cleanup runs after a failure.
+func TestJoinCleanupKeepsBothErrors(t *testing.T) {
+	t.Parallel()
+
+	primary := errors.New("load failed")
+	cleanupErr := errors.New("rollback refused")
+
+	tests := []struct {
+		name        string
+		primary     error
+		cleanupErr  error
+		wantNil     bool
+		wantErrs    []error
+		wantNotErrs []error
+	}{
+		{name: "nothing failed", wantNil: true},
+		{
+			name:        "only the operation failed",
+			primary:     primary,
+			wantErrs:    []error{primary},
+			wantNotErrs: []error{ErrCleanup},
+		},
+		{
+			name:       "only the cleanup failed",
+			cleanupErr: cleanupErr,
+			wantErrs:   []error{cleanupErr, ErrCleanup},
+		},
+		{
+			name:       "both failed",
+			primary:    primary,
+			cleanupErr: cleanupErr,
+			wantErrs:   []error{primary, cleanupErr, ErrCleanup},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := joinCleanup(tt.primary, tt.cleanupErr, "rollback import transaction")
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("joinCleanup = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("joinCleanup = nil, want an error reaching %v", tt.wantErrs)
+			}
+			for _, want := range tt.wantErrs {
+				if !errors.Is(got, want) {
+					t.Errorf("errors.Is(err, %v) = false; err = %v", want, got)
+				}
+			}
+			for _, unwanted := range tt.wantNotErrs {
+				if errors.Is(got, unwanted) {
+					t.Errorf("errors.Is(err, %v) = true, want false; err = %v", unwanted, got)
+				}
+			}
+		})
+	}
+}
+
+// TestJoinCleanupPreservesTypedErrors checks errors.As as well as errors.Is, so
+// a caller inspecting a typed cause still finds it after a cleanup failure is
+// attached. Formatting the two into one string would break this.
+func TestJoinCleanupPreservesTypedErrors(t *testing.T) {
+	t.Parallel()
+
+	got := joinCleanup(&tableError{table: "users"}, errors.New("close failed"), "close insert statement")
+
+	var typed *tableError
+	if !errors.As(got, &typed) {
+		t.Fatalf("errors.As did not reach the typed cause; err = %v", got)
+	}
+	if typed.table != "users" {
+		t.Errorf("table = %q, want users", typed.table)
+	}
+	if !errors.Is(got, ErrCleanup) {
+		t.Errorf("cleanup marker lost; err = %v", got)
+	}
+}
+
+type tableError struct{ table string }
+
+func (e *tableError) Error() string { return "table error: " + e.table }
+
+// TestCommitIsTerminalForRollback documents the database/sql rule the loader's
+// lifecycle depends on, so a future change that adds a rollback after a commit
+// has something to fail against. Commit ends the transaction whether it
+// succeeds or fails, so any later Rollback answers sql.ErrTxDone.
+func TestCommitIsTerminalForRollback(t *testing.T) {
+	t.Parallel()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tx, err := db.BeginTx(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.ExecContext(t.Context(), `CREATE TABLE t (a)`); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if rollbackErr := tx.Rollback(); !errors.Is(rollbackErr, sql.ErrTxDone) {
+		t.Errorf("Rollback after Commit = %v, want sql.ErrTxDone", rollbackErr)
+	}
+}
+
+// TestLoadIntoTxStagingFailureRollsBackEverything is the atomicity guarantee at
+// the library boundary: when the caller owns the transaction, a failure part
+// way through leaves the caller free to roll back and lose every table the load
+// created, not only the one that failed.
+func TestLoadIntoTxStagingFailureRollsBackEverything(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.csv")
+	broken := filepath.Join(dir, "broken.csv")
+	if err := os.WriteFile(good, []byte("id,name\n1,alice\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(broken, []byte("id,name\n1,alice,extra\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tx, err := db.BeginTx(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	goodBuilder, err := NewBuilder().AddPath(good).Build(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := goodBuilder.LoadIntoTxWithPending(t.Context(), tx); err != nil {
+		t.Fatalf("staging the good input: %v", err)
+	}
+
+	brokenBuilder, err := NewBuilder().AddPath(broken).Build(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := brokenBuilder.LoadIntoTxWithPending(t.Context(), tx); err == nil {
+		t.Fatal("staging the broken input = nil, want an error")
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	for _, name := range []string{"good", "broken"} {
+		var n int
+		if err := db.QueryRowContext(t.Context(),
+			`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?`, name).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 {
+			t.Errorf("table %q survived the rollback", name)
+		}
+	}
+}
+
+// TestLoadIntoTxPendingRegistriesStayUnpublished checks the other half: the
+// registry entries a load produces must not reach the process registry until
+// the caller decides the transaction committed. Returning them instead of
+// registering them is what lets a rollback leave nothing behind.
+func TestLoadIntoTxPendingRegistriesStayUnpublished(t *testing.T) {
+	achPath := filepath.Join("testdata", "ppd-debit.ach")
+	if _, err := os.Stat(achPath); err != nil {
+		t.Skipf("ACH fixture not available: %v", err)
+	}
+	UnregisterACHTableSet("ppd_debit")
+	t.Cleanup(func() { UnregisterACHTableSet("ppd_debit") })
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tx, err := db.BeginTx(t.Context(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	builder, err := NewBuilder().AddPath(achPath).Build(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending, err := builder.LoadIntoTxWithPending(t.Context(), tx)
+	if err != nil {
+		t.Fatalf("LoadIntoTxWithPending: %v", err)
+	}
+
+	// Still inside the transaction: nothing may be visible yet.
+	for _, info := range GetACHTableInfos() {
+		if info.BaseName == "ppd_debit" {
+			t.Fatal("the ACH registry was published before the transaction ended")
+		}
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	// The caller never published, so a rolled-back load leaves no entry.
+	for _, info := range GetACHTableInfos() {
+		if info.BaseName == "ppd_debit" {
+			t.Fatal("the ACH registry holds an entry for a rolled-back load")
+		}
+	}
+	_ = pending
+}
+
+// TestStreamProcessorContextCancelLeavesNoTable checks that cancelling mid-load
+// does not leave a half-populated table behind, and that the cancellation is
+// reported as such rather than as a lifecycle defect.
+func TestStreamProcessorContextCancelLeavesNoTable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	csvPath := filepath.Join(dir, "rows.csv")
+	var b strings.Builder
+	b.WriteString("id,name\n")
+	for i := range 5000 {
+		fmt.Fprintf(&b, "%d,name-%d\n", i, i)
+	}
+	if err := os.WriteFile(csvPath, []byte(b.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	db, err := OpenContext(ctx, csvPath)
+	if err == nil {
+		_ = db.Close()
+		t.Fatal("OpenContext with a cancelled context = nil error, want a failure")
+	}
+	if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("err = %v, want it to report the cancellation", err)
+	}
+}

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -322,9 +322,10 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, 
 			// Prepare insert statement within transaction
 			insertStmt, err = sp.prepareInsertStatementTx(ctx, tx, chunk) //nolint:sqlclosecheck // Statement is closed after processing
 			if err != nil {
-				if ownTx {
-					_ = tx.Rollback() //nolint:errcheck // Ignore rollback error during error handling
-				}
+				// No rollback here: the transaction has one owner, and it is the
+				// commit/rollback block after this loop. Rolling back at both
+				// places left the second one to end an already-terminal
+				// transaction, whose sql.ErrTxDone was then discarded.
 				return fmt.Errorf("%w: failed to prepare insert statement: %w", ErrDatabaseOperation, err)
 			}
 
@@ -357,11 +358,26 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, 
 		err = nil
 	}
 
-	// Handle transaction commit/rollback
+	// End the transaction exactly once. A staging failure is rolled back; a
+	// commit is never followed by a rollback, because database/sql ends the
+	// transaction when Commit is called and a rollback afterwards could only
+	// report sql.ErrTxDone — a second error describing nothing the caller can
+	// act on.
 	if tx != nil && ownTx {
 		if err != nil {
 			sp.logger.Debug("rolling back transaction", logKeyTable, input.tableName, "error", err)
-			_ = tx.Rollback() //nolint:errcheck // Ignore rollback error during error handling
+			// A rollback runs because something already failed, so discarding
+			// its error hid the one case that produces one: the load failed and
+			// could not be undone. Both are reported.
+			rollbackErr := tx.Rollback()
+			// When the context is done, database/sql has already rolled the
+			// transaction back itself, so this call loses the race and reports
+			// sql.ErrTxDone. That is cancellation working as documented, not a
+			// cleanup failure, and the cause is already in err.
+			endedByCancellation := errors.Is(rollbackErr, sql.ErrTxDone) && ctx.Err() != nil
+			if !endedByCancellation {
+				err = joinCleanup(err, rollbackErr, "rollback import transaction")
+			}
 		} else {
 			if commitErr := tx.Commit(); commitErr != nil {
 				return fmt.Errorf("%w: failed to commit transaction: %w", ErrDatabaseOperation, commitErr)
@@ -386,9 +402,11 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, 
 		}
 	}
 
-	// Clean up the prepared statement
+	// Clean up the prepared statement. Its close failure is joined rather than
+	// dropped: a statement that cannot be closed holds a connection, which shows
+	// up later as an unrelated hang rather than as this load's problem.
 	if insertStmt != nil {
-		_ = insertStmt.Close() // Ignore close error during statement cleanup
+		err = joinCleanup(err, insertStmt.Close(), "close insert statement")
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Summary

A load's transaction was ended in two places, and every cleanup error was discarded. Both are fixed, and the rule now lives in one place.

## The defects

**Double rollback.** `streamFileToDatabase` rolled the transaction back when preparing the insert statement failed, then returned. The handler after the chunk loop saw a non-nil error and rolled it back again. `database/sql` ends a transaction on the first call, so the second could only answer `sql.ErrTxDone`.

**Discarded rollback errors.** All three sites were `_ = tx.Rollback()`. A rollback runs *because* the load already failed, so discarding its error hid the one outcome that matters: the load failed **and** could not be undone, leaving the database in a state neither the caller's intent nor the starting point describes. A caller saw only the parse error.

**Discarded statement close.** `_ = insertStmt.Close()` — a statement that cannot be closed holds a connection, so the effect surfaced later as an unrelated stall instead of as this load's failure.

## The fix

The transaction has one owner: the block after the chunk loop. It rolls back on failure, commits otherwise, and never rolls back after a commit. A rollback failure is joined onto its cause with `errors.Join`, so `errors.Is` and `errors.As` reach both.

A rollback reporting `sql.ErrTxDone` under a cancelled context is left alone — `database/sql` has already rolled the transaction back itself, so that is cancellation working as documented, not a broken lifecycle. The cause the caller needs is already in the error.

`joinCleanup` is the single place the rule is written, and `ErrCleanup` names the class for callers, so the next thing that needs releasing does not acquire its own variant.

## Which failures were previously invisible

| Failure | Previously | Now caught by |
|---|---|---|
| Rollback fails after a load failure | discarded | `TestJoinCleanupKeepsBothErrors` "both failed" — `errors.Is` reaches cause **and** `ErrCleanup` |
| Cleanup error loses a typed cause | n/a | `TestJoinCleanupPreservesTypedErrors` uses `errors.As` |
| Rollback after Commit | `sql.ErrTxDone`, discarded | `TestCommitIsTerminalForRollback` pins the `database/sql` rule the lifecycle depends on |
| Registry published before commit | fixed in v0.30.2 | `TestLoadIntoTxPendingRegistriesStayUnpublished` asserts nothing is visible inside the transaction *and* nothing after a rollback |
| Earlier inputs survive a later failure | — | `TestLoadIntoTxStagingFailureRollsBackEverything` |
| Cancellation reported as a defect | — | `TestStreamProcessorContextCancelLeavesNoTable` |

## Verification

- `go build ./...`, `go vet ./...` — pass
- `go test ./...` — pass
- `go test -race ./...` — pass
- `golangci-lint run` — 2 issues, both pre-existing (`ach.go` unused nolint directive, `streamXLSXFileToDatabase` unused parameter); confirmed identical on a stashed tree, so this diff adds none

## Compatibility

Additive: `ErrCleanup` is new. An error that used to carry only the primary cause may now also carry a cleanup failure, which is the point — code matching on `errors.Is` is unaffected, code comparing error strings exactly may see a longer message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rollback and cleanup error reporting while preserving the original failure.
  * Ensured transactions terminate exactly once and remain properly closed after commit or rollback.
  * Reported prepared-statement close failures instead of silently discarding them.
  * Improved cancellation handling during streaming operations to prevent incomplete resources from being left behind.
  * Prevented partially loaded data from becoming visible after a failed transaction.

* **New Features**
  * Added `ErrCleanup` for identifying cleanup and rollback failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->