### PR TITLE
fix: report the remaining cleanup failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.4] - 2026-08-03
+
+### Fixed
+
+- Report the remaining cleanup failures instead of discarding them: closing a
+  compressing writer (which is what flushes it, so its failure can mean a
+  truncated file), closing the per-sheet insert statement of an XLSX load, and
+  removing the staged file an atomic write leaves behind. Each is joined onto
+  the operation's own error, so a caller whose write already failed still learns
+  the output is unusable or that a temporary file is still on disk.
+
 ## [0.30.3] - 2026-08-03
 
 ### Fixed

--- a/atomic_write.go
+++ b/atomic_write.go
@@ -43,7 +43,12 @@ func writeFileAtomically(dest string, write func(io.Writer) error) error {
 	// Remove the staged file unless the rename below claimed it; a no-op after a
 	// successful rename.
 	defer func() {
-		_ = os.Remove(tmpName) //nolint:errcheck // Best-effort cleanup; the file is gone after a successful rename
+		// A staged file left behind is a leftover in the user's directory, so
+		// its removal failure is reported rather than dropped. A successful
+		// rename already consumed it, which is not a failure.
+		if removeErr := os.Remove(tmpName); removeErr != nil && !os.IsNotExist(removeErr) {
+			err = joinCleanup(err, removeErr, "remove the staged file "+tmpName)
+		}
 	}()
 
 	if err := write(tmp); err != nil {

--- a/filesql.go
+++ b/filesql.go
@@ -500,9 +500,10 @@ func writeSQLiteTableDataTo(w io.Writer, tableName string, columns []string, row
 		return fmt.Errorf("%w: failed to create writer: %w", ErrCompression, err)
 	}
 	defer func() {
-		if closeErr := closeWriter(); closeErr != nil && err == nil {
-			err = fmt.Errorf("%w: failed to finish writing %s: %w", ErrCompression, tableName, closeErr)
-		}
+		// Closing a compressing writer is what flushes it, so a failure here can
+		// mean a truncated file. Joining rather than dropping it means a caller
+		// whose write already failed still learns the output is unusable.
+		err = joinCleanup(err, closeWriter(), "finish writing "+tableName)
 	}()
 
 	// Write data based on format

--- a/save.go
+++ b/save.go
@@ -688,9 +688,10 @@ func writeXLSXWorkbookCompressed(w io.Writer, path string, sheets []xlsxSheet, c
 		return fmt.Errorf("%w: failed to create writer: %w", ErrCompression, err)
 	}
 	defer func() {
-		if closeErr := closeWriter(); closeErr != nil && err == nil {
-			err = fmt.Errorf("%w: failed to finish writing %s: %w", ErrCompression, path, closeErr)
-		}
+		// Closing a compressing writer is what flushes it, so a failure here can
+		// mean a truncated file. Joining rather than dropping it means a caller
+		// whose write already failed still learns the output is unusable.
+		err = joinCleanup(err, closeWriter(), "finish writing "+path)
 	}()
 
 	return writeXLSXWorkbook(writer, sheets)

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -682,7 +682,10 @@ func (sp *streamProcessor) streamXLSXFileToDatabase(ctx context.Context, db DBTX
 			return fmt.Errorf("%w: failed to prepare insert statement for sheet %s: %w", ErrDatabaseOperation, sheetName, err)
 		}
 		defer func() {
-			_ = insertStmt.Close() // Ignore close error
+			// A statement that cannot be closed holds a connection, so its
+			// failure is joined onto whatever the sheet load returned rather
+			// than dropped.
+			err = joinCleanup(err, insertStmt.Close(), "close insert statement for sheet "+sheetName)
 		}()
 
 		if err := sp.insertChunkData(ctx, insertStmt, chunk); err != nil {


### PR DESCRIPTION
Three sites still dropped a cleanup error when the operation they follow had also failed — the case that produces one.

- **Closing a compressing writer** (`filesql.go`, `save.go`) is what flushes it, so its failure can mean a truncated output file. Dropping it when the write already failed is when the caller most needs to know the output is unusable.
- **The per-sheet insert statement of an XLSX load** (`stream_processor.go`) holds a connection when it cannot be closed, so discarding the error turned a load-time problem into an unrelated stall later.
- **The staged file an atomic write leaves behind** (`atomic_write.go`) is a leftover in the user's own directory. A successful rename already consumed it, so `os.IsNotExist` is not reported; a real removal failure is.

All three use `joinCleanup`, the same rule v0.30.3 introduced for the transaction path, so `errors.Is(err, filesql.ErrCleanup)` identifies them.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...`, `go test -race ./...` — pass
- `golangci-lint run` — 2 issues, both pre-existing and unrelated to this diff

## Compatibility

Additive in behaviour: an error may now also carry a cleanup failure. `errors.Is`/`errors.As` matching is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when exporting SQLite and XLSX data.
  - Cleanup failures while completing compressed outputs are now reported alongside existing operation errors.
  - Failures removing temporary files during atomic writes are surfaced, while expected missing-file cases remain ignored.
  - Errors encountered while closing XLSX sheet operations are no longer silently discarded.

- **Documentation**
  - Added changelog entries describing the improved cleanup and error reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->