### PR TITLE
chore: release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-08-05
+
 ### Added
 
 - `Dialect.DisplayName()` returns a dialect spelled the way its own project


### PR DESCRIPTION
Cuts v0.34.0 for `Dialect.DisplayName()`, a backward-compatible addition.