### PR TITLE
fix(xlsx): refuse a workbook whose sheets map to one table instead of dropping rows

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -862,11 +862,16 @@ func (b *DBBuilder) streamXLSXFileToSQLite(ctx context.Context, db *sql.DB, read
 		return fmt.Errorf("%w: no sheets found in XLSX file", ErrEmptyData)
 	}
 
-	// Base table name from file path (sanitize to ensure a valid identifier)
-	baseTableName := sanitizeTableName(tableFromFilePath(filePath))
+	// Every sheet's table name is worked out before any of them is created, so a
+	// workbook whose sheets would share a table is refused instead of loading the
+	// last one over the others.
+	sheetTables, err := ExcelSheetTableNames(filePath, sheetNames)
+	if err != nil {
+		return err
+	}
 
 	// Process each sheet as a separate table
-	for _, sheetName := range sheetNames {
+	for sheetIndex, sheetName := range sheetNames {
 		rows, err := xlsxFile.GetRows(sheetName)
 		if err != nil {
 			return fmt.Errorf("%w: failed to read sheet %s: %w", ErrParsing, sheetName, err)
@@ -877,7 +882,7 @@ func (b *DBBuilder) streamXLSXFileToSQLite(ctx context.Context, db *sql.DB, read
 			continue
 		}
 
-		tableName := xlsxSheetTableName(baseTableName, sheetName)
+		tableName := sheetTables[sheetIndex]
 
 		// Check if table already exists
 		var tableExists int

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -623,8 +623,14 @@ func (sp *streamProcessor) streamXLSXFileToDatabase(ctx context.Context, db DBTX
 	}
 	sp.logger.Info("processing XLSX file", "path", filePath, "sheet_count", len(sheetNames))
 
-	// Base table name from file path (sanitize to ensure a valid identifier)
-	baseTableName := sanitizeTableName(tableFromFilePath(filePath))
+	// Every sheet's table name is worked out before any of them is created, so a
+	// workbook whose sheets would share a table is refused instead of loading the
+	// last one over the others.
+	sheetTables, err := ExcelSheetTableNames(filePath, sheetNames)
+	if err != nil {
+		sp.logger.Error("sheet names collide", "path", filePath, "error", err)
+		return err
+	}
 
 	// Process each sheet as a separate table
 	for i, sheetName := range sheetNames {
@@ -641,7 +647,7 @@ func (sp *streamProcessor) streamXLSXFileToDatabase(ctx context.Context, db DBTX
 			continue
 		}
 
-		tableName := xlsxSheetTableName(baseTableName, sheetName)
+		tableName := sheetTables[i]
 		sp.logger.Debug("creating table from sheet", "path", filePath, logKeySheet, sheetName, logKeyTable, tableName, "rows", len(rows))
 
 		// Check if table already exists

--- a/table.go
+++ b/table.go
@@ -1,6 +1,7 @@
 package filesql
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"unicode"
@@ -184,6 +185,42 @@ func xlsxSheetTableName(baseTableName, sheetName string) string {
 		return baseTableName
 	}
 	return baseTableName + "_" + sanitized
+}
+
+// ExcelSheetTableNames maps every sheet of a workbook to the table it is loaded
+// as, and reports the sheets that would share one table.
+//
+// A workbook can name two sheets "Data" and "data", or "Q1 sales" and
+// "Q1.sales". Sanitizing makes the first pair identical in case only and the
+// second identical outright, and SQLite compares table names case-insensitively
+// for ASCII, so all four end up asking for the same table. Loading them in turn
+// means the last sheet read is the only one that survives, and the rows of the
+// others are gone with nothing said about it.
+//
+// This is the check that turns that into an error. It is exported because a
+// caller that wants to refuse such a workbook before loading anything — rather
+// than partway through — needs the same rule filesql applies, and a caller
+// reimplementing the sanitizer would drift from it.
+//
+// tables is parallel to sheetNames. err is non-nil when any two sheets collide,
+// and names both the sheets and the table they would share.
+func ExcelSheetTableNames(filePath string, sheetNames []string) (tables []string, err error) {
+	base := sanitizeTableName(tableFromFilePath(filePath))
+	tables = make([]string, len(sheetNames))
+	// SQLite folds ASCII case when it compares identifiers, so the key does too:
+	// "Data" and "data" are one table there, whatever the sanitizer preserved.
+	claimed := make(map[string]string, len(sheetNames))
+	for i, sheet := range sheetNames {
+		table := xlsxSheetTableName(base, sheet)
+		tables[i] = table
+		key := strings.ToLower(table)
+		if first, taken := claimed[key]; taken {
+			return nil, fmt.Errorf("%w: sheets %q and %q of %s both map to table %q; rename one of them",
+				ErrDuplicateTable, first, sheet, filepath.Base(filePath), table)
+		}
+		claimed[key] = sheet
+	}
+	return tables, nil
 }
 
 // xlsxSheetNameForTable undoes xlsxSheetTableName: it is the sheet a table of

--- a/xlsx_sheet_collision_test.go
+++ b/xlsx_sheet_collision_test.go
@@ -1,0 +1,168 @@
+package filesql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/xuri/excelize/v2"
+)
+
+// Two sheets of one workbook can ask for the same table. "Q1 sales" and
+// "Q1.sales" sanitize to the same string, and "x(1)" and "x1" do too, because
+// the sanitizer turns a space and a dot into "_" and drops the brackets.
+// Loading them in turn used to leave only the last one, with the rows of the
+// other gone and nothing said about it. These tests pin the refusal.
+//
+// Sheets differing only in case are not among the cases: Excel compares sheet
+// names case-insensitively itself, so a workbook cannot hold both "Data" and
+// "data" in the first place. The key below folds case anyway, because SQLite
+// does when it compares table names, and the sanitizer preserves it.
+
+// collidingWorkbook builds a workbook whose sheets are named exactly as given,
+// in that order, each with one column and one row.
+func collidingWorkbook(t *testing.T, path string, sheets ...string) string {
+	t.Helper()
+
+	f := excelize.NewFile()
+	for _, sheet := range sheets {
+		if sheet != defaultSheetName {
+			if _, err := f.NewSheet(sheet); err != nil {
+				t.Fatalf("new sheet %q: %v", sheet, err)
+			}
+		}
+		if err := f.SetCellValue(sheet, "A1", "v"); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.SetCellValue(sheet, "A2", sheet); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if sheets[0] != defaultSheetName {
+		if err := f.DeleteSheet(defaultSheetName); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.SaveAs(path); err != nil {
+		t.Fatalf("save %s: %v", path, err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestExcelSheetTableNames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("maps each sheet to its own table", func(t *testing.T) {
+		t.Parallel()
+		got, err := ExcelSheetTableNames("book.xlsx", []string{"Sheet1", "Second", "Q3 actuals"})
+		if err != nil {
+			t.Fatalf("ExcelSheetTableNames: %v", err)
+		}
+		want := []string{"book_Sheet1", "book_Second", "book_Q3_actuals"}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("table %d = %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("rejects sheets that sanitize to the same name", func(t *testing.T) {
+		t.Parallel()
+		_, err := ExcelSheetTableNames("book.xlsx", []string{"Q1 sales", "Q1.sales"})
+		if !errors.Is(err, ErrDuplicateTable) {
+			t.Fatalf("error = %v, want ErrDuplicateTable", err)
+		}
+		for _, want := range []string{`"Q1 sales"`, `"Q1.sales"`, "book.xlsx", "book_Q1_sales"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q should name %s", err, want)
+			}
+		}
+	})
+
+	t.Run("rejects sheets whose punctuation is dropped into the same name", func(t *testing.T) {
+		t.Parallel()
+		_, err := ExcelSheetTableNames("book.xlsx", []string{"x(1)", "x1"})
+		if !errors.Is(err, ErrDuplicateTable) {
+			t.Fatalf("error = %v, want ErrDuplicateTable", err)
+		}
+		if !strings.Contains(err.Error(), "book_x1") {
+			t.Errorf("error %q should name the shared table", err)
+		}
+	})
+
+	t.Run("folds case the way SQLite does", func(t *testing.T) {
+		t.Parallel()
+		// Excel will not hold both of these, but the comparison must fold case
+		// regardless: SQLite treats book_Data and book_data as one table, so a
+		// workbook produced by something other than Excel cannot slip past.
+		if _, err := ExcelSheetTableNames("book.xlsx", []string{"Data", "data"}); !errors.Is(err, ErrDuplicateTable) {
+			t.Fatalf("error = %v, want ErrDuplicateTable", err)
+		}
+	})
+
+	t.Run("keeps a sheet named after its file on the base table", func(t *testing.T) {
+		t.Parallel()
+		got, err := ExcelSheetTableNames("people.xlsx", []string{"people"})
+		if err != nil {
+			t.Fatalf("ExcelSheetTableNames: %v", err)
+		}
+		if got[0] != "people" {
+			t.Errorf("table = %q, want %q", got[0], "people")
+		}
+	})
+}
+
+// TestOpenXLSXWithCollidingSheetsFails drives a real workbook through the
+// loader. The unit test above pins the rule; this one pins that the loader
+// actually applies it, which is what stops the silent overwrite.
+func TestOpenXLSXWithCollidingSheetsFails(t *testing.T) {
+	t.Parallel()
+	path := collidingWorkbook(t, filepath.Join(t.TempDir(), "book.xlsx"), "Q1 sales", "Q1.sales")
+
+	db, err := Open(path)
+	if err == nil {
+		_ = db.Close()
+		t.Fatal("Open succeeded on a workbook whose sheets share a table name")
+	}
+	if !errors.Is(err, ErrDuplicateTable) {
+		t.Errorf("error = %v, want ErrDuplicateTable", err)
+	}
+	for _, want := range []string{"Q1 sales", "Q1.sales", "book_Q1_sales"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should name %s", err, want)
+		}
+	}
+}
+
+// TestOpenXLSXWithDistinctSheetsStillWorks is the guard on the guard: the check
+// must not refuse an ordinary workbook.
+func TestOpenXLSXWithDistinctSheetsStillWorks(t *testing.T) {
+	t.Parallel()
+	path := collidingWorkbook(t, filepath.Join(t.TempDir(), "book.xlsx"), "Alpha", "Beta")
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for table, want := range map[string]string{"book_Alpha": "Alpha", "book_Beta": "Beta"} {
+		var got string
+		if err := db.QueryRowContext(context.Background(), "SELECT v FROM "+table).Scan(&got); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				t.Errorf("%s has no rows", table)
+				continue
+			}
+			t.Fatalf("query %s: %v", table, err)
+		}
+		if got != want {
+			t.Errorf("%s holds %q, want %q", table, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

A workbook whose sheet names sanitize to the same table name lost every sheet but the last, with nothing said about it. `Q1 sales` and `Q1.sales` both become `book_Q1_sales`, and `x(1)` and `x1` both become `book_x1`, because the sanitizer turns a space and a dot into `_` and drops brackets. The loader created each table in turn, so the second sheet replaced the first and its rows were gone. filesql reported success.

The names are now worked out for the whole workbook before any table is created, and two sheets asking for one table is an error naming both sheets and the table they share.

## Changes

`ExcelSheetTableNames(filePath, sheetNames)` in `table.go` maps every sheet to the table it will be loaded as and returns `ErrDuplicateTable` when any two collide. It is exported because a caller that wants to refuse such a workbook before loading anything needs the same rule filesql applies, and a caller reimplementing the sanitizer would drift from it.

`streamProcessor.streamXLSXFileToDatabase` and `DBBuilder.streamXLSXFileToSQLite` both call it before their sheet loop and use the names it returns, so the two Excel loaders cannot disagree about what a sheet is called.

`xlsx_sheet_collision_test.go` covers the mapping rule directly (sanitize collision, punctuation collision, case folding, and the sheet-named-after-its-file case that stays on the base table) and drives a real workbook through `Open` to check the loader applies it. A workbook with distinct sheet names still loads, with each sheet's rows in its own table.

## Design Decisions

The comparison folds ASCII case. Excel refuses to hold two sheets differing only in case, so a workbook written by Excel cannot reach that path — but SQLite compares table names case-insensitively, so `book_Data` and `book_data` are one table there, and a workbook produced by something other than Excel must not slip past.

The check runs before the first table is created rather than as each one is added. A collision discovered halfway leaves the tables already loaded behind, and the caller then has to decide what a partly-loaded workbook means. Refusing up front has one meaning.

`ErrDuplicateTable` is reused rather than a new sentinel added: it is already what "this table name is taken" means, and callers matching on it get the new case for free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * XLSX imports now detect duplicate table names before creating tables.
  * Imports fail with a clear error when sheet names would produce conflicting table names.
  * Distinct sheets continue to load successfully, including sheets matching the workbook filename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->