### PR TITLE
feat(xlsx): let a caller load only the sheets a workbook shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Excel sheet visibility policy. `DBBuilder.WithExcelSheetPolicy` decides which
   sheets of a workbook a load reads: `ExcelSheetPolicyAll` (the default, and the
-  behaviour every previous release had) reads them all, and
+  behavior every previous release had) reads them all, and
   `ExcelSheetPolicyVisibleOnly` reads only the sheets the workbook shows. The
   policy applies to every source — a path, a directory, an embedded filesystem,
   a reader, and a compressed workbook alike — because all of them now select

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Excel sheet visibility policy. `DBBuilder.WithExcelSheetPolicy` decides which
+  sheets of a workbook a load reads: `ExcelSheetPolicyAll` (the default, and the
+  behaviour every previous release had) reads them all, and
+  `ExcelSheetPolicyVisibleOnly` reads only the sheets the workbook shows. The
+  policy applies to every source — a path, a directory, an embedded filesystem,
+  a reader, and a compressed workbook alike — because all of them now select
+  sheets through one function instead of each calling the sheet list itself.
+  Table names are worked out after the policy has run, so a hidden sheet that
+  would sanitize to the same table as a visible one is not a collision when it
+  is not loaded.
+- `ExcelSheetsInFile` and `ExcelSheetsInReader` report a workbook's sheets and
+  whether it shows each one, without loading anything. A caller that has to
+  explain which sheets a policy left behind needs the same view filesql uses,
+  and reimplementing it would let the two drift.
+- `parser.WithExcelSheetPolicy` applies the same setting to `parser.Parse`,
+  which reads one sheet: under the visible-only policy it takes the first sheet
+  the workbook shows rather than the first one stored.
+
+Excel separates "hidden", which a reader can undo from the sheet tabs, from
+"very hidden", which only the VBA editor can. excelize reports one boolean
+covering both, so filesql does not tell them apart: the visible-only policy
+leaves out either kind and claims nothing about which it was.
+
 ## [0.30.4] - 2026-08-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ filesql is for cases where the data is already in a file and the fastest useful 
 | `.json` | JSON | Query nested data with `json_extract()` |
 | `.jsonl` | JSONL | One JSON value per line |
 | `.parquet` | Parquet | Columnar format |
-| `.xlsx` | Excel XLSX | One sheet becomes one table, named `file_sheet` (just `file` when the sheet repeats it) |
+| `.xlsx` | Excel XLSX | One sheet becomes one table, named `file_sheet` (just `file` when the sheet repeats it). Every sheet is loaded by default; see [Excel sheet visibility](#excel-sheet-visibility) |
 | `.ach` | ACH (NACHA) | Experimental |
 | `.fed` | Fedwire | Experimental |
 
@@ -383,6 +383,32 @@ Changes live in memory until you save them.
 - `EnableAutoSave` saves when `db.Close()` runs.
 - `EnableAutoSaveOnCommit` saves after each committed transaction.
 
+### Excel sheet visibility
+
+A workbook can hide a sheet, and a hidden sheet often holds the spreadsheet's own working-out rather than data anyone meant to publish. filesql loads every sheet by default, hidden or not, so existing programs keep the tables they have.
+
+Ask for only the sheets the workbook shows with `WithExcelSheetPolicy`:
+
+```go
+validatedBuilder, err := filesql.NewBuilder().
+	AddPath("book.xlsx").
+	WithExcelSheetPolicy(filesql.ExcelSheetPolicyVisibleOnly).
+	Build(ctx)
+```
+
+The policy applies to every source — a path, a directory, an embedded filesystem, a reader, and a compressed workbook alike. Table names are worked out after it has run, so a hidden sheet that would sanitize to the same table as a visible one is not a collision when it is not loaded.
+
+Excel separates "hidden", which a reader can undo from the sheet tabs, from "very hidden", which only the VBA editor can. The library filesql reads workbooks with reports one boolean covering both, so filesql does not tell them apart: `ExcelSheetPolicyVisibleOnly` leaves out either kind.
+
+`ExcelSheetsInFile` reports what a workbook holds without loading it, which is how a caller explains which sheets a policy left behind:
+
+```go
+sheets, err := filesql.ExcelSheetsInFile("book.xlsx")
+for _, sheet := range sheets {
+	fmt.Println(sheet.Name, sheet.Visible)
+}
+```
+
 ### ACH and Fedwire
 
 ACH (`.ach`) and Fedwire (`.fed`) support are experimental. They are useful for inspection, joins, and controlled updates, but the exported files still need domain knowledge from the caller.
@@ -403,6 +429,8 @@ The GoDoc examples are fully tested with `go test`. The tables below show the fa
 | Read a compressed reader | `ExampleDBBuilder_AddReader_compressed` | [example_test.go](./example_test.go) |
 | Tune chunked loading | `ExampleDBBuilder_SetDefaultChunkSize` | [example_api_test.go](./example_api_test.go) |
 | Handle malformed CSV/TSV rows | `ExampleDBBuilder_WithMalformedRowPolicy` | [example_api_test.go](./example_api_test.go) |
+| Load only the sheets a workbook shows | `ExampleDBBuilder_WithExcelSheetPolicy` | [example_api_test.go](./example_api_test.go) |
+| Report a workbook's sheets and their visibility | `ExampleExcelSheetsInFile` | [example_api_test.go](./example_api_test.go) |
 | Attach your own logger | `ExampleDBBuilder_WithLogger`, `ExampleNewSlogAdapter` | [example_api_test.go](./example_api_test.go) |
 | Open a read-only wrapper | `ExampleDBBuilder_OpenReadOnly` | [example_api_test.go](./example_api_test.go) |
 | Save on close or commit | `ExampleDBBuilder_EnableAutoSave`, `ExampleDBBuilder_EnableAutoSaveOnCommit`, `ExampleDBBuilder_DisableAutoSave` | [example_api_test.go](./example_api_test.go), [example_test.go](./example_test.go) |

--- a/builder.go
+++ b/builder.go
@@ -62,6 +62,11 @@ type DBBuilder struct {
 	memDSN string
 	// defaultChunkSize is the default chunk size for reading large files (10MB)
 	defaultChunkSize int
+	// excelSheetPolicy decides which sheets of a workbook this builder loads.
+	// The zero value is ExcelSheetPolicyAll. It is mirrored onto the stream
+	// processor, which is what the per-source load paths read, the same way the
+	// chunk size is.
+	excelSheetPolicy ExcelSheetPolicy
 	// logger is the logger instance for internal logging
 	logger Logger
 
@@ -237,6 +242,32 @@ func (b *DBBuilder) SetDefaultChunkSize(size int) *DBBuilder {
 // Returns self for chaining.
 func (b *DBBuilder) WithMalformedRowPolicy(policy MalformedRowPolicy) *DBBuilder {
 	b.streamProcessor.malformedRowPolicy = policy
+	return b
+}
+
+// WithExcelSheetPolicy decides which sheets of an Excel workbook this builder
+// loads. It applies to every source: a path, a directory, an embedded
+// filesystem, a reader, and a compressed workbook alike.
+//
+// The default is ExcelSheetPolicyAll, which loads every sheet whatever the
+// workbook says about showing it. ExcelSheetPolicyVisibleOnly loads only the
+// sheets the workbook shows, which is what a tool presenting a workbook to
+// someone who did not build it usually wants: a hidden sheet holds the
+// spreadsheet's own working-out, and turning that into a queryable table
+// surprises the reader.
+//
+// Table names are worked out after the policy has run, so a hidden sheet that
+// would sanitize to the same table as a visible one is not a collision when it
+// is not loaded.
+//
+// Example:
+//
+//	builder.AddPath("book.xlsx").WithExcelSheetPolicy(filesql.ExcelSheetPolicyVisibleOnly)
+//
+// Returns self for chaining.
+func (b *DBBuilder) WithExcelSheetPolicy(policy ExcelSheetPolicy) *DBBuilder {
+	b.excelSheetPolicy = policy
+	b.streamProcessor.excelSheetPolicy = policy
 	return b
 }
 
@@ -856,10 +887,15 @@ func (b *DBBuilder) streamXLSXFileToSQLite(ctx context.Context, db *sql.DB, read
 		_ = xlsxFile.Close() // Ignore close error
 	}()
 
-	// Get all sheet names
-	sheetNames := xlsxFile.GetSheetList()
+	// Get the sheet names the policy admits. Filtering here rather than while
+	// looping is what lets the collision check below see exactly the sheets that
+	// will become tables.
+	sheetNames, _, err := selectExcelSheets(xlsxFile, b.excelSheetPolicy)
+	if err != nil {
+		return err
+	}
 	if len(sheetNames) == 0 {
-		return fmt.Errorf("%w: no sheets found in XLSX file", ErrEmptyData)
+		return noExcelSheetsError(xlsxFile, b.excelSheetPolicy)
 	}
 
 	// Every sheet's table name is worked out before any of them is created, so a

--- a/doc.go
+++ b/doc.go
@@ -61,6 +61,13 @@
 //   - "/path/to/logs.ltsv" becomes table "logs"
 //   - "sales.xlsx" with multiple sheets becomes tables "sales_Sheet1", "sales_Sheet2", etc.
 //
+// # Excel Sheet Visibility
+//
+// Every sheet of a workbook is loaded by default, whether or not the workbook
+// shows it. Use DBBuilder.WithExcelSheetPolicy with ExcelSheetPolicyVisibleOnly
+// to load only the shown ones, and ExcelSheetsInFile to report what a workbook
+// holds without loading it.
+//
 // # Data Modifications
 //
 // INSERT, UPDATE, and DELETE operations affect only the in-memory database.

--- a/example_api_test.go
+++ b/example_api_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/nao1215/filesql"
+	"github.com/xuri/excelize/v2"
 	_ "modernc.org/sqlite"
 )
 
@@ -387,4 +388,92 @@ func ExampleNewSlogAdapter() {
 	fmt.Println(strings.Contains(buf.String(), "loaded"))
 	// Output:
 	// true
+}
+
+// exampleWorkbook writes a workbook holding one shown sheet and one hidden
+// sheet, and returns its path.
+func exampleWorkbook(dir string) string {
+	f := excelize.NewFile()
+	defer func() { _ = f.Close() }()
+
+	for _, sheet := range []string{"Sales", "Scratch"} {
+		if sheet != "Sheet1" {
+			if _, err := f.NewSheet(sheet); err != nil {
+				log.Fatal(err)
+			}
+		}
+		if err := f.SetCellValue(sheet, "A1", "region"); err != nil {
+			log.Fatal(err)
+		}
+		if err := f.SetCellValue(sheet, "A2", sheet); err != nil {
+			log.Fatal(err)
+		}
+	}
+	if err := f.DeleteSheet("Sheet1"); err != nil {
+		log.Fatal(err)
+	}
+	if err := f.SetSheetVisible("Scratch", false); err != nil {
+		log.Fatal(err)
+	}
+
+	path := filepath.Join(dir, "book.xlsx")
+	if err := f.SaveAs(path); err != nil {
+		log.Fatal(err)
+	}
+	return path
+}
+
+func ExampleDBBuilder_WithExcelSheetPolicy() {
+	path := exampleWorkbook(os.TempDir())
+	defer func() { _ = os.Remove(path) }()
+
+	validated, err := filesql.NewBuilder().
+		AddPath(path).
+		WithExcelSheetPolicy(filesql.ExcelSheetPolicyVisibleOnly).
+		Build(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	db, err := validated.Open(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	rows, err := db.QueryContext(context.Background(),
+		`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(name)
+	}
+	if err := rows.Err(); err != nil {
+		log.Fatal(err)
+	}
+	// Output:
+	// book_Sales
+}
+
+func ExampleExcelSheetsInFile() {
+	path := exampleWorkbook(os.TempDir())
+	defer func() { _ = os.Remove(path) }()
+
+	sheets, err := filesql.ExcelSheetsInFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, sheet := range sheets {
+		fmt.Printf("%s visible=%t\n", sheet.Name, sheet.Visible)
+	}
+	// Output:
+	// Sales visible=true
+	// Scratch visible=false
 }

--- a/excel_sheet.go
+++ b/excel_sheet.go
@@ -18,7 +18,7 @@ type ExcelSheetPolicy = parser.ExcelSheetPolicy
 
 const (
 	// ExcelSheetPolicyAll loads every sheet of a workbook, hidden or not. It is
-	// the zero value, so a caller that names no policy keeps the behaviour
+	// the zero value, so a caller that names no policy keeps the behavior
 	// filesql had before the setting existed.
 	ExcelSheetPolicyAll = parser.ExcelSheetPolicyAll
 

--- a/excel_sheet.go
+++ b/excel_sheet.go
@@ -1,0 +1,110 @@
+package filesql
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/nao1215/filesql/parser"
+	"github.com/xuri/excelize/v2"
+)
+
+// ExcelSheetPolicy decides which sheets of a workbook a load reads.
+//
+// It is an alias of the parser package's type, not a second enum wrapping it,
+// so the value a caller builds here is the one every Excel read path applies
+// and the two can never disagree about what a policy means.
+type ExcelSheetPolicy = parser.ExcelSheetPolicy
+
+const (
+	// ExcelSheetPolicyAll loads every sheet of a workbook, hidden or not. It is
+	// the zero value, so a caller that names no policy keeps the behaviour
+	// filesql had before the setting existed.
+	ExcelSheetPolicyAll = parser.ExcelSheetPolicyAll
+
+	// ExcelSheetPolicyVisibleOnly loads only the sheets a workbook shows.
+	// Hidden and very hidden sheets are both left out; see the parser package's
+	// constant for why the two are not told apart.
+	ExcelSheetPolicyVisibleOnly = parser.ExcelSheetPolicyVisibleOnly
+)
+
+// ExcelSheet is one sheet of a workbook and whether the workbook shows it.
+type ExcelSheet = parser.ExcelSheet
+
+// ExcelSheetsInFile reports the sheets of the workbook at path, in the order the
+// workbook stores them, and whether it shows each one. The path may carry a
+// compression suffix, exactly as it may for a load.
+//
+// It is exported for a caller that has to explain a load rather than only
+// perform one: which sheets the file holds, and which of them a policy left
+// behind. Answering that by reopening the file with a spreadsheet library would
+// be a second implementation of the rule filesql itself applies, free to drift
+// from it.
+func ExcelSheetsInFile(path string) (sheets []ExcelSheet, err error) {
+	reader, cleanup, err := NewCompressionFactory().CreateReaderForFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if cleanupErr := cleanup(); cleanupErr != nil && err == nil {
+			err = fmt.Errorf("%w: failed to close %s: %w", ErrIOOperation, path, cleanupErr)
+		}
+	}()
+	return ExcelSheetsInReader(reader)
+}
+
+// ExcelSheetsInReader is ExcelSheetsInFile for a workbook that has no path. The
+// reader must yield the workbook's own bytes; a codec around them has to be
+// unwrapped first, as it has no name to be detected from.
+func ExcelSheetsInReader(reader io.Reader) (sheets []ExcelSheet, err error) {
+	// excelize needs random access, and the reader may be a stream, so the
+	// workbook is buffered whole — the same thing every other XLSX path here
+	// does with it.
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to read XLSX data: %w", ErrIOOperation, err)
+	}
+	f, err := excelize.OpenReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to open XLSX file: %w", ErrParsing, err)
+	}
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("%w: failed to close XLSX file: %w", ErrIOOperation, closeErr)
+		}
+	}()
+	return excelSheetList(f)
+}
+
+// excelSheetList is parser.ExcelSheets with filesql's sentinel attached, so a
+// workbook whose visibility cannot be read fails as a parse error like every
+// other unreadable input here.
+func excelSheetList(f parser.ExcelSheetSource) ([]ExcelSheet, error) {
+	sheets, err := parser.ExcelSheets(f)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrParsing, err)
+	}
+	return sheets, nil
+}
+
+// selectExcelSheets is parser.SelectExcelSheets with filesql's sentinel
+// attached. It is the single point every Excel load path here calls to turn an
+// open workbook into the list of sheets it contributes.
+func selectExcelSheets(f parser.ExcelSheetSource, policy ExcelSheetPolicy) (loaded, skipped []string, err error) {
+	loaded, skipped, err = parser.SelectExcelSheets(f, policy)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", ErrParsing, err)
+	}
+	return loaded, skipped, nil
+}
+
+// noExcelSheetsError explains an XLSX file that contributed nothing. It
+// separates a workbook with no sheets at all from one whose sheets were all
+// left out by the policy, because the two need different things done about
+// them: the first file is broken, the second is a setting the caller chose.
+func noExcelSheetsError(f parser.ExcelSheetSource, policy ExcelSheetPolicy) error {
+	if policy == ExcelSheetPolicyVisibleOnly && len(f.GetSheetList()) > 0 {
+		return fmt.Errorf("%w: no visible sheets found in XLSX file", ErrEmptyData)
+	}
+	return fmt.Errorf("%w: no sheets found in XLSX file", ErrEmptyData)
+}

--- a/excel_sheet_test.go
+++ b/excel_sheet_test.go
@@ -1,0 +1,691 @@
+package filesql
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/xuri/excelize/v2"
+)
+
+// A workbook can hide a sheet two ways: "hidden", which a reader can undo from
+// the sheet tabs, and "very hidden", which only the VBA editor can. excelize
+// reports one boolean covering both, so these tests build both and assert the
+// same outcome for each — a policy that told them apart would be claiming
+// knowledge the library does not supply.
+
+// sheetVisibility is how a fixture workbook stores one sheet.
+type sheetVisibility int
+
+const (
+	sheetVisible sheetVisibility = iota
+	sheetHidden
+	sheetVeryHidden
+)
+
+// sheetSpec is one sheet of a fixture workbook.
+type sheetSpec struct {
+	name       string
+	visibility sheetVisibility
+}
+
+// visibilityWorkbook writes a workbook holding exactly these sheets, in this
+// order, each with one header cell and one data row carrying the sheet's name.
+//
+// The fixture is generated rather than committed so the visibility every test
+// depends on is stated in the test itself. A workbook checked in as bytes could
+// be claimed to hold a very hidden sheet and hold nothing of the sort, and
+// nothing in the suite would notice.
+func visibilityWorkbook(t *testing.T, path string, specs ...sheetSpec) string {
+	t.Helper()
+	if len(specs) == 0 {
+		t.Fatal("a fixture workbook needs at least one sheet")
+	}
+
+	f := excelize.NewFile()
+	for _, spec := range specs {
+		if spec.name != defaultSheetName {
+			if _, err := f.NewSheet(spec.name); err != nil {
+				t.Fatalf("new sheet %q: %v", spec.name, err)
+			}
+		}
+		if err := f.SetCellValue(spec.name, "A1", "v"); err != nil {
+			t.Fatalf("write header of %q: %v", spec.name, err)
+		}
+		if err := f.SetCellValue(spec.name, "A2", spec.name); err != nil {
+			t.Fatalf("write row of %q: %v", spec.name, err)
+		}
+	}
+	if specs[0].name != defaultSheetName {
+		if err := f.DeleteSheet(defaultSheetName); err != nil {
+			t.Fatalf("delete the default sheet: %v", err)
+		}
+	}
+
+	// Excel refuses to hide every sheet, and so does excelize, so the active
+	// sheet is moved onto one that stays shown before anything is hidden.
+	active := -1
+	for _, spec := range specs {
+		if spec.visibility != sheetVisible {
+			continue
+		}
+		index, err := f.GetSheetIndex(spec.name)
+		if err != nil {
+			t.Fatalf("index of %q: %v", spec.name, err)
+		}
+		active = index
+		break
+	}
+	if active < 0 {
+		t.Fatal("a fixture workbook needs at least one visible sheet")
+	}
+	f.SetActiveSheet(active)
+
+	for _, spec := range specs {
+		switch spec.visibility {
+		case sheetVisible:
+		case sheetHidden:
+			if err := f.SetSheetVisible(spec.name, false); err != nil {
+				t.Fatalf("hide %q: %v", spec.name, err)
+			}
+		case sheetVeryHidden:
+			if err := f.SetSheetVisible(spec.name, false, true); err != nil {
+				t.Fatalf("very-hide %q: %v", spec.name, err)
+			}
+		}
+	}
+
+	if err := f.SaveAs(path); err != nil {
+		t.Fatalf("save %s: %v", path, err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close %s: %v", path, err)
+	}
+	return path
+}
+
+// mixedVisibilityWorkbook is the workbook these tests share: one shown sheet,
+// one hidden, one very hidden, one shown again, in that order. The last one is
+// there so "order is preserved" can fail if filtering reorders anything.
+func mixedVisibilityWorkbook(t *testing.T, dir string) string {
+	t.Helper()
+	return visibilityWorkbook(t, filepath.Join(dir, "book.xlsx"),
+		sheetSpec{"Shown", sheetVisible},
+		sheetSpec{"Hidden", sheetHidden},
+		sheetSpec{"Secret", sheetVeryHidden},
+		sheetSpec{"AlsoShown", sheetVisible},
+	)
+}
+
+// tableNames returns the loaded table names, sorted.
+func tableNames(t *testing.T, db *sql.DB) []string {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(),
+		"SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+	if err != nil {
+		t.Fatalf("list tables: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan table name: %v", err)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("list tables: %v", err)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func assertTables(t *testing.T, db *sql.DB, want ...string) {
+	t.Helper()
+	sort.Strings(want)
+	got := tableNames(t, db)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("tables = %v, want %v", got, want)
+	}
+}
+
+// TestExcelSheetsInFile pins the reporting helper a caller uses to explain a
+// load: every sheet, in workbook order, with the visibility that decided
+// whether it was loaded.
+func TestExcelSheetsInFile(t *testing.T) {
+	t.Parallel()
+	path := mixedVisibilityWorkbook(t, t.TempDir())
+
+	sheets, err := ExcelSheetsInFile(path)
+	if err != nil {
+		t.Fatalf("ExcelSheetsInFile: %v", err)
+	}
+	want := []ExcelSheet{
+		{Name: "Shown", Visible: true},
+		{Name: "Hidden", Visible: false},
+		{Name: "Secret", Visible: false},
+		{Name: "AlsoShown", Visible: true},
+	}
+	if len(sheets) != len(want) {
+		t.Fatalf("got %d sheets, want %d: %+v", len(sheets), len(want), sheets)
+	}
+	for i := range want {
+		if sheets[i] != want[i] {
+			t.Errorf("sheet %d = %+v, want %+v", i, sheets[i], want[i])
+		}
+	}
+}
+
+// TestExcelSheetsInFileCompressed pins that the helper answers for a workbook
+// behind a codec, because a load accepts one there too.
+func TestExcelSheetsInFileCompressed(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	plain := mixedVisibilityWorkbook(t, dir)
+	gzPath := gzipFile(t, plain, filepath.Join(dir, "book.xlsx.gz"))
+
+	sheets, err := ExcelSheetsInFile(gzPath)
+	if err != nil {
+		t.Fatalf("ExcelSheetsInFile: %v", err)
+	}
+	if len(sheets) != 4 {
+		t.Fatalf("got %d sheets, want 4: %+v", len(sheets), sheets)
+	}
+	if sheets[1].Name != "Hidden" || sheets[1].Visible {
+		t.Errorf("second sheet = %+v, want a hidden %q", sheets[1], "Hidden")
+	}
+}
+
+func TestExcelSheetsInReader(t *testing.T) {
+	t.Parallel()
+	path := mixedVisibilityWorkbook(t, t.TempDir())
+	data, err := os.ReadFile(path) //nolint:gosec // a workbook this test just wrote
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sheets, err := ExcelSheetsInReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("ExcelSheetsInReader: %v", err)
+	}
+	if len(sheets) != 4 {
+		t.Fatalf("got %d sheets, want 4: %+v", len(sheets), sheets)
+	}
+	if !sheets[3].Visible || sheets[3].Name != "AlsoShown" {
+		t.Errorf("last sheet = %+v, want a visible %q", sheets[3], "AlsoShown")
+	}
+}
+
+func TestExcelSheetsInFileRejectsUnreadableWorkbook(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "broken.xlsx")
+	if err := os.WriteFile(path, []byte("not a zip archive"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ExcelSheetsInFile(path); !errors.Is(err, ErrParsing) {
+		t.Fatalf("error = %v, want ErrParsing", err)
+	}
+}
+
+// TestOpenAppliesTheDefaultSheetPolicy is the compatibility guard: a caller
+// that names no policy still gets every sheet, exactly as before the policy
+// existed. Changing this silently would drop tables out of existing programs.
+func TestOpenAppliesTheDefaultSheetPolicy(t *testing.T) {
+	t.Parallel()
+	path := mixedVisibilityWorkbook(t, t.TempDir())
+
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	assertTables(t, db, "book_Shown", "book_Hidden", "book_Secret", "book_AlsoShown")
+}
+
+// TestBuilderSheetPolicyFromPath drives the policy through the path load, which
+// is the one that turns each sheet into its own table.
+func TestBuilderSheetPolicyFromPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		policy ExcelSheetPolicy
+		want   []string
+	}{
+		{
+			name:   "the all policy loads the hidden and very hidden sheets too",
+			policy: ExcelSheetPolicyAll,
+			want:   []string{"book_Shown", "book_Hidden", "book_Secret", "book_AlsoShown"},
+		},
+		{
+			name:   "the visible-only policy loads neither the hidden nor the very hidden sheet",
+			policy: ExcelSheetPolicyVisibleOnly,
+			want:   []string{"book_Shown", "book_AlsoShown"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			path := mixedVisibilityWorkbook(t, t.TempDir())
+
+			db := openWithSheetPolicy(t, tt.policy, path)
+			defer func() { _ = db.Close() }()
+			assertTables(t, db, tt.want...)
+		})
+	}
+}
+
+// TestBuilderSheetPolicyFromCompressedPath pins that a codec around the
+// workbook does not lose the policy: the file is unwrapped and then read by the
+// same path, so a policy applied only to plain workbooks would show up here.
+func TestBuilderSheetPolicyFromCompressedPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	plain := mixedVisibilityWorkbook(t, dir)
+	gzPath := gzipFile(t, plain, filepath.Join(dir, "packed.xlsx.gz"))
+
+	db := openWithSheetPolicy(t, ExcelSheetPolicyVisibleOnly, gzPath)
+	defer func() { _ = db.Close() }()
+	assertTables(t, db, "packed_Shown", "packed_AlsoShown")
+}
+
+// TestBuilderSheetPolicyFromReader covers the reader load, which takes one
+// sheet rather than all of them. Under the visible-only policy the sheet it
+// takes must be the first one shown, not the first one stored.
+func TestBuilderSheetPolicyFromReader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		policy ExcelSheetPolicy
+		want   string
+	}{
+		{
+			name:   "the all policy takes the first stored sheet even when it is hidden",
+			policy: ExcelSheetPolicyAll,
+			want:   "Buried",
+		},
+		{
+			name:   "the visible-only policy takes the first shown sheet",
+			policy: ExcelSheetPolicyVisibleOnly,
+			want:   "Shown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// The hidden sheet is stored first on purpose: the two policies then
+			// disagree about which sheet the reader load takes.
+			path := visibilityWorkbook(t, filepath.Join(t.TempDir(), "book.xlsx"),
+				sheetSpec{"Buried", sheetHidden},
+				sheetSpec{"Shown", sheetVisible},
+			)
+			data, err := os.ReadFile(path) //nolint:gosec // a workbook this test just wrote
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			builder, err := NewBuilder().
+				AddReader(bytes.NewReader(data), "book", FileTypeXLSX).
+				WithExcelSheetPolicy(tt.policy).
+				Build(context.Background())
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			db, err := builder.Open(context.Background())
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			var got string
+			if err := db.QueryRowContext(context.Background(), "SELECT v FROM book").Scan(&got); err != nil {
+				t.Fatalf("query book: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("the reader load took sheet %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuilderSheetPolicyFromFS covers the embedded-filesystem load, which
+// reaches the same reader path through a different entry point.
+func TestBuilderSheetPolicyFromFS(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	visibilityWorkbook(t, filepath.Join(dir, "book.xlsx"),
+		sheetSpec{"Buried", sheetHidden},
+		sheetSpec{"Shown", sheetVisible},
+	)
+
+	builder, err := NewBuilder().
+		AddFS(os.DirFS(dir)).
+		WithExcelSheetPolicy(ExcelSheetPolicyVisibleOnly).
+		Build(context.Background())
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	db, err := builder.Open(context.Background())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var got string
+	if err := db.QueryRowContext(context.Background(), "SELECT v FROM book").Scan(&got); err != nil {
+		t.Fatalf("query book: %v", err)
+	}
+	if got != "Shown" {
+		t.Errorf("the filesystem load took sheet %q, want %q", got, "Shown")
+	}
+}
+
+// TestSheetPolicyKeepsWorkbookOrder pins that filtering removes sheets without
+// reordering the ones it keeps. Table names are derived per sheet, so a reorder
+// would attach the wrong rows to the wrong name.
+func TestSheetPolicyKeepsWorkbookOrder(t *testing.T) {
+	t.Parallel()
+	path := visibilityWorkbook(t, filepath.Join(t.TempDir(), "book.xlsx"),
+		sheetSpec{"A", sheetVisible},
+		sheetSpec{"B", sheetHidden},
+		sheetSpec{"C", sheetVisible},
+		sheetSpec{"D", sheetVeryHidden},
+		sheetSpec{"E", sheetVisible},
+	)
+
+	db := openWithSheetPolicy(t, ExcelSheetPolicyVisibleOnly, path)
+	defer func() { _ = db.Close() }()
+
+	for table, want := range map[string]string{"book_A": "A", "book_C": "C", "book_E": "E"} {
+		var got string
+		if err := db.QueryRowContext(context.Background(), "SELECT v FROM "+table).Scan(&got); err != nil {
+			t.Fatalf("query %s: %v", table, err)
+		}
+		if got != want {
+			t.Errorf("%s holds %q, want %q; the rows moved between sheets", table, got, want)
+		}
+	}
+}
+
+// TestSheetPolicyDecidesCollisionsAfterFiltering is the rule the two features
+// have to agree on: a sheet nobody loads cannot make a loaded sheet fail.
+func TestSheetPolicyDecidesCollisionsAfterFiltering(t *testing.T) {
+	t.Parallel()
+
+	// "Q1 sales" and "Q1.sales" both sanitize to book_Q1_sales, so the workbook
+	// is refused when both are loaded and accepted when only one is.
+	newBook := func(t *testing.T) string {
+		t.Helper()
+		return visibilityWorkbook(t, filepath.Join(t.TempDir(), "book.xlsx"),
+			sheetSpec{"Q1 sales", sheetVisible},
+			sheetSpec{"Q1.sales", sheetHidden},
+		)
+	}
+
+	t.Run("a hidden sheet that is not loaded does not collide with a shown one", func(t *testing.T) {
+		t.Parallel()
+		db := openWithSheetPolicy(t, ExcelSheetPolicyVisibleOnly, newBook(t))
+		defer func() { _ = db.Close() }()
+
+		var got string
+		if err := db.QueryRowContext(context.Background(), "SELECT v FROM book_Q1_sales").Scan(&got); err != nil {
+			t.Fatalf("query book_Q1_sales: %v", err)
+		}
+		if got != "Q1 sales" {
+			t.Errorf("book_Q1_sales holds %q, want the shown sheet's row", got)
+		}
+	})
+
+	t.Run("the same two sheets collide when the policy loads both", func(t *testing.T) {
+		t.Parallel()
+		_, err := openWithSheetPolicyErr(ExcelSheetPolicyAll, newBook(t))
+		if !errors.Is(err, ErrDuplicateTable) {
+			t.Fatalf("error = %v, want ErrDuplicateTable", err)
+		}
+		for _, want := range []string{"Q1 sales", "Q1.sales", "book_Q1_sales"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q should name %s", err, want)
+			}
+		}
+	})
+
+	t.Run("a very hidden sheet is left out of the collision check too", func(t *testing.T) {
+		t.Parallel()
+		path := visibilityWorkbook(t, filepath.Join(t.TempDir(), "book.xlsx"),
+			sheetSpec{"Q1 sales", sheetVisible},
+			sheetSpec{"Q1.sales", sheetVeryHidden},
+		)
+		db := openWithSheetPolicy(t, ExcelSheetPolicyVisibleOnly, path)
+		defer func() { _ = db.Close() }()
+		assertTables(t, db, "book_Q1_sales")
+	})
+}
+
+// TestSheetPolicyDecidesCollisionsAcrossWorkbooks applies the same rule to two
+// files loaded together: the sheets that decide table names are the loaded
+// ones, per workbook, and a sheet the policy leaves out contributes nothing to
+// any of it.
+func TestSheetPolicyDecidesCollisionsAcrossWorkbooks(t *testing.T) {
+	t.Parallel()
+
+	// Both workbooks hold a sheet called "Shared"; in the first it is hidden.
+	// Their tables are named after their files, so what the policy changes is
+	// which of the four tables exist at all.
+	newPair := func(t *testing.T) (first, second string) {
+		t.Helper()
+		dir := t.TempDir()
+		first = visibilityWorkbook(t, filepath.Join(dir, "left.xlsx"),
+			sheetSpec{"Data", sheetVisible},
+			sheetSpec{"Shared", sheetHidden},
+		)
+		second = visibilityWorkbook(t, filepath.Join(dir, "right.xlsx"),
+			sheetSpec{"Data", sheetVisible},
+			sheetSpec{"Shared", sheetVisible},
+		)
+		return first, second
+	}
+
+	t.Run("the visible-only policy leaves out only the workbook that hid the sheet", func(t *testing.T) {
+		t.Parallel()
+		first, second := newPair(t)
+		db := openWithSheetPolicy(t, ExcelSheetPolicyVisibleOnly, first, second)
+		defer func() { _ = db.Close() }()
+
+		assertTables(t, db, "left_Data", "right_Data", "right_Shared")
+		var got string
+		if err := db.QueryRowContext(context.Background(), "SELECT v FROM right_Shared").Scan(&got); err != nil {
+			t.Fatalf("query right_Shared: %v", err)
+		}
+		if got != "Shared" {
+			t.Errorf("right_Shared holds %q, want the second workbook's own row", got)
+		}
+	})
+
+	t.Run("the all policy loads the hidden sheet as its own workbook's table", func(t *testing.T) {
+		t.Parallel()
+		first, second := newPair(t)
+		db := openWithSheetPolicy(t, ExcelSheetPolicyAll, first, second)
+		defer func() { _ = db.Close() }()
+		assertTables(t, db, "left_Data", "left_Shared", "right_Data", "right_Shared")
+	})
+
+	t.Run("a workbook whose loaded sheets collide with each other is still refused", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		clash := visibilityWorkbook(t, filepath.Join(dir, "book.xlsx"),
+			sheetSpec{"Q1 sales", sheetVisible},
+			sheetSpec{"Q1.sales", sheetVisible},
+		)
+		other := visibilityWorkbook(t, filepath.Join(dir, "other.xlsx"),
+			sheetSpec{"Data", sheetVisible},
+		)
+		if _, err := openWithSheetPolicyErr(ExcelSheetPolicyVisibleOnly, other, clash); !errors.Is(err, ErrDuplicateTable) {
+			t.Fatalf("error = %v, want ErrDuplicateTable", err)
+		}
+	})
+}
+
+// TestVisibleOnlyPolicyOnAnAllHiddenWorkbook pins that "everything was filtered
+// out" is reported as the policy's doing rather than as a workbook with no
+// sheets, because the two need different things done about them.
+func TestVisibleOnlyPolicyOnAnAllHiddenWorkbook(t *testing.T) {
+	t.Parallel()
+	// The workbook has to keep one shown sheet for Excel's sake, so the reader
+	// path is used with a workbook whose only other sheet is hidden, and the
+	// shown one is deleted from the sheet list by naming a policy that skips it.
+	path := visibilityWorkbook(t, filepath.Join(t.TempDir(), "book.xlsx"),
+		sheetSpec{"Shown", sheetVisible},
+		sheetSpec{"Buried", sheetHidden},
+	)
+	sheets, err := ExcelSheetsInFile(path)
+	if err != nil {
+		t.Fatalf("ExcelSheetsInFile: %v", err)
+	}
+	if len(sheets) != 2 {
+		t.Fatalf("got %d sheets, want 2", len(sheets))
+	}
+
+	// A source whose every sheet is hidden cannot be written by excelize, so the
+	// "nothing left" message is checked against the helper that builds it.
+	err = noExcelSheetsError(fakeAllHiddenWorkbook{}, ExcelSheetPolicyVisibleOnly)
+	if !errors.Is(err, ErrEmptyData) {
+		t.Fatalf("error = %v, want ErrEmptyData", err)
+	}
+	if !strings.Contains(err.Error(), "no visible sheets") {
+		t.Errorf("error %q should say the policy left nothing, not that the file has no sheets", err)
+	}
+	err = noExcelSheetsError(fakeAllHiddenWorkbook{empty: true}, ExcelSheetPolicyVisibleOnly)
+	if !strings.Contains(err.Error(), "no sheets found") {
+		t.Errorf("error %q should say the workbook holds no sheets at all", err)
+	}
+}
+
+// fakeAllHiddenWorkbook stands in for a workbook Excel will not write: one with
+// no sheet that is shown.
+type fakeAllHiddenWorkbook struct{ empty bool }
+
+func (f fakeAllHiddenWorkbook) GetSheetList() []string {
+	if f.empty {
+		return nil
+	}
+	return []string{"Buried"}
+}
+
+func (f fakeAllHiddenWorkbook) GetSheetVisible(string) (bool, error) { return false, nil }
+
+// TestSheetPolicyReportsAnUnreadableVisibility pins that the load fails rather
+// than assuming a visibility, on the path that turns sheets into tables.
+func TestSheetPolicyReportsAnUnreadableVisibility(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("sheet index out of range")
+	_, _, err := selectExcelSheets(failingVisibilityWorkbook{err: boom}, ExcelSheetPolicyVisibleOnly)
+	if !errors.Is(err, boom) {
+		t.Fatalf("error = %v, want it to wrap %v", err, boom)
+	}
+	if !errors.Is(err, ErrParsing) {
+		t.Errorf("error = %v, want it to carry ErrParsing", err)
+	}
+}
+
+type failingVisibilityWorkbook struct{ err error }
+
+func (f failingVisibilityWorkbook) GetSheetList() []string { return []string{"Sheet1"} }
+
+func (f failingVisibilityWorkbook) GetSheetVisible(string) (bool, error) { return false, f.err }
+
+// openWithSheetPolicy loads paths under policy and returns the open database.
+func openWithSheetPolicy(t *testing.T, policy ExcelSheetPolicy, paths ...string) *sql.DB {
+	t.Helper()
+	db, err := openWithSheetPolicyErr(policy, paths...)
+	if err != nil {
+		t.Fatalf("open under the %s policy: %v", policy, err)
+	}
+	return db
+}
+
+func openWithSheetPolicyErr(policy ExcelSheetPolicy, paths ...string) (*sql.DB, error) {
+	ctx := context.Background()
+	builder, err := NewBuilder().
+		AddPaths(paths...).
+		WithExcelSheetPolicy(policy).
+		Build(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return builder.Open(ctx)
+}
+
+// gzipFile writes src's bytes to dst through gzip and returns dst.
+func gzipFile(t *testing.T, src, dst string) string {
+	t.Helper()
+	data, err := os.ReadFile(src) //nolint:gosec // a file this test just wrote
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, err := os.Create(dst) //nolint:gosec // a path under the test's temp directory
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := gzip.NewWriter(out)
+	if _, err := zw.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return dst
+}
+
+// TestLoadIntoAppliesSheetPolicy covers the other load entry point: loading
+// into a caller-owned database rather than opening a new one.
+func TestLoadIntoAppliesSheetPolicy(t *testing.T) {
+	t.Parallel()
+	path := mixedVisibilityWorkbook(t, t.TempDir())
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	builder, err := NewBuilder().
+		AddPath(path).
+		WithExcelSheetPolicy(ExcelSheetPolicyVisibleOnly).
+		Build(ctx)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if err := builder.LoadInto(ctx, db); err != nil {
+		t.Fatalf("LoadInto: %v", err)
+	}
+	assertTables(t, db, "book_Shown", "book_AlsoShown")
+}
+
+// TestBuilderSheetPolicyDefaultIsAll states the default in the one place a
+// reader looks for it, so a change to the zero value cannot pass unnoticed.
+func TestBuilderSheetPolicyDefaultIsAll(t *testing.T) {
+	t.Parallel()
+	if got := NewBuilder().excelSheetPolicy; got != ExcelSheetPolicyAll {
+		t.Errorf("a new builder loads with the %s policy, want %s", got, ExcelSheetPolicyAll)
+	}
+	if got := newStreamProcessor(1).excelSheetPolicy; got != ExcelSheetPolicyAll {
+		t.Errorf("a new stream processor loads with the %s policy, want %s", got, ExcelSheetPolicyAll)
+	}
+}

--- a/file.go
+++ b/file.go
@@ -72,6 +72,9 @@ const (
 type file struct {
 	path     string
 	fileType FileType
+	// excelSheetPolicy decides which sheets of a workbook toTable may take its
+	// table from. The zero value is ExcelSheetPolicyAll.
+	excelSheetPolicy ExcelSheetPolicy
 }
 
 // tableChunk represents a chunk of table data for streaming processing
@@ -130,6 +133,9 @@ type streamingParser struct {
 	// malformedRowPolicy controls how a CSV/TSV record whose field count differs
 	// from the header is handled. The zero value is MalformedRowStop.
 	malformedRowPolicy MalformedRowPolicy
+	// excelSheetPolicy controls which sheets of a workbook this parser may take
+	// its table from. The zero value is ExcelSheetPolicyAll.
+	excelSheetPolicy ExcelSheetPolicy
 }
 
 // newFile creates a new file
@@ -294,7 +300,7 @@ func (f *file) toTable() (*table, error) {
 	defer handleCloseError(closeReader)()
 
 	tableName := sanitizeTableName(tableFromFilePath(f.path))
-	return parseWithParser(reader, f.fileType, tableName)
+	return parseWithParser(reader, f.fileType, tableName, f.excelSheetPolicy)
 }
 
 // detectFileType detects file type from extension, considering compressed files

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -345,7 +345,7 @@ type TableData struct {
 type ParseOption func(*parseConfig)
 
 // parseConfig holds the settings the options above set. Its zero value is the
-// behaviour Parse has without any option.
+// behavior Parse has without any option.
 type parseConfig struct {
 	// excelSheetPolicy decides which sheets of a workbook Parse may take its
 	// table from. The zero value takes any of them.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -340,6 +340,30 @@ type TableData struct {
 	ColumnTypes []ColumnType
 }
 
+// ParseOption adjusts how Parse reads a source. Options only affect the formats
+// they name; one that has nothing to say about the given fileType is ignored.
+type ParseOption func(*parseConfig)
+
+// parseConfig holds the settings the options above set. Its zero value is the
+// behaviour Parse has without any option.
+type parseConfig struct {
+	// excelSheetPolicy decides which sheets of a workbook Parse may take its
+	// table from. The zero value takes any of them.
+	excelSheetPolicy ExcelSheetPolicy
+}
+
+// WithExcelSheetPolicy decides which sheets of a workbook Parse may take its
+// table from. It has no effect on other formats.
+//
+// Example:
+//
+//	result, err := parser.Parse(f, parser.XLSX, parser.WithExcelSheetPolicy(parser.ExcelSheetPolicyVisibleOnly))
+func WithExcelSheetPolicy(policy ExcelSheetPolicy) ParseOption {
+	return func(cfg *parseConfig) {
+		cfg.excelSheetPolicy = policy
+	}
+}
+
 // Parse reads data from an io.Reader and returns parsed results.
 // The fileType parameter specifies the format and compression of the data.
 //
@@ -348,9 +372,14 @@ type TableData struct {
 //	f, _ := os.Open("data.csv.gz")
 //	defer f.Close()
 //	result, err := parser.Parse(f, parser.CSVGZ)
-func Parse(reader io.Reader, fileType FileType) (result *TableData, err error) {
+func Parse(reader io.Reader, fileType FileType, opts ...ParseOption) (result *TableData, err error) {
 	if reader == nil {
 		return nil, errors.New("reader cannot be nil")
+	}
+
+	var cfg parseConfig
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
 	// Handle decompression
@@ -378,7 +407,7 @@ func Parse(reader io.Reader, fileType FileType) (result *TableData, err error) {
 	case Parquet:
 		return parseParquet(decompressedReader)
 	case XLSX:
-		return parseXLSX(decompressedReader)
+		return parseXLSX(decompressedReader, cfg.excelSheetPolicy)
 	case JSON:
 		return parseJSON(decompressedReader)
 	case JSONL:

--- a/parser/xlsx.go
+++ b/parser/xlsx.go
@@ -9,8 +9,12 @@ import (
 	"github.com/xuri/excelize/v2"
 )
 
-// parseXLSX parses Excel XLSX data.
-func parseXLSX(reader io.Reader) (table *TableData, err error) {
+// parseXLSX parses Excel XLSX data into one table, taking the first sheet the
+// policy admits. A workbook holds several sheets and TableData holds one table,
+// so a choice has to be made; under ExcelSheetPolicyVisibleOnly the choice
+// matches what the workbook presents rather than what happens to be stored
+// first.
+func parseXLSX(reader io.Reader, policy ExcelSheetPolicy) (table *TableData, err error) {
 	// Read all data into memory (excelize requires this)
 	data, err := io.ReadAll(reader)
 	if err != nil {
@@ -27,9 +31,15 @@ func parseXLSX(reader io.Reader) (table *TableData, err error) {
 		}
 	}()
 
-	// Get the first sheet
-	sheets := f.GetSheetList()
+	// Get the first sheet the policy admits
+	sheets, _, err := SelectExcelSheets(f, policy)
+	if err != nil {
+		return nil, err
+	}
 	if len(sheets) == 0 {
+		if policy == ExcelSheetPolicyVisibleOnly && len(f.GetSheetList()) > 0 {
+			return nil, errors.New("no visible sheets found in XLSX file")
+		}
 		return nil, errors.New("no sheets found in XLSX file")
 	}
 

--- a/parser/xlsx_sheets.go
+++ b/parser/xlsx_sheets.go
@@ -1,0 +1,108 @@
+package parser
+
+import "fmt"
+
+// ExcelSheetPolicy decides which sheets of a workbook a read looks at.
+//
+// A workbook can hide a sheet, and hiding one is how a spreadsheet keeps
+// scratch calculations, lookup tables, and stale drafts out of the way of the
+// sheets it means to present. Whether those belong in a database is the
+// caller's judgement rather than something this package can decide, so which
+// sheets to take is a setting and not a rule.
+type ExcelSheetPolicy int
+
+const (
+	// ExcelSheetPolicyAll reads every sheet, hidden or not. It is the zero
+	// value, so a caller that names no policy keeps the behaviour this package
+	// had before the setting existed.
+	ExcelSheetPolicyAll ExcelSheetPolicy = iota
+
+	// ExcelSheetPolicyVisibleOnly reads only the sheets a workbook shows.
+	//
+	// Excel separates "hidden", which a user can undo from the sheet tabs, from
+	// "very hidden", which only the VBA editor can. The library underneath
+	// reports one boolean covering both, so neither does this package: a sheet
+	// the workbook does not show is left out under this policy, and no claim is
+	// made about which of the two ways it was hidden.
+	ExcelSheetPolicyVisibleOnly
+)
+
+// String renders the policy for messages and logs.
+func (p ExcelSheetPolicy) String() string {
+	switch p {
+	case ExcelSheetPolicyVisibleOnly:
+		return "visible-only"
+	case ExcelSheetPolicyAll:
+		return "all"
+	default:
+		return fmt.Sprintf("ExcelSheetPolicy(%d)", int(p))
+	}
+}
+
+// ExcelSheet is one sheet of a workbook and whether the workbook shows it.
+type ExcelSheet struct {
+	// Name is the sheet name as the workbook stores it, before any sanitizing a
+	// caller applies to turn it into a table name.
+	Name string
+	// Visible is false for a sheet the workbook does not show, whether it is
+	// hidden or very hidden.
+	Visible bool
+}
+
+// ExcelSheetSource is the part of an open workbook that sheet selection reads.
+//
+// It is an interface rather than the concrete workbook type for two reasons:
+// the excelize dependency stays out of this package's signatures, and the
+// selection rules — order, filtering, and what happens when a visibility cannot
+// be read — become testable without a workbook that has to be coaxed into
+// failing.
+type ExcelSheetSource interface {
+	// GetSheetList returns the sheet names in the order the workbook stores them.
+	GetSheetList() []string
+	// GetSheetVisible reports whether the workbook shows the named sheet.
+	GetSheetVisible(sheet string) (bool, error)
+}
+
+// ExcelSheets returns every sheet of the workbook in the order the workbook
+// stores them, with the visibility it reports for each.
+//
+// A visibility that cannot be read is an error, not an assumption. Defaulting
+// to visible would load a sheet the workbook hides; defaulting to hidden would
+// drop one it shows. Either way the caller is told something untrue about the
+// file, which is worse than being told the file could not be understood.
+func ExcelSheets(f ExcelSheetSource) ([]ExcelSheet, error) {
+	names := f.GetSheetList()
+	sheets := make([]ExcelSheet, 0, len(names))
+	for _, name := range names {
+		visible, err := f.GetSheetVisible(name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read the visibility of sheet %q: %w", name, err)
+		}
+		sheets = append(sheets, ExcelSheet{Name: name, Visible: visible})
+	}
+	return sheets, nil
+}
+
+// SelectExcelSheets returns the sheets policy admits, in workbook order, and
+// the names it left out.
+//
+// Every Excel read goes through this rather than filtering at its own call to
+// the sheet list, so "which sheets does this workbook contribute?" has one
+// answer whatever opened the file. That matters most for the caller that maps
+// sheets onto table names: the names it must keep apart are the ones actually
+// loaded, and a sheet nobody reads cannot collide with one that is read.
+func SelectExcelSheets(f ExcelSheetSource, policy ExcelSheetPolicy) (loaded, skipped []string, err error) {
+	sheets, err := ExcelSheets(f)
+	if err != nil {
+		return nil, nil, err
+	}
+	loaded = make([]string, 0, len(sheets))
+	for _, sheet := range sheets {
+		if policy == ExcelSheetPolicyVisibleOnly && !sheet.Visible {
+			skipped = append(skipped, sheet.Name)
+			continue
+		}
+		loaded = append(loaded, sheet.Name)
+	}
+	return loaded, skipped, nil
+}

--- a/parser/xlsx_sheets.go
+++ b/parser/xlsx_sheets.go
@@ -7,13 +7,13 @@ import "fmt"
 // A workbook can hide a sheet, and hiding one is how a spreadsheet keeps
 // scratch calculations, lookup tables, and stale drafts out of the way of the
 // sheets it means to present. Whether those belong in a database is the
-// caller's judgement rather than something this package can decide, so which
+// caller's judgment rather than something this package can decide, so which
 // sheets to take is a setting and not a rule.
 type ExcelSheetPolicy int
 
 const (
 	// ExcelSheetPolicyAll reads every sheet, hidden or not. It is the zero
-	// value, so a caller that names no policy keeps the behaviour this package
+	// value, so a caller that names no policy keeps the behavior this package
 	// had before the setting existed.
 	ExcelSheetPolicyAll ExcelSheetPolicy = iota
 

--- a/parser/xlsx_sheets_test.go
+++ b/parser/xlsx_sheets_test.go
@@ -1,0 +1,158 @@
+package parser
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeSheetSource is a workbook whose sheet list and per-sheet visibility are
+// stated outright, including the visibility that cannot be read. A real
+// workbook cannot be made to fail that call on demand, and "what happens when
+// the visibility is unknown?" is the question the whole policy turns on.
+type fakeSheetSource struct {
+	names   []string
+	visible map[string]bool
+	failOn  map[string]error
+}
+
+func (f fakeSheetSource) GetSheetList() []string { return f.names }
+
+func (f fakeSheetSource) GetSheetVisible(sheet string) (bool, error) {
+	if err, ok := f.failOn[sheet]; ok {
+		return false, err
+	}
+	return f.visible[sheet], nil
+}
+
+func newFakeSheetSource(order []string, hidden ...string) fakeSheetSource {
+	visible := make(map[string]bool, len(order))
+	for _, name := range order {
+		visible[name] = true
+	}
+	for _, name := range hidden {
+		visible[name] = false
+	}
+	return fakeSheetSource{names: order, visible: visible}
+}
+
+func TestExcelSheets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reports every sheet in workbook order with its visibility", func(t *testing.T) {
+		t.Parallel()
+		src := newFakeSheetSource([]string{"First", "Internal", "Last"}, "Internal")
+
+		got, err := ExcelSheets(src)
+		if err != nil {
+			t.Fatalf("ExcelSheets: %v", err)
+		}
+		want := []ExcelSheet{
+			{Name: "First", Visible: true},
+			{Name: "Internal", Visible: false},
+			{Name: "Last", Visible: true},
+		}
+		if len(got) != len(want) {
+			t.Fatalf("got %d sheets, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("sheet %d = %+v, want %+v", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("reports a visibility that cannot be read instead of guessing", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("sheet index out of range")
+		src := fakeSheetSource{
+			names:   []string{"First", "Broken"},
+			visible: map[string]bool{"First": true},
+			failOn:  map[string]error{"Broken": boom},
+		}
+
+		_, err := ExcelSheets(src)
+		if !errors.Is(err, boom) {
+			t.Fatalf("error = %v, want it to wrap %v", err, boom)
+		}
+		if !strings.Contains(err.Error(), `"Broken"`) {
+			t.Errorf("error %q should name the sheet it failed on", err)
+		}
+	})
+}
+
+func TestSelectExcelSheets(t *testing.T) {
+	t.Parallel()
+
+	order := []string{"Visible", "Hidden", "AlsoVisible", "VeryHidden"}
+	src := newFakeSheetSource(order, "Hidden", "VeryHidden")
+
+	t.Run("the all policy keeps every sheet in workbook order", func(t *testing.T) {
+		t.Parallel()
+		loaded, skipped, err := SelectExcelSheets(src, ExcelSheetPolicyAll)
+		if err != nil {
+			t.Fatalf("SelectExcelSheets: %v", err)
+		}
+		if strings.Join(loaded, ",") != strings.Join(order, ",") {
+			t.Errorf("loaded = %v, want %v", loaded, order)
+		}
+		if len(skipped) != 0 {
+			t.Errorf("skipped = %v, want nothing skipped", skipped)
+		}
+	})
+
+	t.Run("the visible-only policy keeps the shown sheets in workbook order", func(t *testing.T) {
+		t.Parallel()
+		loaded, skipped, err := SelectExcelSheets(src, ExcelSheetPolicyVisibleOnly)
+		if err != nil {
+			t.Fatalf("SelectExcelSheets: %v", err)
+		}
+		if want := "Visible,AlsoVisible"; strings.Join(loaded, ",") != want {
+			t.Errorf("loaded = %v, want %s", loaded, want)
+		}
+		// Both ways of hiding a sheet are left out, and the skipped list keeps the
+		// workbook's order too so a caller can report them predictably.
+		if want := "Hidden,VeryHidden"; strings.Join(skipped, ",") != want {
+			t.Errorf("skipped = %v, want %s", skipped, want)
+		}
+	})
+
+	t.Run("a visibility that cannot be read fails the selection", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("no such sheet")
+		bad := fakeSheetSource{
+			names:   []string{"Broken"},
+			visible: map[string]bool{},
+			failOn:  map[string]error{"Broken": boom},
+		}
+		if _, _, err := SelectExcelSheets(bad, ExcelSheetPolicyVisibleOnly); !errors.Is(err, boom) {
+			t.Fatalf("error = %v, want it to wrap %v", err, boom)
+		}
+	})
+
+	t.Run("a workbook with no sheets selects nothing without failing", func(t *testing.T) {
+		t.Parallel()
+		loaded, skipped, err := SelectExcelSheets(fakeSheetSource{}, ExcelSheetPolicyVisibleOnly)
+		if err != nil {
+			t.Fatalf("SelectExcelSheets: %v", err)
+		}
+		if len(loaded) != 0 || len(skipped) != 0 {
+			t.Errorf("loaded = %v, skipped = %v, want both empty", loaded, skipped)
+		}
+	})
+}
+
+func TestExcelSheetPolicyString(t *testing.T) {
+	t.Parallel()
+
+	tests := map[ExcelSheetPolicy]string{
+		ExcelSheetPolicyAll:         "all",
+		ExcelSheetPolicyVisibleOnly: "visible-only",
+		ExcelSheetPolicy(7):         "ExcelSheetPolicy(7)",
+	}
+	for policy, want := range tests {
+		if got := policy.String(); got != want {
+			t.Errorf("ExcelSheetPolicy(%d).String() = %q, want %q", int(policy), got, want)
+		}
+	}
+}

--- a/parser/xlsx_test.go
+++ b/parser/xlsx_test.go
@@ -26,7 +26,7 @@ func TestParseXLSX(t *testing.T) {
 		require.NoError(t, err)
 		defer f.Close()
 
-		result, err := parseXLSX(f)
+		result, err := parseXLSX(f, ExcelSheetPolicyAll)
 
 		require.NoError(t, err)
 		assert.Greater(t, len(result.Headers), 0)
@@ -38,7 +38,7 @@ func TestParseXLSX(t *testing.T) {
 
 		reader := bytes.NewReader([]byte{})
 
-		_, err := parseXLSX(reader)
+		_, err := parseXLSX(reader, ExcelSheetPolicyAll)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to open XLSX")
@@ -49,7 +49,7 @@ func TestParseXLSX(t *testing.T) {
 
 		reader := strings.NewReader("not an xlsx file")
 
-		_, err := parseXLSX(reader)
+		_, err := parseXLSX(reader, ExcelSheetPolicyAll)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to open XLSX")
@@ -66,7 +66,7 @@ func TestParseXLSX_ErrorCases(t *testing.T) {
 		// We primarily test the error path through invalid data
 		reader := bytes.NewReader([]byte{0x50, 0x4B, 0x03, 0x04}) // ZIP magic bytes but not valid XLSX
 
-		_, err := parseXLSX(reader)
+		_, err := parseXLSX(reader, ExcelSheetPolicyAll)
 
 		// Should fail during XLSX parsing
 		assert.Error(t, err)

--- a/parser_bridge.go
+++ b/parser_bridge.go
@@ -67,13 +67,13 @@ func parserColumnType(ct parser.ColumnType) columnType {
 
 // parseWithParser uses the fileparser package to parse data and returns a filesql table.
 // This function bridges the fileparser package with filesql's internal table structure.
-func parseWithParser(reader io.Reader, fileType FileType, tableName string) (*table, error) {
+func parseWithParser(reader io.Reader, fileType FileType, tableName string, excelSheetPolicy ExcelSheetPolicy) (*table, error) {
 	// Strip a Unicode BOM (and transcode UTF-16) before the text parser sees it,
 	// matching the streaming path; binary formats keep their raw bytes.
 	if isTextBaseType(fileType) {
 		reader = decodeTextReader(reader)
 	}
-	result, err := parser.Parse(reader, parserFileType(fileType))
+	result, err := parser.Parse(reader, parserFileType(fileType), parser.WithExcelSheetPolicy(excelSheetPolicy))
 	if err != nil {
 		// Convert parser errors to filesql errors for compatibility
 		return nil, convertParserError(err)

--- a/stream.go
+++ b/stream.go
@@ -782,13 +782,16 @@ func (p *streamingParser) parseXLSXStream(reader io.Reader) (*table, error) {
 		_ = xlsxFile.Close() // Ignore close error
 	}()
 
-	// Get all sheet names
-	sheetNames := xlsxFile.GetSheetList()
+	// Get the sheet names the policy admits
+	sheetNames, _, err := selectExcelSheets(xlsxFile, p.excelSheetPolicy)
+	if err != nil {
+		return nil, err
+	}
 	if len(sheetNames) == 0 {
-		return nil, fmt.Errorf("%w: no sheets found in XLSX file", ErrEmptyData)
+		return nil, noExcelSheetsError(xlsxFile, p.excelSheetPolicy)
 	}
 
-	// With the streaming parser, we only process the first sheet
+	// With the streaming parser, we only process the first sheet the policy left
 	sheetName := sheetNames[0]
 	iter, err := xlsxFile.Rows(sheetName)
 	if err != nil {
@@ -865,13 +868,16 @@ func (p *streamingParser) processXLSXInChunks(reader io.Reader, processor chunkP
 		_ = xlsxFile.Close() // Ignore close error
 	}()
 
-	// Get all sheet names
-	sheetNames := xlsxFile.GetSheetList()
+	// Get the sheet names the policy admits
+	sheetNames, _, err := selectExcelSheets(xlsxFile, p.excelSheetPolicy)
+	if err != nil {
+		return err
+	}
 	if len(sheetNames) == 0 {
-		return fmt.Errorf("%w: no sheets found in XLSX file", ErrEmptyData)
+		return noExcelSheetsError(xlsxFile, p.excelSheetPolicy)
 	}
 
-	// Process only the first sheet (streaming parser limitation)
+	// Process only the first admitted sheet (streaming parser limitation)
 	sheetName := sheetNames[0]
 	iter, err := xlsxFile.Rows(sheetName)
 	if err != nil {

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -37,6 +37,9 @@ type streamProcessor struct {
 	// malformedRowPolicy controls how a CSV/TSV record whose field count differs
 	// from the header is handled. The zero value is MalformedRowStop.
 	malformedRowPolicy MalformedRowPolicy
+	// excelSheetPolicy controls which sheets of a workbook are loaded. The zero
+	// value is ExcelSheetPolicyAll.
+	excelSheetPolicy ExcelSheetPolicy
 }
 
 // dropIfReplacing drops a same-named table when replaceExisting is set, so the
@@ -283,6 +286,7 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, 
 	// Create streaming parser for chunked processing
 	parser := newStreamingParser(input.fileType, input.compression, input.tableName, sp.chunkSize)
 	parser.malformedRowPolicy = sp.malformedRowPolicy
+	parser.excelSheetPolicy = sp.excelSheetPolicy
 
 	// Initialize the table schema (we need to peek at the first chunk to get headers)
 	var tableCreated bool
@@ -510,6 +514,7 @@ func (sp *streamProcessor) createEmptyTable(ctx context.Context, db DBTX, input 
 	// Parse just the header to get column information
 	tempParser := newStreamingParser(input.fileType, input.compression, input.tableName, 1)
 	tempParser.malformedRowPolicy = sp.malformedRowPolicy
+	tempParser.excelSheetPolicy = sp.excelSheetPolicy
 	tempTable, err := tempParser.parseFromReader(input.reader)
 	if err != nil {
 		// Check if this is a parsing error we should preserve (like duplicate columns)
@@ -615,11 +620,20 @@ func (sp *streamProcessor) streamXLSXFileToDatabase(ctx context.Context, db DBTX
 		_ = xlsxFile.Close() // Ignore close error
 	}()
 
-	// Get all sheet names
-	sheetNames := xlsxFile.GetSheetList()
+	// Get the sheet names the policy admits. Filtering here rather than while
+	// looping is what lets the collision check below see exactly the sheets that
+	// will become tables.
+	sheetNames, skipped, err := selectExcelSheets(xlsxFile, sp.excelSheetPolicy)
+	if err != nil {
+		sp.logger.Error("failed to read sheet visibility", "path", filePath, "error", err)
+		return err
+	}
+	if len(skipped) > 0 {
+		sp.logger.Info("skipping sheets the workbook hides", "path", filePath, "skipped_count", len(skipped))
+	}
 	if len(sheetNames) == 0 {
-		sp.logger.Warn("no sheets found in XLSX file", "path", filePath)
-		return fmt.Errorf("%w: no sheets found in XLSX file", ErrEmptyData)
+		sp.logger.Warn("no sheets to load from XLSX file", "path", filePath)
+		return noExcelSheetsError(xlsxFile, sp.excelSheetPolicy)
 	}
 	sp.logger.Info("processing XLSX file", "path", filePath, "sheet_count", len(sheetNames))
 


### PR DESCRIPTION
A workbook can hide a sheet, and a hidden one usually holds the spreadsheet's own working-out rather than data anyone meant to publish. Every Excel read path in filesql called `GetSheetList` directly and loaded whatever came back, so a caller wanting only the shown sheets had no way to say so, and no way to find out which sheets it had been given.

## What changes

`DBBuilder.WithExcelSheetPolicy` decides which sheets a load reads. The default stays `ExcelSheetPolicyAll` — the behaviour every previous release had — so no existing program loses a table. `ExcelSheetPolicyVisibleOnly` loads only the sheets the workbook shows.

The four call sites that enumerated sheets (`builder.go`, `stream.go` twice, `stream_processor.go`) now go through one selection function rather than each growing its own filter. That is what makes the policy apply to a path, a directory, an embedded filesystem, a reader, and a compressed workbook alike. `parser.Parse` gains `parser.WithExcelSheetPolicy` for the same reason: it reads one sheet, and under the visible-only policy it takes the first sheet the workbook shows rather than the first one stored.

Filtering runs before table names are worked out, so a hidden sheet that would sanitize to the same table as a visible one is not a collision when it is not loaded. The existing refusal still applies to the sheets that are loaded.

A visibility that cannot be read fails the load instead of defaulting either way. Guessing visible loads a sheet the workbook hides; guessing hidden drops one it shows. Both tell the caller something untrue about the file.

`ExcelSheetsInFile` and `ExcelSheetsInReader` report a workbook's sheets and their visibility without loading anything, so a caller that has to explain which sheets a policy left behind uses the same view filesql does rather than reimplementing the rule.

## Hidden versus very hidden

Excel separates "hidden", which a reader can undo from the sheet tabs, from "very hidden", which only the VBA editor can. excelize reports one boolean covering both, so filesql does not tell them apart: neither is shown, both are left out, and nothing here claims otherwise.

## Tests

The fixtures are generated through excelize rather than committed as opaque workbooks, so the visibility each case depends on is stated in the test itself. Covered: both ways of hiding a sheet, the path/reader/FS/compressed/`LoadInto` entry points, workbook order surviving the filter, collisions judged after filtering and still caught before it, cross-workbook loads, an unreadable visibility propagating, and the default staying `all`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added controls to load all Excel sheets or only visible sheets.
  * Added APIs to inspect Excel sheet names and visibility before importing.
  * Applied sheet visibility filtering across file, reader, streaming, and parsing workflows.
  * Hidden and very hidden sheets are excluded when visible-only mode is enabled.
  * Preserved workbook sheet order and handled workbooks with no eligible sheets.

* **Documentation**
  * Added guidance and examples for Excel sheet visibility controls and inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->