### PR TITLE
chore: release v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-08-05
+
 ### Changed
 
 - A file that fails to load is reported once instead of three times. The wrapper


### PR DESCRIPTION
Cuts v0.33.0. The only change is the one merged in #232: a failing input is named once in the error instead of three times, and the framing that repeated it is a `*ParseError` carrying `Source` and `Err`.