### PR TITLE
chore: release v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-08-04
+
 ### Added
 
 - Excel sheet visibility policy. `DBBuilder.WithExcelSheetPolicy` decides which


### PR DESCRIPTION
Cuts the Excel sheet visibility policy as v0.32.0. The change is additive — filesql's default stays `ExcelSheetPolicyAll`, so no existing caller loses a table — which makes this a minor bump.