### PR TITLE
fix: name a failing input once instead of three times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cause without it. The failure is now a `*ParseError` carrying `Source` and
   `Err`: its message names the input once, `errors.Is` still finds `ErrParsing`
   and whatever sentinel the cause holds, and a caller that loads one file at a
-  time can read `Err` and say the path itself.
+  time can read `Err` and say the path itself. The reader that produced the
+  cause no longer announces `parsing failed` a second time either, so a cause
+  that already carried `ErrParsing` is reported once rather than nested inside
+  itself.
 
 ## [0.32.1] - 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- A file that fails to load is reported once instead of three times. The wrapper
+  said `filesql: parsing failed: failed to stream file rm.csv: filesql: column
+  count mismatch: row 1 has 2 fields, want 3` — two framing verbs for one event
+  and the package's own name twice — and a caller that had already named the
+  file added a third mention of the path, because there was no way to reach the
+  cause without it. The failure is now a `*ParseError` carrying `Source` and
+  `Err`: its message names the input once, `errors.Is` still finds `ErrParsing`
+  and whatever sentinel the cause holds, and a caller that loads one file at a
+  time can read `Err` and say the path itself.
+
 ## [0.32.1] - 2026-08-04
 
 ### Fixed

--- a/errors.go
+++ b/errors.go
@@ -74,3 +74,31 @@ var (
 // errDuplicateColumnName is an internal alias for backward compatibility.
 // Deprecated: Use ErrDuplicateColumn instead.
 var errDuplicateColumnName = ErrDuplicateColumn
+
+// ParseError is a failure reading one input, with the input named.
+//
+// Both this package and its callers want to say which file failed, and both
+// used to. Loading one bad file produced "filesql: parsing failed: failed to
+// stream file rm.csv: filesql: column count mismatch: row 1 has 2 fields, want
+// 3" — two framing verbs for one event, this package's name twice — and a
+// caller that had already named the file added a third mention of it, because
+// there was no way to reach the cause on its own.
+//
+// So the framing is a type instead of more text. Error names the source once
+// for a caller that loaded several inputs at once and cannot otherwise tell
+// which one failed; a caller that loads one file at a time reads Err and says
+// the path itself.
+type ParseError struct {
+	// Source is the input that failed: a file path, or the table name of a
+	// reader input, which is all a reader has to be known by.
+	Source string
+	// Err is what went wrong reading it.
+	Err error
+}
+
+func (e *ParseError) Error() string { return e.Source + ": " + e.Err.Error() }
+
+// Unwrap reports the cause and ErrParsing together, so errors.Is still finds
+// the sentinel the message used to spell out and errors.As still reaches the
+// cause.
+func (e *ParseError) Unwrap() []error { return []error{ErrParsing, e.Err} }

--- a/errors_chain_test.go
+++ b/errors_chain_test.go
@@ -103,3 +103,42 @@ func TestErrorWrappingKeepsTheMessage(t *testing.T) {
 func wrapForTest(inner error) error {
 	return fmt.Errorf("%w: failed to create writer: %w", ErrCompression, inner)
 }
+
+// TestParseFailure_NamesTheInputOnce is the message half of the same concern.
+//
+// A file that fails to load used to be reported as
+// "filesql: parsing failed: failed to stream file rm.csv: filesql: column count
+// mismatch: row 1 has 2 fields, want 3": two generic framing verbs saying the
+// same thing, and this package's own name twice. A caller that already knows
+// which file it asked for then added a third mention of the path, because there
+// was no way to reach the cause without it.
+func TestParseFailure_NamesTheInputOnce(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "rm.csv")
+	require.NoError(t, os.WriteFile(path, []byte("a,b,c\n1,2\n"), 0o600))
+
+	db, err := OpenContext(context.Background(), path)
+	if db != nil {
+		defer func() { _ = db.Close() }()
+	}
+	require.Error(t, err)
+
+	msg := err.Error()
+	assert.Equal(t, 1, strings.Count(msg, "rm.csv"), "the path is named once: %s", msg)
+	assert.Equal(t, 1, strings.Count(msg, "filesql: "), "the package names itself once: %s", msg)
+	assert.NotContains(t, msg, "parsing failed", msg)
+	assert.NotContains(t, msg, "failed to stream file", msg)
+
+	// The sentinel the old message spelled out is still reachable, and so is the
+	// cause, so nothing that branched on either has to change.
+	assert.ErrorIs(t, err, ErrParsing)
+	assert.ErrorIs(t, err, ErrColumnMismatch)
+
+	// A caller that already named the file reaches the cause without the path.
+	var parseErr *ParseError
+	require.ErrorAs(t, err, &parseErr)
+	assert.Equal(t, path, parseErr.Source)
+	assert.NotContains(t, parseErr.Err.Error(), "rm.csv")
+}

--- a/errors_chain_test.go
+++ b/errors_chain_test.go
@@ -115,30 +115,59 @@ func wrapForTest(inner error) error {
 func TestParseFailure_NamesTheInputOnce(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-	path := filepath.Join(dir, "rm.csv")
-	require.NoError(t, os.WriteFile(path, []byte("a,b,c\n1,2\n"), 0o600))
-
-	db, err := OpenContext(context.Background(), path)
-	if db != nil {
-		defer func() { _ = db.Close() }()
+	tests := []struct {
+		name    string
+		file    string
+		content string
+		// wantSentinel is the sentinel the cause carries, beyond ErrParsing.
+		wantSentinel error
+	}{
+		{
+			name:         "a row with fewer fields than the header",
+			file:         "rm.csv",
+			content:      "a,b,c\n1,2\n",
+			wantSentinel: ErrColumnMismatch,
+		},
+		{
+			// This one used to take the other framing path: the cause already
+			// carried ErrParsing, and the reader wrapped it in ErrParsing again,
+			// so the message announced the package twice on its own.
+			name:         "a quoted field the CSV reader cannot parse",
+			file:         "quote.csv",
+			content:      "a,b\n\"unclosed,2\n",
+			wantSentinel: ErrParsing,
+		},
 	}
-	require.Error(t, err)
 
-	msg := err.Error()
-	assert.Equal(t, 1, strings.Count(msg, "rm.csv"), "the path is named once: %s", msg)
-	assert.Equal(t, 1, strings.Count(msg, "filesql: "), "the package names itself once: %s", msg)
-	assert.NotContains(t, msg, "parsing failed", msg)
-	assert.NotContains(t, msg, "failed to stream file", msg)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// The sentinel the old message spelled out is still reachable, and so is the
-	// cause, so nothing that branched on either has to change.
-	assert.ErrorIs(t, err, ErrParsing)
-	assert.ErrorIs(t, err, ErrColumnMismatch)
+			path := filepath.Join(t.TempDir(), tt.file)
+			require.NoError(t, os.WriteFile(path, []byte(tt.content), 0o600))
 
-	// A caller that already named the file reaches the cause without the path.
-	var parseErr *ParseError
-	require.ErrorAs(t, err, &parseErr)
-	assert.Equal(t, path, parseErr.Source)
-	assert.NotContains(t, parseErr.Err.Error(), "rm.csv")
+			db, err := OpenContext(context.Background(), path)
+			if db != nil {
+				defer func() { _ = db.Close() }()
+			}
+			require.Error(t, err)
+
+			msg := err.Error()
+			assert.Equal(t, 1, strings.Count(msg, tt.file), "the path is named once: %s", msg)
+			assert.Equal(t, 1, strings.Count(msg, "filesql: "), "the package names itself once: %s", msg)
+			assert.NotContains(t, msg, "streaming processing failed", msg)
+			assert.NotContains(t, msg, "failed to stream file", msg)
+
+			// The sentinels the old message spelled out are still reachable, and so
+			// is the cause, so nothing that branched on either has to change.
+			assert.ErrorIs(t, err, ErrParsing)
+			assert.ErrorIs(t, err, tt.wantSentinel)
+
+			// A caller that already named the file reaches the cause without the path.
+			var parseErr *ParseError
+			require.ErrorAs(t, err, &parseErr)
+			assert.Equal(t, path, parseErr.Source)
+			assert.NotContains(t, parseErr.Err.Error(), tt.file)
+		})
+	}
 }

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -411,7 +411,11 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, 
 	}
 
 	if err != nil {
-		return fmt.Errorf("%w: streaming processing failed: %w", ErrParsing, err)
+		// Returned as it came. The caller wraps this in a *ParseError, which
+		// carries ErrParsing and names the input, so announcing "parsing failed"
+		// again here put this package's name in the message twice for every cause
+		// that already had it.
+		return err
 	}
 
 	return nil

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -20,11 +20,6 @@ const (
 	logKeySheet = "sheet"
 )
 
-// streamError wraps stream processing errors with sentinel errors for errors.Is() compatibility.
-func streamError(sentinel error, format string, args ...any) error {
-	return fmt.Errorf("%w: "+format, append([]any{sentinel}, args...)...)
-}
-
 // streamProcessor handles streaming operations for database loading
 type streamProcessor struct {
 	chunkSize int
@@ -77,10 +72,12 @@ func (sp *streamProcessor) streamAllFilesToDatabase(ctx context.Context, db DBTX
 		sp.logger.Debug("streaming file", "path", path, "index", i+1, "total", len(collectedPaths))
 		if err := sp.streamFileToDatabase(ctx, db, path, pending); err != nil {
 			sp.logger.Error("failed to stream file", "path", path, "error", err)
-			// Wrap the underlying error with %w as well so a sentinel it carries
-			// (for example ErrColumnMismatch from the malformed-row policy) stays
-			// detectable with errors.Is alongside ErrParsing.
-			return streamError(ErrParsing, "failed to stream file %s: %w", path, err)
+			// A *ParseError rather than more text: it names the file once and
+			// carries both ErrParsing and whatever sentinel the cause holds (for
+			// example ErrColumnMismatch from the malformed-row policy), so
+			// errors.Is finds either and a caller that already named the file can
+			// reach the cause alone.
+			return &ParseError{Source: path, Err: err}
 		}
 	}
 	sp.logger.Info("completed file streaming", "file_count", len(collectedPaths))
@@ -98,7 +95,7 @@ func (sp *streamProcessor) streamAllReadersToDatabase(ctx context.Context, db DB
 		if err := sp.streamReaderToDatabase(ctx, db, ri, pending); err != nil {
 			sp.closeReaderInput(ri)
 			sp.logger.Error("failed to stream reader", logKeyTable, ri.tableName, "error", err)
-			return streamError(ErrParsing, "failed to stream reader input for table '%s': %w", ri.tableName, err)
+			return &ParseError{Source: ri.tableName, Err: err}
 		}
 		sp.closeReaderInput(ri)
 	}


### PR DESCRIPTION
## What

Loading one malformed file produced:

```
filesql: parsing failed: failed to stream file rm.csv: filesql: column count mismatch: row 1 has 2 fields, want 3
```

Two generic framing verbs for one event ("parsing failed", "failed to stream file"), and the package's own name twice. A caller that already knew which file it had asked for then added a third mention of the path, because there was no way to reach the cause on its own — sqly's version of the same message named `rm.csv` three times.

## Change

The framing is a type instead of more text:

```go
type ParseError struct {
	Source string // the file path, or a reader input's table name
	Err    error
}
```

`Error` names the source once, which is what a caller that loaded several inputs at a time needs. `Unwrap() []error` reports `ErrParsing` and the cause together, so `errors.Is(err, ErrParsing)` and `errors.Is(err, ErrColumnMismatch)` both keep working, and a caller that loads one file at a time reads `Err` and says the path itself.

The message becomes:

```
rm.csv: filesql: column count mismatch: row 1 has 2 fields, want 3
```

## Tests

`TestParseFailure_NamesTheInputOnce` loads a real short-row CSV and asserts the composed message names the path once and the package once, that neither framing verb is back, that both sentinels are still reachable, and that `errors.As` gives a caller the cause without the path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured parse errors that preserve the input source and underlying cause.
  * Improved error inspection, allowing applications to identify parsing and column-mismatch failures.
  * Single-file operations can now access the original parsing cause directly.

* **Bug Fixes**
  * File and reader failures now report the source path only once, with clearer error messages.
  * Preserved access to underlying parsing details when handling streaming failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->