### PR TITLE
fix: stop discarding an input because another shares its base name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.1] - 2026-08-04
+
+### Fixed
+
+- Stop discarding an input because another input shares its base name.
+  Deduplication — which exists so a dataset offered both plain and compressed is
+  read once — was keyed on the derived table name, so `a/users.csv` and
+  `b/users.csv` looked like one source and one of them was dropped without a
+  word. Files are now the same source only when they are in the same place: the
+  path with any compression suffix removed. `dir/users.csv` still displaces
+  `dir/users.csv.gz`; `a/users.csv` and `b/users.csv.gz` are two inputs and both
+  are loaded.
+- Return the surviving inputs in the order they were given. The result was built
+  by ranging over a map, so the order changed between runs of the same command.
+  Everything downstream reads it: which input a `LoadInto` leaves in place under
+  its last-wins rule, which malformed file a failing load names, and the order
+  the duplicate-table check works through.
+
+Loading a directory tree that holds two files of the same base name in different
+subdirectories now fails with `ErrDuplicateTable` instead of silently loading
+one of them. That is a behavior change, and it is the point: the previous
+outcome was to lose a file and not say which. `LoadInto` and `LoadIntoTx` keep
+their last-wins contract for a same-named table — what changed is that both
+inputs are now read at all.
+
 ## [0.32.0] - 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ filesql is for cases where the data is already in a file and the fastest useful 
 | `.ach` | ACH (NACHA) | Experimental |
 | `.fed` | Fedwire | Experimental |
 
+Two inputs are the same source only when they are in the same place. `dir/users.csv` and `dir/users.csv.gz` are one dataset offered twice, and the plain one is read; `a/users.csv` and `b/users.csv` are two files, and both are loaded — which then asks for one table twice, and is reported rather than resolved by picking one.
+
 Compressed wrappers are supported for CSV, TSV, LTSV, JSON, JSONL, Parquet, and XLSX:
 `.gz`, `.bz2`, `.xz`, `.zst`, `.z`, `.snappy`, `.s2`, `.lz4`.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ filesql is for cases where the data is already in a file and the fastest useful 
 | `.ach` | ACH (NACHA) | Experimental |
 | `.fed` | Fedwire | Experimental |
 
-Two inputs are the same source only when they are in the same place. `dir/users.csv` and `dir/users.csv.gz` are one dataset offered twice, and the plain one is read; `a/users.csv` and `b/users.csv` are two files, and both are loaded — which then asks for one table twice, and is reported rather than resolved by picking one.
+Two inputs are the same source only when they are in the same place. `dir/users.csv` and `dir/users.csv.gz` are one dataset offered twice, and the plain one is read; `a/users.csv` and `b/users.csv` are two files, and both are loaded. What happens when both then want the table `users` is the loading API's business: `Open` and `OpenContext` build a fresh database and refuse it with `ErrDuplicateTable`, while `LoadInto` and `LoadIntoTx` load into a database you own and keep their last-wins rule, so the later input replaces the table. Neither one silently drops a file.
 
 Compressed wrappers are supported for CSV, TSV, LTSV, JSON, JSONL, Parquet, and XLSX:
 `.gz`, `.bz2`, `.xz`, `.zst`, `.z`, `.snappy`, `.s2`, `.lz4`.

--- a/dedup_test.go
+++ b/dedup_test.go
@@ -1,0 +1,417 @@
+package filesql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Deduplication exists for one case: the same dataset offered both plain and
+// compressed, where reading both would build one table from one place twice.
+// It used to be keyed on the table name instead of the place, which made
+// "a/users.csv" and "b/users.csv" look like the same input. One of them was
+// dropped, nothing was said about it, and which one survived came out of a Go
+// map — so the same command could lose a different file on different runs.
+//
+// These tests pin both halves of the repair: what counts as one source, and
+// that the surviving order is the order the caller gave.
+
+// TestSourceIdentity covers the rule the deduplication is built on, directly.
+func TestSourceIdentity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a codec suffix does not change which source a path names", func(t *testing.T) {
+		t.Parallel()
+		for _, compressed := range []string{
+			"dir/users.csv.gz", "dir/users.csv.bz2", "dir/users.csv.xz",
+			"dir/users.csv.zst", "dir/users.csv.z", "dir/users.csv.snappy",
+			"dir/users.csv.s2", "dir/users.csv.lz4",
+		} {
+			if got, want := sourceIdentity(compressed), sourceIdentity("dir/users.csv"); got != want {
+				t.Errorf("sourceIdentity(%q) = %q, want %q", compressed, got, want)
+			}
+		}
+	})
+
+	t.Run("the same file written two ways is one source", func(t *testing.T) {
+		t.Parallel()
+		if got, want := sourceIdentity("./dir/users.csv"), sourceIdentity("dir/users.csv"); got != want {
+			t.Errorf("sourceIdentity of an equivalent path = %q, want %q", got, want)
+		}
+		if got, want := sourceIdentity("dir/../dir/users.csv"), sourceIdentity("dir/users.csv"); got != want {
+			t.Errorf("sourceIdentity of an equivalent path = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("files in different directories are different sources", func(t *testing.T) {
+		t.Parallel()
+		pairs := [][2]string{
+			{"a/users.csv", "b/users.csv"},
+			{"a/users.csv", "b/users.csv.gz"},
+			{"a/book.xlsx.gz", "b/book.xlsx.gz"},
+			{"users.csv", "nested/users.csv"},
+		}
+		for _, pair := range pairs {
+			if sourceIdentity(pair[0]) == sourceIdentity(pair[1]) {
+				t.Errorf("%q and %q share a source identity; they are different files", pair[0], pair[1])
+			}
+		}
+	})
+
+	t.Run("different files in one directory are different sources", func(t *testing.T) {
+		t.Parallel()
+		// These sanitize to the same table name. That is a collision for whoever
+		// creates the tables to report, and no business of deduplication's.
+		if sourceIdentity("dir/user-data.csv") == sourceIdentity("dir/user data.csv") {
+			t.Error("two differently named files share a source identity")
+		}
+		if sourceIdentity("dir/products.tsv") == sourceIdentity("dir/products.parquet") {
+			t.Error("two formats of different data share a source identity")
+		}
+	})
+}
+
+// TestDeduplicateCompressedFiles asserts the whole result slice, in order,
+// rather than membership. Order is the half of the contract a set comparison
+// cannot see, and it is the half everything downstream reads: which input a
+// last-wins load leaves in place, which malformed file a failing load names,
+// and what order the collision check works through.
+func TestDeduplicateCompressedFiles(t *testing.T) {
+	t.Parallel()
+
+	fp := newFileProcessor(1)
+
+	tests := []struct {
+		name  string
+		files []string
+		want  []string
+	}{
+		{
+			name:  "a plain file wins over its own compressed twin",
+			files: []string{"dir/users.csv", "dir/users.csv.gz"},
+			want:  []string{"dir/users.csv"},
+		},
+		{
+			name: "and wins from behind, too",
+			// The plain file is second here. Preferring it must not depend on it
+			// being seen first.
+			files: []string{"dir/users.csv.gz", "dir/users.csv"},
+			want:  []string{"dir/users.csv"},
+		},
+		{
+			name:  "the same name in two directories is two sources",
+			files: []string{"a/users.csv", "b/users.csv"},
+			want:  []string{"a/users.csv", "b/users.csv"},
+		},
+		{
+			name: "a plain file does not displace a compressed file somewhere else",
+			// The bug this replaces: both map to table "users", so one vanished.
+			files: []string{"a/users.csv", "b/users.csv.gz"},
+			want:  []string{"a/users.csv", "b/users.csv.gz"},
+		},
+		{
+			name:  "two compressed workbooks in different directories both survive",
+			files: []string{"a/book.xlsx.gz", "b/book.xlsx.gz"},
+			want:  []string{"a/book.xlsx.gz", "b/book.xlsx.gz"},
+		},
+		{
+			name: "files that only share a sanitized name both survive",
+			// "user-data" and "user data" both sanitize to user_data, and
+			// products.tsv and products.parquet both to products. Whether that
+			// can be loaded is the table layer's decision, made out loud.
+			files: []string{"dir/user-data.csv", "dir/user data.csv", "dir/products.tsv", "dir/products.parquet"},
+			want:  []string{"dir/user-data.csv", "dir/user data.csv", "dir/products.tsv", "dir/products.parquet"},
+		},
+		{
+			name: "order survives a longer list",
+			files: []string{
+				"z/last.csv", "a/first.csv", "m/middle.csv.gz",
+				"a/first.csv.gz", "q/other.tsv",
+			},
+			want: []string{"z/last.csv", "a/first.csv", "m/middle.csv.gz", "q/other.tsv"},
+		},
+		{
+			name:  "the same source named twice is read once",
+			files: []string{"./dir/users.csv", "dir/users.csv"},
+			want:  []string{"./dir/users.csv"},
+		},
+		{
+			name:  "an exact repeat is read once",
+			files: []string{"dir/users.csv", "dir/users.csv"},
+			want:  []string{"dir/users.csv"},
+		},
+		{
+			name:  "a lone compressed file is kept",
+			files: []string{"dir/users.csv.gz"},
+			want:  []string{"dir/users.csv.gz"},
+		},
+		{
+			name:  "nothing in, nothing out",
+			files: []string{},
+			want:  []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := fp.deduplicateCompressedFiles(tt.files)
+			if strings.Join(got, "|") != strings.Join(tt.want, "|") {
+				t.Errorf("deduplicateCompressedFiles(%v)\n got %v\nwant %v", tt.files, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDeduplicateCompressedFilesIsStable checks the result is a function of the
+// input and nothing else. The old implementation built its result by ranging
+// over a map, so the answer was free to change between calls in one process —
+// which is exactly the kind of failure that reproduces once and then hides.
+func TestDeduplicateCompressedFilesIsStable(t *testing.T) {
+	t.Parallel()
+
+	fp := newFileProcessor(1)
+	files := []string{
+		"a/users.csv", "b/users.csv.gz", "c/users.csv", "a/users.csv.gz",
+		"d/orders.tsv", "e/orders.tsv", "f/logs.ltsv.xz",
+	}
+	want := strings.Join(fp.deduplicateCompressedFiles(files), "|")
+
+	for i := range 50 {
+		got := strings.Join(fp.deduplicateCompressedFiles(files), "|")
+		if got != want {
+			t.Fatalf("call %d returned %q, want %q; the result depends on something other than the input", i, got, want)
+		}
+	}
+	// And the answer itself, so a stable-but-wrong result is not mistaken for
+	// success.
+	if expected := "a/users.csv|b/users.csv.gz|c/users.csv|d/orders.tsv|e/orders.tsv|f/logs.ltsv.xz"; want != expected {
+		t.Errorf("result = %q, want %q", want, expected)
+	}
+}
+
+// writeCSVFile writes a one-column CSV whose single row carries value.
+func writeCSVFile(t *testing.T, path, value string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("v\n"+value+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// sameNamePair writes a/book.csv and b/book.csv, each carrying its own value.
+// Both want the table "book", so what each API does with them is the question
+// these tests ask.
+func sameNamePair(t *testing.T) (first, second string) {
+	t.Helper()
+	dir := t.TempDir()
+	return writeCSVFile(t, filepath.Join(dir, "a", "book.csv"), "from-a"),
+		writeCSVFile(t, filepath.Join(dir, "b", "book.csv"), "from-b")
+}
+
+// TestOpenContextRefusesTwoSourcesWantingOneTable pins Open's side of the
+// contract. Open builds a fresh database, so two files asking for one table
+// cannot both be honored, and the answer is a refusal that names the file —
+// deterministically, on every run. What it must never be is one of the two
+// loading and the other disappearing.
+func TestOpenContextRefusesTwoSourcesWantingOneTable(t *testing.T) {
+	t.Parallel()
+	first, second := sameNamePair(t)
+
+	db, err := OpenContext(context.Background(), first, second)
+	if err == nil {
+		_ = db.Close()
+		t.Fatal("OpenContext succeeded on two files that both want the table 'book'")
+	}
+	if !errors.Is(err, ErrDuplicateTable) {
+		t.Errorf("error = %v, want ErrDuplicateTable", err)
+	}
+	// The second file is the one that found the name taken, so it is the one
+	// named. Reversing the arguments reverses that, which the next check asserts.
+	if !strings.Contains(err.Error(), filepath.ToSlash(second)) {
+		t.Errorf("error %q should name the file that collided, %q", err, second)
+	}
+
+	reversed, err := OpenContext(context.Background(), second, first)
+	if err == nil {
+		_ = reversed.Close()
+		t.Fatal("OpenContext succeeded with the arguments reversed")
+	}
+	if !strings.Contains(err.Error(), filepath.ToSlash(first)) {
+		t.Errorf("with the arguments reversed the error %q should name %q", err, first)
+	}
+}
+
+// TestLoadIntoKeepsItsLastWinsContract pins the other API's side, and pins that
+// this change did not move it. LoadInto loads into a database the caller owns,
+// where replacing a same-named table is the useful behavior and has been the
+// documented one; what changed is only that both inputs are now read at all.
+// Before, one of them was discarded before any of this was reached.
+func TestLoadIntoKeepsItsLastWinsContract(t *testing.T) {
+	t.Parallel()
+	first, second := sameNamePair(t)
+
+	for _, tt := range []struct {
+		name  string
+		paths []string
+		want  string
+	}{
+		{name: "the later input wins", paths: []string{first, second}, want: "from-b"},
+		{name: "and reversing the order reverses the winner", paths: []string{second, first}, want: "from-a"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			db := newMemoryDB(t)
+			ctx := context.Background()
+			if err := LoadInto(ctx, db, tt.paths...); err != nil {
+				t.Fatalf("LoadInto: %v", err)
+			}
+			var got string
+			if err := db.QueryRowContext(ctx, "SELECT v FROM book").Scan(&got); err != nil {
+				t.Fatalf("query book: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("book holds %q, want %q; input order decides last-wins", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoadIntoTxKeepsInputOrder is the same question for the transactional
+// entry point, where the caller owns the transaction as well.
+func TestLoadIntoTxKeepsInputOrder(t *testing.T) {
+	t.Parallel()
+	first, second := sameNamePair(t)
+
+	for _, tt := range []struct {
+		name  string
+		paths []string
+		want  string
+	}{
+		{name: "the later input wins", paths: []string{first, second}, want: "from-b"},
+		{name: "and reversing the order reverses the winner", paths: []string{second, first}, want: "from-a"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			db := newMemoryDB(t)
+			ctx := context.Background()
+
+			builder, err := NewBuilder().AddPaths(tt.paths...).Build(ctx)
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			tx, err := db.BeginTx(ctx, nil)
+			if err != nil {
+				t.Fatalf("BeginTx: %v", err)
+			}
+			if err := builder.LoadIntoTx(ctx, tx); err != nil {
+				if rollbackErr := tx.Rollback(); rollbackErr != nil {
+					t.Errorf("rollback after a failed load: %v", rollbackErr)
+				}
+				t.Fatalf("LoadIntoTx: %v", err)
+			}
+			if err := tx.Commit(); err != nil {
+				t.Fatalf("Commit: %v", err)
+			}
+
+			var got string
+			if err := db.QueryRowContext(ctx, "SELECT v FROM book").Scan(&got); err != nil {
+				t.Fatalf("query book: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("book holds %q, want %q; input order decides last-wins", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoadReadsEveryDistinctSource is the plainest statement of what the repair
+// bought: files that merely share a base name all arrive.
+func TestLoadReadsEveryDistinctSource(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	paths := []string{
+		writeCSVFile(t, filepath.Join(dir, "a", "users.csv"), "a"),
+		writeCSVFile(t, filepath.Join(dir, "b", "orders.csv"), "b"),
+		writeCSVFile(t, filepath.Join(dir, "c", "logs.csv"), "c"),
+	}
+
+	db := newMemoryDB(t)
+	ctx := context.Background()
+	if err := LoadInto(ctx, db, paths...); err != nil {
+		t.Fatalf("LoadInto: %v", err)
+	}
+	for table, want := range map[string]string{"users": "a", "orders": "b", "logs": "c"} {
+		var got string
+		if err := db.QueryRowContext(ctx, "SELECT v FROM "+table).Scan(&got); err != nil {
+			t.Fatalf("query %s: %v", table, err)
+		}
+		if got != want {
+			t.Errorf("%s holds %q, want %q", table, got, want)
+		}
+	}
+}
+
+// TestOpenDirectoryWithCollidingBasenamesFails is the test the repointed
+// fixtures above refer to. A directory tree holding two files of the same base
+// name in different subdirectories cannot become one database, and saying so is
+// the whole point: the previous behavior was to load one of them and leave the
+// other out, without a word and without deciding which.
+func TestOpenDirectoryWithCollidingBasenamesFails(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeCSVFile(t, filepath.Join(dir, "a", "book.csv"), "from-a")
+	writeCSVFile(t, filepath.Join(dir, "b", "book.csv"), "from-b")
+
+	db, err := Open(dir)
+	if err == nil {
+		_ = db.Close()
+		t.Fatal("Open succeeded on a tree with two files that both want the table 'book'")
+	}
+	if !errors.Is(err, ErrDuplicateTable) {
+		t.Errorf("error = %v, want ErrDuplicateTable", err)
+	}
+}
+
+// TestOpenDirectoryStillPrefersThePlainSibling keeps the case deduplication is
+// actually for: one dataset, offered twice in one place.
+func TestOpenDirectoryStillPrefersThePlainSibling(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeCSVFile(t, filepath.Join(dir, "users.csv"), "plain")
+	gzipFile(t, filepath.Join(dir, "users.csv"), filepath.Join(dir, "users.csv.gz"))
+
+	db, err := Open(dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var rows int
+	if err := db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM users").Scan(&rows); err != nil {
+		t.Fatalf("query users: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("users holds %d rows, want 1; the compressed twin was loaded as well", rows)
+	}
+}
+
+// newMemoryDB opens a caller-owned in-memory database, pinned to one connection
+// so every query reaches the same one.
+func newMemoryDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}

--- a/dedup_test.go
+++ b/dedup_test.go
@@ -234,8 +234,9 @@ func TestOpenContextRefusesTwoSourcesWantingOneTable(t *testing.T) {
 		t.Errorf("error = %v, want ErrDuplicateTable", err)
 	}
 	// The second file is the one that found the name taken, so it is the one
-	// named. Reversing the arguments reverses that, which the next check asserts.
-	if !strings.Contains(err.Error(), filepath.ToSlash(second)) {
+	// named. The path is compared as the platform writes it — normalizing it
+	// here would have passed on Windows whatever the message said.
+	if !strings.Contains(err.Error(), second) {
 		t.Errorf("error %q should name the file that collided, %q", err, second)
 	}
 
@@ -244,7 +245,7 @@ func TestOpenContextRefusesTwoSourcesWantingOneTable(t *testing.T) {
 		_ = reversed.Close()
 		t.Fatal("OpenContext succeeded with the arguments reversed")
 	}
-	if !strings.Contains(err.Error(), filepath.ToSlash(first)) {
+	if !strings.Contains(err.Error(), first) {
 		t.Errorf("with the arguments reversed the error %q should name %q", err, first)
 	}
 }

--- a/file_processor.go
+++ b/file_processor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -231,32 +232,65 @@ func (fp *fileProcessor) processFSToReaders(_ context.Context, filesystem fs.FS)
 	return readers, nil
 }
 
-// deduplicateCompressedFiles removes compressed files when their uncompressed versions exist
-func (fp *fileProcessor) deduplicateCompressedFiles(files []string) []string {
-	// Create a map of table names to file paths, prioritizing uncompressed files
-	tableToFile := make(map[string]string)
+// sourceIdentity is what makes two inputs the same source: the path with any
+// compression suffix removed.
+//
+// It is the path, and deliberately not the table name. A table name comes from
+// the base name alone, so "a/users.csv" and "b/users.csv" produce the same one
+// while naming entirely different files. Keying deduplication on it dropped one
+// of them without a word, and which one it dropped depended on Go's map
+// iteration order — so a load could lose a different file on every run. Two
+// inputs are the same source only when they are in the same place.
+//
+// Separators are normalized to "/" so a local path and an fs.FS path (always
+// slash-separated) compare the same way on every platform.
+//
+// Case is significant, including on Windows, where the filesystem's is not.
+// That errs toward keeping both: two paths that really are one file are then
+// loaded twice and reported as a table collision, rather than one of them
+// vanishing. Losing an input in silence is the failure this function exists to
+// prevent, so the tie is broken away from it.
+func sourceIdentity(filePath string) string {
+	stripped := NewCompressionFactory().RemoveCompressionExtension(filePath)
+	return path.Clean(filepath.ToSlash(stripped))
+}
 
-	// First pass: collect all uncompressed files
+// deduplicateCompressedFiles drops an input that is another input's compressed
+// twin, and an input listed twice, keeping the order the caller gave.
+//
+// Two things it must not do. It must not treat inputs from different places as
+// the same file: a directory holding "users.csv" and another holding
+// "users.csv.gz" are two datasets, and both belong in the load. And it must not
+// decide the surviving order from a map, because everything downstream depends
+// on it — which input a last-wins load leaves in place, which malformed file a
+// failing load reports, and the order the collision check sees.
+func (fp *fileProcessor) deduplicateCompressedFiles(files []string) []string {
+	// The sources that arrived uncompressed. A compressed input matching one of
+	// these is the same data behind a codec, so reading it would build the same
+	// table twice from the same place.
+	plain := make(map[string]struct{}, len(files))
 	for _, file := range files {
-		tableName := sanitizeTableName(tableFromFilePath(file))
 		if !fp.isCompressedFile(file) {
-			tableToFile[tableName] = file
+			plain[sourceIdentity(file)] = struct{}{}
 		}
 	}
 
-	// Second pass: add compressed files only if uncompressed version doesn't exist
+	result := make([]string, 0, len(files))
+	emitted := make(map[string]struct{}, len(files))
 	for _, file := range files {
-		tableName := sanitizeTableName(tableFromFilePath(file))
+		identity := sourceIdentity(file)
+		if _, already := emitted[identity]; already {
+			// The same source named twice — "./users.csv" and "users.csv", or a
+			// path repeated outright. Loading it twice would build one table from
+			// one file two times over.
+			continue
+		}
 		if fp.isCompressedFile(file) {
-			if _, exists := tableToFile[tableName]; !exists {
-				tableToFile[tableName] = file
+			if _, uncompressed := plain[identity]; uncompressed {
+				continue
 			}
 		}
-	}
-
-	// Convert map back to slice
-	result := make([]string, 0, len(tableToFile))
-	for _, file := range tableToFile {
+		emitted[identity] = struct{}{}
 		result = append(result, file)
 	}
 

--- a/filesql_test.go
+++ b/filesql_test.go
@@ -46,13 +46,19 @@ func TestOpen(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// testdata/tree, not testdata: see
+			// TestOpenDirectoryWithCollidingBasenamesFails for why loading the
+			// whole tree is an error.
 			name:    "Directory path",
-			paths:   []string{"testdata"},
+			paths:   []string{filepath.Join("testdata", "tree")},
 			wantErr: false,
 		},
 		{
+			// sample2.csv, not sample.csv: the tree holds its own sample.csv, and
+			// two different files asking for one table is a collision rather than
+			// something to resolve silently.
 			name:    "Mixed file and directory paths",
-			paths:   []string{filepath.Join("testdata", "sample.csv"), "testdata"},
+			paths:   []string{filepath.Join("testdata", "sample2.csv"), filepath.Join("testdata", "tree")},
 			wantErr: false,
 		},
 		{
@@ -191,8 +197,11 @@ func TestMultipleFiles(t *testing.T) {
 		t.Skip("Skipping slow multiple files test in local development")
 	}
 
-	// Test loading multiple files from directory
-	db, err := Open("testdata")
+	// testdata/tree, not testdata: the wider tree holds several files that map
+	// to one table from different directories, which is now a reported
+	// collision rather than a silent drop. See
+	// TestOpenDirectoryWithCollidingBasenamesFails.
+	db, err := Open(filepath.Join("testdata", "tree"))
 	require.NoError(t, err, "Failed to open directory")
 	defer db.Close()
 
@@ -254,8 +263,8 @@ func TestJoinMultipleTables(t *testing.T) {
 		t.Skip("Skipping slow join multiple tables test in local development")
 	}
 
-	// Test joining tables from multiple files
-	db, err := Open("testdata")
+	// See TestMultipleFiles for why this is testdata/tree.
+	db, err := Open(filepath.Join("testdata", "tree"))
 	require.NoError(t, err, "Failed to open directory")
 	defer db.Close()
 
@@ -819,7 +828,8 @@ func TestDumpDatabase(t *testing.T) {
 			name: "Directory dump",
 			setupFunc: func(t *testing.T) *sql.DB {
 				t.Helper()
-				db, err := Open("testdata")
+				// See TestMultipleFiles for why this is testdata/tree.
+				db, err := Open(filepath.Join("testdata", "tree"))
 				require.NoError(t, err, "Failed to open database")
 				return db
 			},
@@ -2651,9 +2661,9 @@ func TestDirectoryLoading(t *testing.T) {
 		t.Skip("Skipping slow directory loading test in local development")
 	}
 
-	// Open database with directory path
-	db, err := Open("testdata")
-	require.NoError(t, err, "Open(testdata) failed")
+	// See TestMultipleFiles for why this is testdata/tree.
+	db, err := Open(filepath.Join("testdata", "tree"))
+	require.NoError(t, err, "Open(testdata/tree) failed")
 	defer db.Close()
 
 	// Get all table names
@@ -2863,8 +2873,9 @@ func TestMixedDirectoryAndFiles(t *testing.T) {
 	}
 	defer os.Remove(tempFile)
 
-	// Open with mixed paths: directory + specific file
-	db, err := Open("testdata", tempFile)
+	// Open with mixed paths: directory + specific file. See
+	// TestOpenDirectoryWithCollidingBasenamesFails for why this is testdata/tree.
+	db, err := Open(filepath.Join("testdata", "tree"), tempFile)
 	require.NoError(t, err, "Open with mixed paths failed")
 	defer db.Close()
 

--- a/testdata/tree/logs.ltsv
+++ b/testdata/tree/logs.ltsv
@@ -1,0 +1,3 @@
+time:2024-01-01T10:00:00Z	level:INFO	message:Application started
+time:2024-01-01T10:01:00Z	level:ERROR	message:Database connection failed
+time:2024-01-01T10:02:00Z	level:INFO	message:Application recovered

--- a/testdata/tree/products.tsv
+++ b/testdata/tree/products.tsv
@@ -1,0 +1,4 @@
+id	name	price
+1	Laptop	1000
+2	Mouse	25
+3	Keyboard	50

--- a/testdata/tree/sample.csv
+++ b/testdata/tree/sample.csv
@@ -1,0 +1,4 @@
+id,name,age,email
+1,John Doe,30,john@example.com
+2,Jane Smith,25,jane@example.com
+3,Bob Johnson,35,bob@example.com

--- a/testdata/tree/users.csv
+++ b/testdata/tree/users.csv
@@ -1,0 +1,4 @@
+id,name,role
+1,Alice,admin
+2,Bob,user
+3,Charlie,user


### PR DESCRIPTION
## The bug

`deduplicateCompressedFiles` exists so a dataset offered both plain and compressed is read once. It keyed on the derived table name, which comes from the base name alone — so `a/users.csv` and `b/users.csv` looked like the same source, and one of them was dropped without a word.

Which one survived came out of ranging over a map, so the same command could lose a different file on different runs. The order of the survivors came from there too, and everything downstream reads it: which input a `LoadInto` leaves in place under its last-wins rule, which malformed file a failing load names, and the order the duplicate-table check works through.

## The fix

Two inputs are the same source only when they are in the same place: the path with any compression suffix removed, separators normalized so a local path and an `fs.FS` path compare alike. Case is significant even on Windows — that errs toward keeping both, so two paths that really are one file are reported as a table collision rather than one of them vanishing, and vanishing is the failure being fixed.

The result is built by walking the input in order. Never from a map.

| Inputs | Before | After |
|:--|:--|:--|
| `dir/users.csv`, `dir/users.csv.gz` | plain wins | plain wins (unchanged) |
| `a/users.csv`, `b/users.csv` | one dropped, nondeterministically | both loaded |
| `a/users.csv`, `b/users.csv.gz` | one dropped | both loaded |
| `a/book.xlsx.gz`, `b/book.xlsx.gz` | one dropped | both loaded |
| `./users.csv`, `users.csv` | one read | one read (unchanged) |

## Behavior change

Loading a directory tree that holds two files of the same base name in different subdirectories now fails with `ErrDuplicateTable` instead of silently loading one of them.

Four tests here were relying on that not happening: `testdata/` holds `company/orders.csv` beside `embed_test/orders.tsv`, `users.csv` beside `embed_test/users.csv`, and `products.tsv` beside `products.parquet`. They now load `testdata/tree`, a fixture with no such overlap, and `TestOpenDirectoryWithCollidingBasenamesFails` pins the refusal they used to depend on not happening. No assertion was removed or loosened.

`LoadInto` and `LoadIntoTx` keep their last-wins contract for a same-named table. What changed is only that both inputs are read at all — `TestLoadIntoKeepsItsLastWinsContract` and `TestLoadIntoTxKeepsInputOrder` pin it in both argument orders, so a change to it cannot pass unnoticed.

## Tests

`dedup_test.go` asserts whole result slices in order rather than membership, because order is the half of the contract a set comparison cannot see. It covers the source-identity rule directly, the plain-beats-compressed case from both orders, files sharing only a sanitized name, repeats and equivalent spellings, and stability across repeated calls.

Both halves were checked by breaking them: keying identity on the table name again fails 8 assertions across 4 tests; rebuilding the result from a map fails `TestDeduplicateCompressedFiles` on every run, via a different subtest each time — which is the nondeterminism itself. Neither mutation is committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file deduplication by distinguishing sources in different directories.
  * Compressed and uncompressed versions of the same file are handled consistently.
  * Input order is preserved during loading.
  * Duplicate table names from separate sources now report an error instead of being silently ignored.

* **Documentation**
  * Clarified file identity, compression handling, and duplicate-table behavior.

* **Tests**
  * Added coverage for deduplication, ordering, directory loading, and duplicate-table scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->