### PR TITLE
feat(dialect): spell each dialect the way its own project does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Dialect.DisplayName()` returns a dialect spelled the way its own project
+  spells it: `SQLite`, `MySQL`, `PostgreSQL`, `GoogleSQL`. The wire value is a
+  lowercase identifier, right for a flag value and wrong in a sentence, so every
+  caller that printed one for a person kept its own table of names and drifted
+  from `Dialects()` as soon as a dialect was added. A dialect installed with
+  `RegisterTranslator` reads back as its wire value, so the result is never
+  empty.
+
 ## [0.33.0] - 2026-08-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lowercase identifier, right for a flag value and wrong in a sentence, so every
   caller that printed one for a person kept its own table of names and drifted
   from `Dialects()` as soon as a dialect was added. A dialect installed with
-  `RegisterTranslator` reads back as its wire value, so the result is never
-  empty.
+  `RegisterTranslator` reads back as its wire value, so any dialect with a name
+  has one to print; the zero `Dialect` returns `""`.
 
 ## [0.33.0] - 2026-08-05
 

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -53,9 +53,10 @@ var displayNames = map[Dialect]string{
 
 // DisplayName returns the dialect spelled the way its own project spells it, for
 // a message a person reads. A dialect with no spelling here — one installed by
-// RegisterTranslator — reads back as its wire value, so the result is never
-// empty. It lives beside Dialects() so a dialect added to one arrives in the
-// other, instead of every caller keeping its own table of names.
+// RegisterTranslator — reads back as its wire value, so any dialect with a name
+// has one to print; the zero Dialect has neither and returns "". It lives beside
+// Dialects() so a dialect added to one arrives in the other, instead of every
+// caller keeping its own table of names.
 func (d Dialect) DisplayName() string {
 	if name, ok := displayNames[d]; ok {
 		return name

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -41,6 +41,28 @@ func Dialects() []Dialect {
 	return []Dialect{SQLite, MySQL, PostgreSQL, GoogleSQL}
 }
 
+// displayNames spells each dialect the way its own project does. The wire value
+// is a lowercase identifier, which is right for parsing a flag value and wrong
+// in a sentence a person reads.
+var displayNames = map[Dialect]string{
+	SQLite:     "SQLite",
+	MySQL:      "MySQL",
+	PostgreSQL: "PostgreSQL",
+	GoogleSQL:  "GoogleSQL",
+}
+
+// DisplayName returns the dialect spelled the way its own project spells it, for
+// a message a person reads. A dialect with no spelling here — one installed by
+// RegisterTranslator — reads back as its wire value, so the result is never
+// empty. It lives beside Dialects() so a dialect added to one arrives in the
+// other, instead of every caller keeping its own table of names.
+func (d Dialect) DisplayName() string {
+	if name, ok := displayNames[d]; ok {
+		return name
+	}
+	return string(d)
+}
+
 // Parse maps a user-supplied dialect name to a Dialect. Matching is
 // case-insensitive and ignores surrounding whitespace. Aliases are accepted:
 // "sqlite3" for SQLite; "postgres" and "pg" for PostgreSQL; "bigquery",

--- a/dialect/dialect_test.go
+++ b/dialect/dialect_test.go
@@ -62,6 +62,45 @@ func TestDialects(t *testing.T) {
 	}
 }
 
+func TestDialectDisplayName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input Dialect
+		want  string
+	}{
+		{"sqlite", SQLite, "SQLite"},
+		{"mysql", MySQL, "MySQL"},
+		{"postgresql", PostgreSQL, "PostgreSQL"},
+		{"googlesql", GoogleSQL, "GoogleSQL"},
+		{"unregistered dialect reads back as its wire value", Dialect("oracle"), "oracle"},
+		{"empty dialect", Dialect(""), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tt.input.DisplayName(); got != tt.want {
+				t.Fatalf("Dialect(%q).DisplayName() = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEveryBuiltInDialectHasADisplayName(t *testing.T) {
+	t.Parallel()
+	// A dialect added to Dialects() without a spelling would read back as its
+	// lowercase wire value in a sentence, which is the drift this pins.
+	for _, d := range Dialects() {
+		name := d.DisplayName()
+		if name == "" {
+			t.Fatalf("Dialect(%q).DisplayName() is empty", d)
+		}
+		if name == string(d) {
+			t.Fatalf("Dialect(%q).DisplayName() = %q, want a spelled-out name", d, name)
+		}
+	}
+}
+
 func TestTranslateSQLiteIsIdentity(t *testing.T) {
 	t.Parallel()
 	// The SQLite dialect must never alter the query, including constructs the


### PR DESCRIPTION
A dialect's wire value is a lowercase identifier. That is right for parsing a flag value and wrong in a sentence a person reads, so every caller that prints one keeps a private map from `Dialect` to `PostgreSQL` — and that map drifts from `Dialects()` the moment a dialect is added upstream.

`DisplayName()` puts the spelling next to the list it belongs to: `SQLite`, `MySQL`, `PostgreSQL`, `GoogleSQL`. A dialect installed with `RegisterTranslator` has no entry and reads back as its wire value, so the result is never empty.

The added test asserts every dialect returned by `Dialects()` has a spelling, so a dialect added without one fails here instead of reading back lowercase in a caller's message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added display names for built-in dialects.
  * Added fallback display values for registered and unregistered dialects.
  * Ensured dialect display names are never empty.

* **Documentation**
  * Added an Unreleased changelog entry describing dialect display-name support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->