### PR TITLE
chore(release): prepare v0.30.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.3] - 2026-08-03
+
 ### Fixed
 
 - Report a failed rollback instead of discarding it. A load that fails and then


### PR DESCRIPTION
Label the Unreleased section as v0.30.3.

v0.30.3 carries the cleanup-error and transaction-lifecycle fixes from #224: a failed rollback is reported instead of discarded, a load's transaction is ended exactly once, a prepared statement that fails to close is reported, and a rollback reporting `sql.ErrTxDone` under a canceled context is treated as cancellation rather than a broken transaction. `ErrCleanup` is the new sentinel for that class of failure.