### PR TITLE
fix: keep Parquet column types and dialect result column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A Parquet file's declared column types now reach SQLite instead of every
+  column arriving as TEXT. Parquet states the type of each column in its own
+  schema, and the streaming import ignored it, so a `DOUBLE` price and an
+  `INT64` quantity became text and carried TEXT affinity into every comparison:
+  `MAX(price)` returned the lexicographically largest value, `ORDER BY price`
+  sorted digit strings, and `WHERE price > 100` compared `100` as `'100'`. The
+  same rows loaded from CSV, where types are inferred from the values, answered
+  those queries correctly, so one file gave two answers depending on its format.
+  The Arrow schema now decides the column type, which is also the only way to
+  tell a `STRING` column of zip codes from an `INT64` one. `parser.Parse` reads
+  the schema the same way.
+
+- A Parquet export writes each column as the type its values call for rather
+  than as `STRING`. Parquet readers trust the schema, so a numeric column
+  written as digit strings reached the next tool as text. A column whose values
+  are not all numeric is still written as `STRING`, because SQLite types values
+  rather than columns and a dump has to carry back what the rows held; a column
+  with no rows takes the declared type of the table it came from.
+
+- A dialect rewrite no longer renames the caller's result columns. SQLite names
+  an unaliased result column after the text of the expression that produced it,
+  so rewriting the expression renamed the column: PostgreSQL's `SELECT
+  amt::text` came back as `postgresql_cast(amt, 'text')`, and that name reached
+  the caller as a CSV header and a JSON key. MySQL's `/` and `CONCAT`,
+  GoogleSQL's `SAFE_CAST`, and every other rewritten select item had the same
+  problem. A rewritten item now carries its original text as an alias, so
+  `amt::text` stays `amt::text`. An item the query already named, a bare column
+  reference, and a `*` are left alone.
+
 ## [0.34.0] - 2026-08-05
 
 ### Added

--- a/dialect/cast_test.go
+++ b/dialect/cast_test.go
@@ -157,10 +157,12 @@ func TestCastUnknownTypePassesThrough(t *testing.T) {
 		query   string
 		want    string
 	}{
-		{PostgreSQL, "SELECT a::inet", "SELECT CAST(a AS inet)"},
+		// A pass-through still renames the column when the spelling changes, so
+		// the original text comes back as an alias.
+		{PostgreSQL, "SELECT a::inet", `SELECT CAST(a AS inet) AS "a::inet"`},
 		{PostgreSQL, "SELECT CAST(a AS inet)", "SELECT CAST(a AS inet)"},
 		{MySQL, "SELECT CAST(x AS GEOMETRY)", "SELECT CAST(x AS GEOMETRY)"},
-		{GoogleSQL, "SELECT SAFE_CAST(x AS GEOGRAPHY)", "SELECT CAST(x AS GEOGRAPHY)"},
+		{GoogleSQL, "SELECT SAFE_CAST(x AS GEOGRAPHY)", `SELECT CAST(x AS GEOGRAPHY) AS "SAFE_CAST(x AS GEOGRAPHY)"`},
 	}
 	for _, tt := range tests {
 		got, err := Translate(tt.dialect, tt.query)

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -142,12 +142,17 @@ func builtinTranslate(d Dialect, query string) (string, error) {
 		return "", err
 	}
 
-	tokens, err = rewriteTokens(d, tokens)
+	rewritten, err := rewriteTokens(d, tokens)
 	if err != nil {
 		return "", err
 	}
 
-	return render(tokens), nil
+	// Rewriting changes the text of an expression, and SQLite names an unaliased
+	// result column after that text. This puts the original text back as an alias
+	// so the caller's column keeps its name.
+	rewritten = preserveSelectLabels(tokens, rewritten)
+
+	return render(rewritten), nil
 }
 
 // rewriteTokens applies the dialect-specific token rewrite rules. Dialects

--- a/dialect/googlesql_test.go
+++ b/dialect/googlesql_test.go
@@ -13,37 +13,37 @@ func TestGoogleSQLTranslate(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"C-1_extract", "SELECT EXTRACT(YEAR FROM d) FROM t", "SELECT DATE_PART('year', d) FROM t"},
+		{"C-1_extract", "SELECT EXTRACT(YEAR FROM d) FROM t", "SELECT DATE_PART('year', d) AS \"EXTRACT(YEAR FROM d)\" FROM t"},
 
 		// G-1 backtick compound identifier is lexical (tokenizer).
 		{"G-1_backtick_path", "SELECT x FROM `proj.dataset.table`", `SELECT x FROM "proj.dataset.table"`},
 
-		{"G-2_safe_cast", "SELECT SAFE_CAST(x AS INT64) FROM t", "SELECT googlesql_safe_cast(x, 'INT64') FROM t"},
-		{"G-2_safe_cast_unknown_type", "SELECT SAFE_CAST(x AS GEOGRAPHY)", "SELECT CAST(x AS GEOGRAPHY)"},
+		{"G-2_safe_cast", "SELECT SAFE_CAST(x AS INT64) FROM t", "SELECT googlesql_safe_cast(x, 'INT64') AS \"SAFE_CAST(x AS INT64)\" FROM t"},
+		{"G-2_safe_cast_unknown_type", "SELECT SAFE_CAST(x AS GEOGRAPHY)", "SELECT CAST(x AS GEOGRAPHY) AS \"SAFE_CAST(x AS GEOGRAPHY)\""},
 
-		{"G-3_date_literal", "SELECT DATE '2026-01-01'", "SELECT '2026-01-01'"},
-		{"G-3_timestamp_literal", "SELECT TIMESTAMP '2026-01-01 00:00:00'", "SELECT '2026-01-01 00:00:00'"},
+		{"G-3_date_literal", "SELECT DATE '2026-01-01'", "SELECT '2026-01-01' AS \"DATE '2026-01-01'\""},
+		{"G-3_timestamp_literal", "SELECT TIMESTAMP '2026-01-01 00:00:00'", "SELECT '2026-01-01 00:00:00' AS \"TIMESTAMP '2026-01-01 00:00:00'\""},
 		{"G-3_date_word_not_literal", "SELECT DATE FROM t", "SELECT DATE FROM t"},
 
-		{"G-4_cast_int64", "SELECT CAST(x AS INT64)", "SELECT googlesql_cast(x, 'INT64')"},
-		{"G-4_cast_float64", "SELECT CAST(x AS FLOAT64)", "SELECT googlesql_cast(x, 'FLOAT64')"},
-		{"G-4_cast_string", "SELECT CAST(x AS STRING)", "SELECT googlesql_cast(x, 'STRING')"},
-		{"G-4_cast_bytes", "SELECT CAST(x AS BYTES)", "SELECT googlesql_cast(x, 'BYTES')"},
+		{"G-4_cast_int64", "SELECT CAST(x AS INT64)", "SELECT googlesql_cast(x, 'INT64') AS \"CAST(x AS INT64)\""},
+		{"G-4_cast_float64", "SELECT CAST(x AS FLOAT64)", "SELECT googlesql_cast(x, 'FLOAT64') AS \"CAST(x AS FLOAT64)\""},
+		{"G-4_cast_string", "SELECT CAST(x AS STRING)", "SELECT googlesql_cast(x, 'STRING') AS \"CAST(x AS STRING)\""},
+		{"G-4_cast_bytes", "SELECT CAST(x AS BYTES)", "SELECT googlesql_cast(x, 'BYTES') AS \"CAST(x AS BYTES)\""},
 
-		{"G-6_format", "SELECT FORMAT('%d', n) FROM t", "SELECT printf('%d', n) FROM t"},
+		{"G-6_format", "SELECT FORMAT('%d', n) FROM t", "SELECT printf('%d', n) AS \"FORMAT('%d', n)\" FROM t"},
 
-		{"G-7_date_add", "SELECT DATE_ADD(d, INTERVAL 3 DAY)", "SELECT interval_add(d, 3, 'day')"},
-		{"G-7_timestamp_sub", "SELECT TIMESTAMP_SUB(ts, INTERVAL 2 HOUR)", "SELECT interval_add(ts, -(2), 'hour')"},
+		{"G-7_date_add", "SELECT DATE_ADD(d, INTERVAL 3 DAY)", "SELECT interval_add(d, 3, 'day') AS \"DATE_ADD(d, INTERVAL 3 DAY)\""},
+		{"G-7_timestamp_sub", "SELECT TIMESTAMP_SUB(ts, INTERVAL 2 HOUR)", "SELECT interval_add(ts, -(2), 'hour') AS \"TIMESTAMP_SUB(ts, INTERVAL 2 HOUR)\""},
 
-		{"G-8_date_diff", "SELECT DATE_DIFF(a, b, DAY) FROM t", "SELECT DATE_DIFF(a, b, 'day') FROM t"},
-		{"G-8_timestamp_diff", "SELECT TIMESTAMP_DIFF(a, b, SECOND)", "SELECT TIMESTAMP_DIFF(a, b, 'second')"},
+		{"G-8_date_diff", "SELECT DATE_DIFF(a, b, DAY) FROM t", "SELECT DATE_DIFF(a, b, 'day') AS \"DATE_DIFF(a, b, DAY)\" FROM t"},
+		{"G-8_timestamp_diff", "SELECT TIMESTAMP_DIFF(a, b, SECOND)", "SELECT TIMESTAMP_DIFF(a, b, 'second') AS \"TIMESTAMP_DIFF(a, b, SECOND)\""},
 
 		// G-10 raw and byte strings are lexical.
 		{"G-10_raw_string", `SELECT r'a\nb'`, `SELECT 'a\nb'`},
 		{"G-10_byte_string", `SELECT b'AB'`, `SELECT x'4142'`},
 
 		{"double_quoted_string", `SELECT "hello"`, `SELECT 'hello'`},
-		{"nested_safe_cast_in_extract", "SELECT EXTRACT(YEAR FROM SAFE_CAST(s AS DATETIME))", "SELECT DATE_PART('year', googlesql_safe_cast(s, 'DATETIME'))"},
+		{"nested_safe_cast_in_extract", "SELECT EXTRACT(YEAR FROM SAFE_CAST(s AS DATETIME))", "SELECT DATE_PART('year', googlesql_safe_cast(s, 'DATETIME')) AS \"EXTRACT(YEAR FROM SAFE_CAST(s AS DATETIME))\""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dialect/label.go
+++ b/dialect/label.go
@@ -1,6 +1,9 @@
 package dialect
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // SQLite names an unaliased result column after the text of the expression that
 // produced it, so rewriting an expression renames the caller's column. A
@@ -39,19 +42,30 @@ func preserveSelectLabels(original, rewritten []token) []token {
 		return rewritten
 	}
 
-	// Walk backwards so an insertion never shifts an index not yet used.
-	out := rewritten
-	for i := len(before) - 1; i >= 0; i-- {
+	// Collect first, then insert from the highest index down. Reverse item order
+	// is not the same as reverse position order: a scalar subquery's own item
+	// sits inside its parent's span, so inserting by item order shifted the
+	// parent's end index and put its alias in the middle of the subquery.
+	type insertion struct {
+		at    int
+		label string
+	}
+	var inserts []insertion
+	for i := range before {
 		label, ok := labelFor(original, before[i], rewritten, after[i])
 		if !ok {
 			continue
 		}
-		alias := []token{
+		inserts = append(inserts, insertion{at: lastSignificant(rewritten, after[i]) + 1, label: label})
+	}
+	sort.Slice(inserts, func(i, j int) bool { return inserts[i].at > inserts[j].at })
+
+	out := rewritten
+	for _, ins := range inserts {
+		out = insertTokens(out, ins.at, []token{
 			spaceToken(), wordToken("AS"), spaceToken(),
-			{kind: tokQuotedIdent, text: label},
-		}
-		end := lastSignificant(rewritten, after[i]) + 1
-		out = insertTokens(out, end, alias)
+			{kind: tokQuotedIdent, text: ins.label},
+		})
 	}
 	return out
 }
@@ -71,13 +85,34 @@ func labelFor(original []token, before tokenSpan, rewritten []token, after token
 	return origText, true
 }
 
+// expressionEndKeywords are words that finish an expression and can therefore
+// never be an alias: "CASE ... END", "x IS NULL", "TRUE".
+var expressionEndKeywords = map[string]bool{
+	"END": true, "NULL": true, "TRUE": true, "FALSE": true,
+	"CURRENT_DATE": true, "CURRENT_TIME": true, "CURRENT_TIMESTAMP": true,
+}
+
+// operandExpectingKeywords are words that must be followed by an operand, so the
+// word after one belongs to the expression rather than naming it. Not every SQL
+// keyword is here — only the ones that can stand immediately before the last
+// word of a select item, which is the only position that matters.
+var operandExpectingKeywords = map[string]bool{
+	"DIV": true, "MOD": true, "AND": true, "OR": true, "NOT": true, "IS": true,
+	"LIKE": true, "GLOB": true, "REGEXP": true, "MATCH": true, "BETWEEN": true,
+	"IN": true, "ESCAPE": true, "COLLATE": true, "WHEN": true, "THEN": true,
+	"ELSE": true, "CASE": true, "DISTINCT": true, "ALL": true, "INTERVAL": true,
+}
+
 // hasAlias reports whether a select item already names its column.
 //
 // An item ending in a word or a quoted identifier is ambiguous: "amt::text" ends
 // in a word that belongs to the expression, while "amt::text label" ends in an
-// alias. The token before it decides — an operator means the word is part of the
-// expression — and every other shape is read as an alias. That is the safe way
-// round: a missed alias leaves a label unimproved, while a wrongly added one
+// alias. What precedes the last word decides. An operator, or a keyword that
+// demands an operand, means the word is part of the expression; anything else is
+// read as an alias.
+//
+// The ambiguous cases are resolved towards "alias", because that is the safe way
+// round: a missed alias leaves one label unimproved, while a wrongly added one
 // makes the statement a syntax error.
 func hasAlias(tokens []token, span tokenSpan) bool {
 	last := lastSignificant(tokens, span)
@@ -87,11 +122,20 @@ func hasAlias(tokens []token, span tokenSpan) bool {
 	if tokens[last].kind != tokWord && tokens[last].kind != tokQuotedIdent {
 		return false
 	}
+	if tokens[last].kind == tokWord && expressionEndKeywords[strings.ToUpper(tokens[last].text)] {
+		return false
+	}
 	prev := lastSignificant(tokens, tokenSpan{start: span.start, end: last})
 	if prev < 0 {
 		return false
 	}
-	return tokens[prev].kind != tokOp
+	if tokens[prev].kind == tokOp {
+		return false
+	}
+	if tokens[prev].kind == tokWord && operandExpectingKeywords[strings.ToUpper(tokens[prev].text)] {
+		return false
+	}
+	return true
 }
 
 // isBareColumnRef reports whether a select item is nothing but a column

--- a/dialect/label.go
+++ b/dialect/label.go
@@ -1,0 +1,230 @@
+package dialect
+
+import "strings"
+
+// SQLite names an unaliased result column after the text of the expression that
+// produced it, so rewriting an expression renames the caller's column. A
+// PostgreSQL "amt::text" became "postgresql_cast(amt, 'text')" and reached the
+// caller under that name — as a CSV header, as a JSON key, as whatever the
+// result was rendered into. The helper is this package's business; the label is
+// the caller's.
+//
+// So a select item the rewrite changed carries its original text as an alias.
+// The label is the expression as it was written rather than the name the source
+// database would have derived, because that rule is one rule for every dialect:
+// PostgreSQL, MySQL, and GoogleSQL each name a bare cast differently, and a
+// translation that guessed per dialect would be three rules that still all
+// disagree with SQLite. What sqly promises is SQLite semantics over the caller's
+// syntax, and the caller's syntax is what the label now shows.
+
+// tokenSpan is a half-open range of token indices.
+type tokenSpan struct {
+	start int
+	end   int
+}
+
+// preserveSelectLabels re-labels the select items that rewriting changed, so a
+// result column keeps the name the original query gave it. original and
+// rewritten are the same statement before and after rewriteTokens.
+//
+// The two streams are matched by position: a rewrite replaces expressions but
+// never adds or removes a select list or a top-level comma, so the n-th item of
+// the rewritten stream is the n-th item of the original. Anything that breaks
+// that assumption — a differing number of lists or items — returns the rewritten
+// stream untouched, because a wrong alias is worse than a rewritten label.
+func preserveSelectLabels(original, rewritten []token) []token {
+	before := selectListItems(original)
+	after := selectListItems(rewritten)
+	if len(before) != len(after) || len(before) == 0 {
+		return rewritten
+	}
+
+	// Walk backwards so an insertion never shifts an index not yet used.
+	out := rewritten
+	for i := len(before) - 1; i >= 0; i-- {
+		label, ok := labelFor(original, before[i], rewritten, after[i])
+		if !ok {
+			continue
+		}
+		alias := []token{
+			spaceToken(), wordToken("AS"), spaceToken(),
+			{kind: tokQuotedIdent, text: label},
+		}
+		end := lastSignificant(rewritten, after[i]) + 1
+		out = insertTokens(out, end, alias)
+	}
+	return out
+}
+
+// labelFor reports the label a select item should carry, and whether it needs
+// one at all. An item needs a label when the rewrite changed its text and the
+// query did not already name it.
+func labelFor(original []token, before tokenSpan, rewritten []token, after tokenSpan) (string, bool) {
+	origText := strings.TrimSpace(render(original[before.start:before.end]))
+	newText := strings.TrimSpace(render(rewritten[after.start:after.end]))
+	if origText == "" || origText == newText {
+		return "", false
+	}
+	if hasAlias(original, before) || isBareColumnRef(original, before) || endsWithStar(original, before) {
+		return "", false
+	}
+	return origText, true
+}
+
+// hasAlias reports whether a select item already names its column.
+//
+// An item ending in a word or a quoted identifier is ambiguous: "amt::text" ends
+// in a word that belongs to the expression, while "amt::text label" ends in an
+// alias. The token before it decides — an operator means the word is part of the
+// expression — and every other shape is read as an alias. That is the safe way
+// round: a missed alias leaves a label unimproved, while a wrongly added one
+// makes the statement a syntax error.
+func hasAlias(tokens []token, span tokenSpan) bool {
+	last := lastSignificant(tokens, span)
+	if last < 0 {
+		return false
+	}
+	if tokens[last].kind != tokWord && tokens[last].kind != tokQuotedIdent {
+		return false
+	}
+	prev := lastSignificant(tokens, tokenSpan{start: span.start, end: last})
+	if prev < 0 {
+		return false
+	}
+	return tokens[prev].kind != tokOp
+}
+
+// isBareColumnRef reports whether a select item is nothing but a column
+// reference such as "a" or "t"."b". SQLite already labels those with the column
+// name, and an alias holding the qualified text would rename them.
+func isBareColumnRef(tokens []token, span tokenSpan) bool {
+	wantName := true
+	seen := false
+	for i := span.start; i < span.end; i++ {
+		t := tokens[i]
+		if !isSignificant(t) {
+			continue
+		}
+		if wantName {
+			if t.kind != tokWord && t.kind != tokQuotedIdent {
+				return false
+			}
+			seen = true
+		} else if !isOpEq(t, ".") {
+			return false
+		}
+		wantName = !wantName
+	}
+	return seen && !wantName
+}
+
+// endsWithStar reports whether a select item is "*" or "t.*", neither of which
+// can take an alias.
+func endsWithStar(tokens []token, span tokenSpan) bool {
+	last := lastSignificant(tokens, span)
+	return last >= 0 && isOpEq(tokens[last], "*")
+}
+
+// lastSignificant returns the index of the last non-whitespace, non-comment
+// token in span, or -1 when there is none.
+func lastSignificant(tokens []token, span tokenSpan) int {
+	for i := span.end - 1; i >= span.start; i-- {
+		if isSignificant(tokens[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+// insertTokens returns tokens with extra spliced in at index at.
+func insertTokens(tokens []token, at int, extra []token) []token {
+	out := make([]token, 0, len(tokens)+len(extra))
+	out = append(out, tokens[:at]...)
+	out = append(out, extra...)
+	out = append(out, tokens[at:]...)
+	return out
+}
+
+// selectListItems returns the span of every top-level item of every select list
+// in the statement, in the order the items appear. A subquery contributes its
+// own items, which is what makes the result of a derived table keep its labels
+// too.
+func selectListItems(tokens []token) []tokenSpan {
+	var items []tokenSpan
+	depth := 0
+	for i := range tokens {
+		switch {
+		case isOpEq(tokens[i], "("):
+			depth++
+		case isOpEq(tokens[i], ")"):
+			depth--
+		case tokens[i].kind == tokWord && strings.EqualFold(tokens[i].text, "SELECT"):
+			items = append(items, parseSelectList(tokens, i+1, depth)...)
+		}
+	}
+	return items
+}
+
+// selectListEnd names the keywords that end a select list. WHERE, GROUP,
+// HAVING, ORDER, and LIMIT cannot legally precede FROM, but ending on them costs
+// nothing and keeps a malformed statement from swallowing the rest of the query
+// as one select item.
+var selectListEnd = map[string]bool{
+	"FROM": true, "INTO": true, "WHERE": true, "GROUP": true, "HAVING": true,
+	"ORDER": true, "LIMIT": true, "WINDOW": true,
+	"UNION": true, "INTERSECT": true, "EXCEPT": true,
+}
+
+// parseSelectList splits the select list starting at from into its top-level
+// items. baseDepth is the parenthesis depth the SELECT itself sits at; the list
+// ends where the depth drops below it, at a keyword that closes the list, or at
+// the end of the statement.
+func parseSelectList(tokens []token, from, baseDepth int) []tokenSpan {
+	// A leading DISTINCT or ALL is a modifier, not the first item.
+	if i := nextSig(tokens, from); i >= 0 && tokens[i].kind == tokWord {
+		if strings.EqualFold(tokens[i].text, "DISTINCT") || strings.EqualFold(tokens[i].text, "ALL") {
+			from = i + 1
+		}
+	}
+
+	var items []tokenSpan
+	depth := baseDepth
+	start := from
+	for i := from; i < len(tokens); i++ {
+		t := tokens[i]
+		switch {
+		case isOpEq(t, "("):
+			depth++
+			continue
+		case isOpEq(t, ")"):
+			depth--
+			if depth < baseDepth {
+				return appendSpan(items, start, i)
+			}
+			continue
+		}
+		if depth != baseDepth {
+			continue
+		}
+		if isOpEq(t, ";") {
+			return appendSpan(items, start, i)
+		}
+		if t.kind == tokWord && selectListEnd[strings.ToUpper(t.text)] {
+			return appendSpan(items, start, i)
+		}
+		if isOpEq(t, ",") {
+			items = appendSpan(items, start, i)
+			start = i + 1
+		}
+	}
+	return appendSpan(items, start, len(tokens))
+}
+
+// appendSpan adds a span unless it is empty, which is what a select list with
+// no items leaves behind.
+func appendSpan(items []tokenSpan, start, end int) []tokenSpan {
+	if start >= end {
+		return items
+	}
+	return append(items, tokenSpan{start: start, end: end})
+}

--- a/dialect/label_test.go
+++ b/dialect/label_test.go
@@ -109,6 +109,41 @@ func TestTranslatePreservesResultColumnLabels(t *testing.T) {
 			want:    `SELECT x FROM (SELECT mysql_divide(a, b) AS "a / b" FROM t)`,
 		},
 		{
+			// A scalar subquery holds its own select list, so both items are
+			// labeled. The inner alias sits inside the outer item, which is why
+			// insertions are ordered by position rather than by item.
+			name:    "a scalar subquery labels both the outer item and its own",
+			dialect: MySQL,
+			query:   "SELECT (SELECT a / b FROM t)",
+			want:    `SELECT (SELECT mysql_divide(a, b) AS "a / b" FROM t) AS "(SELECT a / b FROM t)"`,
+		},
+		{
+			// DIV is an operator spelled as a word, so the operand after it is not
+			// an alias.
+			name:    "a word operator is not an implicit alias",
+			dialect: MySQL,
+			query:   "SELECT a DIV b FROM t",
+			want:    `SELECT CAST(mysql_divide(a, b) AS INTEGER) AS "a DIV b" FROM t`,
+		},
+		{
+			name:    "an expression ending in NULL is labeled",
+			dialect: PostgreSQL,
+			query:   "SELECT amt::text IS NULL FROM t",
+			want:    `SELECT postgresql_cast(amt, 'text') IS NULL AS "amt::text IS NULL" FROM t`,
+		},
+		{
+			name:    "a COLLATE suffix is not an implicit alias",
+			dialect: PostgreSQL,
+			query:   "SELECT amt::text COLLATE NOCASE FROM t",
+			want:    `SELECT postgresql_cast(amt, 'text') COLLATE NOCASE AS "amt::text COLLATE NOCASE" FROM t`,
+		},
+		{
+			name:    "an implicit alias after a keyword-ending expression is left alone",
+			dialect: PostgreSQL,
+			query:   "SELECT amt::text IS NULL flag FROM t",
+			want:    `SELECT postgresql_cast(amt, 'text') IS NULL flag FROM t`,
+		},
+		{
 			name:    "a quoted label is escaped",
 			dialect: PostgreSQL,
 			query:   `SELECT "od"::text FROM t`,

--- a/dialect/label_test.go
+++ b/dialect/label_test.go
@@ -1,0 +1,183 @@
+package dialect
+
+import "testing"
+
+// A rewrite changes the text of an expression, and SQLite names an unaliased
+// result column after that text. Left alone, translation renames the caller's
+// columns to the helper functions this package rewrites into: a PostgreSQL
+// "amt::text" came back as "postgresql_cast(amt, 'text')", which reached the
+// caller as a CSV header and a JSON key. The label belongs to the query as it
+// was written, so a rewritten select item carries its original text as an alias.
+
+func TestTranslatePreservesResultColumnLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dialect Dialect
+		query   string
+		want    string
+	}{
+		{
+			name:    "postgresql cast operator",
+			dialect: PostgreSQL,
+			query:   "SELECT amt::text FROM t",
+			want:    `SELECT postgresql_cast(amt, 'text') AS "amt::text" FROM t`,
+		},
+		{
+			name:    "postgresql cast call",
+			dialect: PostgreSQL,
+			query:   "SELECT CAST(amt AS text) FROM t",
+			want:    `SELECT postgresql_cast(amt, 'text') AS "CAST(amt AS text)" FROM t`,
+		},
+		{
+			name:    "postgresql ilike",
+			dialect: PostgreSQL,
+			query:   "SELECT a ILIKE 'x' FROM t",
+			want:    `SELECT like_insensitive('x', a) AS "a ILIKE 'x'" FROM t`,
+		},
+		{
+			name:    "mysql cast",
+			dialect: MySQL,
+			query:   "SELECT CAST(a AS SIGNED) FROM t",
+			want:    `SELECT mysql_cast(a, 'SIGNED') AS "CAST(a AS SIGNED)" FROM t`,
+		},
+		{
+			name:    "mysql division",
+			dialect: MySQL,
+			query:   "SELECT a / b FROM t",
+			want:    `SELECT mysql_divide(a, b) AS "a / b" FROM t`,
+		},
+		{
+			name:    "mysql concat",
+			dialect: MySQL,
+			query:   "SELECT CONCAT(a,b) FROM t",
+			want:    `SELECT strict_concat(a,b) AS "CONCAT(a,b)" FROM t`,
+		},
+		{
+			name:    "googlesql safe cast",
+			dialect: GoogleSQL,
+			query:   "SELECT SAFE_CAST(a AS INT64) FROM t",
+			want:    `SELECT googlesql_safe_cast(a, 'INT64') AS "SAFE_CAST(a AS INT64)" FROM t`,
+		},
+		{
+			name:    "an explicit alias is left alone",
+			dialect: PostgreSQL,
+			query:   "SELECT amt::text AS label FROM t",
+			want:    `SELECT postgresql_cast(amt, 'text') AS label FROM t`,
+		},
+		{
+			name:    "an implicit alias is left alone",
+			dialect: PostgreSQL,
+			query:   "SELECT amt::text label FROM t",
+			want:    `SELECT postgresql_cast(amt, 'text') label FROM t`,
+		},
+		{
+			name:    "an item the rewrite did not touch keeps its own text",
+			dialect: PostgreSQL,
+			query:   "SELECT a + 1 FROM t",
+			want:    "SELECT a + 1 FROM t",
+		},
+		{
+			name:    "a bare column reference is not aliased",
+			dialect: PostgreSQL,
+			query:   "SELECT a, t.b FROM t",
+			want:    "SELECT a, t.b FROM t",
+		},
+		{
+			name:    "a star is not aliased",
+			dialect: MySQL,
+			query:   "SELECT *, a / b FROM t",
+			want:    `SELECT *, mysql_divide(a, b) AS "a / b" FROM t`,
+		},
+		{
+			name:    "only the rewritten item is aliased",
+			dialect: MySQL,
+			query:   "SELECT a, a / b, b FROM t",
+			want:    `SELECT a, mysql_divide(a, b) AS "a / b", b FROM t`,
+		},
+		{
+			name:    "a rewrite inside a WHERE clause is not aliased",
+			dialect: MySQL,
+			query:   "SELECT a FROM t WHERE a / b > 1",
+			want:    "SELECT a FROM t WHERE mysql_divide(a, b) > 1",
+		},
+		{
+			name:    "a subquery select list is aliased too",
+			dialect: MySQL,
+			query:   "SELECT x FROM (SELECT a / b FROM t)",
+			want:    `SELECT x FROM (SELECT mysql_divide(a, b) AS "a / b" FROM t)`,
+		},
+		{
+			name:    "a quoted label is escaped",
+			dialect: PostgreSQL,
+			query:   `SELECT "od"::text FROM t`,
+			want:    `SELECT postgresql_cast("od", 'text') AS """od""::text" FROM t`,
+		},
+		{
+			name:    "distinct is not mistaken for a select item",
+			dialect: MySQL,
+			query:   "SELECT DISTINCT a / b FROM t",
+			want:    `SELECT DISTINCT mysql_divide(a, b) AS "a / b" FROM t`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Translate(tt.dialect, tt.query)
+			if err != nil {
+				t.Fatalf("Translate(%s, %q) error: %v", tt.dialect, tt.query, err)
+			}
+			if got != tt.want {
+				t.Errorf("Translate(%s, %q)\n got: %s\nwant: %s", tt.dialect, tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTranslatePreservesLabelsInStatementsWithoutSelectList checks the pass
+// leaves alone the statements that have no select list to label, so an UPDATE or
+// an INSERT is translated exactly as before.
+func TestTranslatePreservesLabelsInStatementsWithoutSelectList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dialect Dialect
+		query   string
+		want    string
+	}{
+		{
+			name:    "update",
+			dialect: MySQL,
+			query:   "UPDATE t SET x = a / b",
+			want:    "UPDATE t SET x = mysql_divide(a, b)",
+		},
+		{
+			name:    "delete",
+			dialect: MySQL,
+			query:   "DELETE FROM t WHERE a / b > 1",
+			want:    "DELETE FROM t WHERE mysql_divide(a, b) > 1",
+		},
+		{
+			name:    "insert with a select list",
+			dialect: MySQL,
+			query:   "INSERT INTO t SELECT a / b FROM u",
+			want:    `INSERT INTO t SELECT mysql_divide(a, b) AS "a / b" FROM u`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := Translate(tt.dialect, tt.query)
+			if err != nil {
+				t.Fatalf("Translate(%s, %q) error: %v", tt.dialect, tt.query, err)
+			}
+			if got != tt.want {
+				t.Errorf("Translate(%s, %q)\n got: %s\nwant: %s", tt.dialect, tt.query, got, tt.want)
+			}
+		})
+	}
+}

--- a/dialect/mysql_test.go
+++ b/dialect/mysql_test.go
@@ -36,12 +36,12 @@ func TestMySQLTranslate(t *testing.T) {
 		{"M-6_group_concat_plain", "SELECT GROUP_CONCAT(name) FROM t", "SELECT GROUP_CONCAT(name) FROM t"},
 		{"M-6_group_concat_distinct", "SELECT GROUP_CONCAT(DISTINCT name) FROM t", "SELECT GROUP_CONCAT(DISTINCT name) FROM t"},
 
-		{"M-7_div", "SELECT a DIV b FROM t", "SELECT CAST(mysql_divide(a, b) AS INTEGER) FROM t"},
+		{"M-7_div", "SELECT a DIV b FROM t", `SELECT CAST(mysql_divide(a, b) AS INTEGER) AS "a DIV b" FROM t`},
 		{"M-7_div_literals", "SELECT 7 DIV 2", "SELECT CAST(mysql_divide(7, 2) AS INTEGER) AS \"7 DIV 2\""},
 		{"M-7_div_qualified", "SELECT t.a DIV t.b FROM t", "SELECT CAST(mysql_divide(t.a, t.b) AS INTEGER) AS \"t.a DIV t.b\" FROM t"},
-		{"M-7_div_paren_left", "SELECT (a + b) DIV c", "SELECT CAST(mysql_divide((a + b), c) AS INTEGER)"},
+		{"M-7_div_paren_left", "SELECT (a + b) DIV c", `SELECT CAST(mysql_divide((a + b), c) AS INTEGER) AS "(a + b) DIV c"`},
 		{"M-7_div_call_right", "SELECT x DIV ABS(y)", "SELECT CAST(mysql_divide(x, ABS(y)) AS INTEGER) AS \"x DIV ABS(y)\""},
-		{"M-7_div_call_left", "SELECT ABS(x) DIV y", "SELECT CAST(mysql_divide(ABS(x), y) AS INTEGER)"},
+		{"M-7_div_call_left", "SELECT ABS(x) DIV y", `SELECT CAST(mysql_divide(ABS(x), y) AS INTEGER) AS "ABS(x) DIV y"`},
 
 		{"M-8_cast_signed", "SELECT CAST(x AS SIGNED) FROM t", "SELECT mysql_cast(x, 'SIGNED') AS \"CAST(x AS SIGNED)\" FROM t"},
 		{"M-8_cast_unsigned_integer", "SELECT CAST(x AS UNSIGNED INTEGER)", "SELECT mysql_cast(x, 'UNSIGNED') AS \"CAST(x AS UNSIGNED INTEGER)\""},

--- a/dialect/mysql_test.go
+++ b/dialect/mysql_test.go
@@ -15,40 +15,40 @@ func TestMySQLTranslate(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"C-1_extract", "SELECT EXTRACT(YEAR FROM d) FROM t", "SELECT DATE_PART('year', d) FROM t"},
-		{"C-1_extract_expr", "SELECT EXTRACT(MONTH FROM o.created) FROM t", "SELECT DATE_PART('month', o.created) FROM t"},
+		{"C-1_extract", "SELECT EXTRACT(YEAR FROM d) FROM t", "SELECT DATE_PART('year', d) AS \"EXTRACT(YEAR FROM d)\" FROM t"},
+		{"C-1_extract_expr", "SELECT EXTRACT(MONTH FROM o.created) FROM t", "SELECT DATE_PART('month', o.created) AS \"EXTRACT(MONTH FROM o.created)\" FROM t"},
 
-		{"M-5_date_add", "SELECT DATE_ADD(d, INTERVAL 3 DAY) FROM t", "SELECT interval_add(d, 3, 'day') FROM t"},
-		{"M-5_date_sub", "SELECT DATE_SUB(d, INTERVAL 2 MONTH) FROM t", "SELECT interval_add(d, -(2), 'month') FROM t"},
-		{"M-5_date_add_hour", "SELECT DATE_ADD(ts, INTERVAL 5 HOUR)", "SELECT interval_add(ts, 5, 'hour')"},
-		{"M-5_date_add_string_arg", "SELECT DATE_ADD('2020-01-01', INTERVAL 1 YEAR)", "SELECT interval_add('2020-01-01', 1, 'year')"},
+		{"M-5_date_add", "SELECT DATE_ADD(d, INTERVAL 3 DAY) FROM t", "SELECT interval_add(d, 3, 'day') AS \"DATE_ADD(d, INTERVAL 3 DAY)\" FROM t"},
+		{"M-5_date_sub", "SELECT DATE_SUB(d, INTERVAL 2 MONTH) FROM t", "SELECT interval_add(d, -(2), 'month') AS \"DATE_SUB(d, INTERVAL 2 MONTH)\" FROM t"},
+		{"M-5_date_add_hour", "SELECT DATE_ADD(ts, INTERVAL 5 HOUR)", "SELECT interval_add(ts, 5, 'hour') AS \"DATE_ADD(ts, INTERVAL 5 HOUR)\""},
+		{"M-5_date_add_string_arg", "SELECT DATE_ADD('2020-01-01', INTERVAL 1 YEAR)", "SELECT interval_add('2020-01-01', 1, 'year') AS \"DATE_ADD('2020-01-01', INTERVAL 1 YEAR)\""},
 
 		// MySQL CONCAT is NULL-propagating: any NULL argument makes the whole
 		// result NULL. SQLite's own concat() treats NULL as an empty string, so the
 		// call has to be routed to a helper rather than passed through.
-		{"M-x_concat", "SELECT CONCAT(a, b) FROM t", "SELECT strict_concat(a, b) FROM t"},
-		{"M-x_concat_one_arg", "SELECT CONCAT(a)", "SELECT strict_concat(a)"},
-		{"M-x_concat_nested", "SELECT CONCAT(a, CONCAT(b, c))", "SELECT strict_concat(a, strict_concat(b, c))"},
+		{"M-x_concat", "SELECT CONCAT(a, b) FROM t", "SELECT strict_concat(a, b) AS \"CONCAT(a, b)\" FROM t"},
+		{"M-x_concat_one_arg", "SELECT CONCAT(a)", "SELECT strict_concat(a) AS \"CONCAT(a)\""},
+		{"M-x_concat_nested", "SELECT CONCAT(a, CONCAT(b, c))", "SELECT strict_concat(a, strict_concat(b, c)) AS \"CONCAT(a, CONCAT(b, c))\""},
 		{"M-x_concat_ws_untouched", "SELECT CONCAT_WS(',', a, b)", "SELECT CONCAT_WS(',', a, b)"},
 		{"M-x_group_concat_untouched", "SELECT GROUP_CONCAT(a) FROM t", "SELECT GROUP_CONCAT(a) FROM t"},
 
-		{"M-6_group_concat_separator", "SELECT GROUP_CONCAT(name SEPARATOR ', ') FROM t", "SELECT GROUP_CONCAT(name, ', ') FROM t"},
+		{"M-6_group_concat_separator", "SELECT GROUP_CONCAT(name SEPARATOR ', ') FROM t", "SELECT GROUP_CONCAT(name, ', ') AS \"GROUP_CONCAT(name SEPARATOR ', ')\" FROM t"},
 		{"M-6_group_concat_plain", "SELECT GROUP_CONCAT(name) FROM t", "SELECT GROUP_CONCAT(name) FROM t"},
 		{"M-6_group_concat_distinct", "SELECT GROUP_CONCAT(DISTINCT name) FROM t", "SELECT GROUP_CONCAT(DISTINCT name) FROM t"},
 
 		{"M-7_div", "SELECT a DIV b FROM t", "SELECT CAST(mysql_divide(a, b) AS INTEGER) FROM t"},
-		{"M-7_div_literals", "SELECT 7 DIV 2", "SELECT CAST(mysql_divide(7, 2) AS INTEGER)"},
-		{"M-7_div_qualified", "SELECT t.a DIV t.b FROM t", "SELECT CAST(mysql_divide(t.a, t.b) AS INTEGER) FROM t"},
+		{"M-7_div_literals", "SELECT 7 DIV 2", "SELECT CAST(mysql_divide(7, 2) AS INTEGER) AS \"7 DIV 2\""},
+		{"M-7_div_qualified", "SELECT t.a DIV t.b FROM t", "SELECT CAST(mysql_divide(t.a, t.b) AS INTEGER) AS \"t.a DIV t.b\" FROM t"},
 		{"M-7_div_paren_left", "SELECT (a + b) DIV c", "SELECT CAST(mysql_divide((a + b), c) AS INTEGER)"},
-		{"M-7_div_call_right", "SELECT x DIV ABS(y)", "SELECT CAST(mysql_divide(x, ABS(y)) AS INTEGER)"},
+		{"M-7_div_call_right", "SELECT x DIV ABS(y)", "SELECT CAST(mysql_divide(x, ABS(y)) AS INTEGER) AS \"x DIV ABS(y)\""},
 		{"M-7_div_call_left", "SELECT ABS(x) DIV y", "SELECT CAST(mysql_divide(ABS(x), y) AS INTEGER)"},
 
-		{"M-8_cast_signed", "SELECT CAST(x AS SIGNED) FROM t", "SELECT mysql_cast(x, 'SIGNED') FROM t"},
-		{"M-8_cast_unsigned_integer", "SELECT CAST(x AS UNSIGNED INTEGER)", "SELECT mysql_cast(x, 'UNSIGNED')"},
-		{"M-8_cast_char", "SELECT CAST(x AS CHAR)", "SELECT mysql_cast(x, 'CHAR')"},
-		{"M-8_cast_decimal", "SELECT CAST(x AS DECIMAL(10,2))", "SELECT mysql_cast(x, 'DECIMAL(10,2)')"},
-		{"M-8_cast_datetime", "SELECT CAST(x AS DATETIME)", "SELECT mysql_cast(x, 'DATETIME')"},
-		{"M-8_cast_binary", "SELECT CAST(x AS BINARY)", "SELECT mysql_cast(x, 'BINARY')"},
+		{"M-8_cast_signed", "SELECT CAST(x AS SIGNED) FROM t", "SELECT mysql_cast(x, 'SIGNED') AS \"CAST(x AS SIGNED)\" FROM t"},
+		{"M-8_cast_unsigned_integer", "SELECT CAST(x AS UNSIGNED INTEGER)", "SELECT mysql_cast(x, 'UNSIGNED') AS \"CAST(x AS UNSIGNED INTEGER)\""},
+		{"M-8_cast_char", "SELECT CAST(x AS CHAR)", "SELECT mysql_cast(x, 'CHAR') AS \"CAST(x AS CHAR)\""},
+		{"M-8_cast_decimal", "SELECT CAST(x AS DECIMAL(10,2))", "SELECT mysql_cast(x, 'DECIMAL(10,2)') AS \"CAST(x AS DECIMAL(10,2))\""},
+		{"M-8_cast_datetime", "SELECT CAST(x AS DATETIME)", "SELECT mysql_cast(x, 'DATETIME') AS \"CAST(x AS DATETIME)\""},
+		{"M-8_cast_binary", "SELECT CAST(x AS BINARY)", "SELECT mysql_cast(x, 'BINARY') AS \"CAST(x AS BINARY)\""},
 		{"M-8_cast_unknown_passthrough", "SELECT CAST(x AS GEOMETRY)", "SELECT CAST(x AS GEOMETRY)"},
 
 		{"M-9_rlike", "SELECT * FROM t WHERE name RLIKE '^a'", "SELECT * FROM t WHERE name REGEXP '^a'"},
@@ -56,12 +56,12 @@ func TestMySQLTranslate(t *testing.T) {
 
 		{"M-10_limit_offset", "SELECT * FROM t LIMIT 5, 10", "SELECT * FROM t LIMIT 5, 10"},
 
-		{"nested_date_add_in_extract", "SELECT EXTRACT(DAY FROM DATE_ADD(d, INTERVAL 1 DAY))", "SELECT DATE_PART('day', interval_add(d, 1, 'day'))"},
+		{"nested_date_add_in_extract", "SELECT EXTRACT(DAY FROM DATE_ADD(d, INTERVAL 1 DAY))", "SELECT DATE_PART('day', interval_add(d, 1, 'day')) AS \"EXTRACT(DAY FROM DATE_ADD(d, INTERVAL 1 DAY))\""},
 		{"unrelated_function_untouched", "SELECT COALESCE(a, b), SUM(c) FROM t", "SELECT COALESCE(a, b), SUM(c) FROM t"},
 		{"extract_without_from_passthrough", "SELECT EXTRACT(x) FROM t", "SELECT EXTRACT(x) FROM t"},
 		{"cast_without_as_passthrough", "SELECT CAST(x) FROM t", "SELECT CAST(x) FROM t"},
 		{"date_add_without_interval_passthrough", "SELECT DATE_ADD(a, b) FROM t", "SELECT DATE_ADD(a, b) FROM t"},
-		{"nested_cast_in_unrecognized_call", "SELECT COALESCE(CAST(x AS SIGNED), 0) FROM t", "SELECT COALESCE(mysql_cast(x, 'SIGNED'), 0) FROM t"},
+		{"nested_cast_in_unrecognized_call", "SELECT COALESCE(CAST(x AS SIGNED), 0) FROM t", "SELECT COALESCE(mysql_cast(x, 'SIGNED'), 0) AS \"COALESCE(CAST(x AS SIGNED), 0)\" FROM t"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dialect/postgresql_test.go
+++ b/dialect/postgresql_test.go
@@ -13,14 +13,14 @@ func TestPostgreSQLTranslate(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"C-1_extract", "SELECT EXTRACT(YEAR FROM d) FROM t", "SELECT DATE_PART('year', d) FROM t"},
+		{"C-1_extract", "SELECT EXTRACT(YEAR FROM d) FROM t", "SELECT DATE_PART('year', d) AS \"EXTRACT(YEAR FROM d)\" FROM t"},
 
-		{"P-1_cast", "SELECT a::int FROM t", "SELECT postgresql_cast(a, 'int') FROM t"},
-		{"P-1_cast_text", "SELECT a::text", "SELECT postgresql_cast(a, 'text')"},
-		{"P-1_cast_chain", "SELECT a::int::text", "SELECT postgresql_cast(postgresql_cast(a, 'int'), 'text')"},
-		{"P-1_cast_varchar_param", "SELECT a::varchar(50)", "SELECT postgresql_cast(a, 'varchar(50)')"},
-		{"P-1_cast_unknown_type", "SELECT a::inet", "SELECT CAST(a AS inet)"},
-		{"P-1_cast_paren_operand", "SELECT (a + b)::int", "SELECT postgresql_cast((a + b), 'int')"},
+		{"P-1_cast", "SELECT a::int FROM t", "SELECT postgresql_cast(a, 'int') AS \"a::int\" FROM t"},
+		{"P-1_cast_text", "SELECT a::text", "SELECT postgresql_cast(a, 'text') AS \"a::text\""},
+		{"P-1_cast_chain", "SELECT a::int::text", "SELECT postgresql_cast(postgresql_cast(a, 'int'), 'text') AS \"a::int::text\""},
+		{"P-1_cast_varchar_param", "SELECT a::varchar(50)", "SELECT postgresql_cast(a, 'varchar(50)') AS \"a::varchar(50)\""},
+		{"P-1_cast_unknown_type", "SELECT a::inet", "SELECT CAST(a AS inet) AS \"a::inet\""},
+		{"P-1_cast_paren_operand", "SELECT (a + b)::int", "SELECT postgresql_cast((a + b), 'int') AS \"(a + b)::int\""},
 
 		{"P-2_ilike", "SELECT * FROM t WHERE name ILIKE 'a%'", `SELECT * FROM t WHERE like_insensitive('a%', name)`},
 		{"P-2_not_ilike", "SELECT * FROM t WHERE name NOT ILIKE 'a%'", `SELECT * FROM t WHERE NOT like_insensitive('a%', name)`},
@@ -30,19 +30,19 @@ func TestPostgreSQLTranslate(t *testing.T) {
 		{"P-3_match_ci", "SELECT * FROM t WHERE name ~* '^a'", "SELECT * FROM t WHERE name REGEXP '(?i)^a'"},
 		{"P-3_not_match_ci", "SELECT * FROM t WHERE name !~* '^a'", "SELECT * FROM t WHERE name NOT REGEXP '(?i)^a'"},
 
-		{"P-4_position", "SELECT POSITION('b' IN name) FROM t", "SELECT INSTR(name, 'b') FROM t"},
-		{"P-4_position_expr", "SELECT POSITION(sub IN col) FROM t", "SELECT INSTR(col, sub) FROM t"},
+		{"P-4_position", "SELECT POSITION('b' IN name) FROM t", "SELECT INSTR(name, 'b') AS \"POSITION('b' IN name)\" FROM t"},
+		{"P-4_position_expr", "SELECT POSITION(sub IN col) FROM t", "SELECT INSTR(col, sub) AS \"POSITION(sub IN col)\" FROM t"},
 
-		{"P-5_substring_from_for", "SELECT SUBSTRING(name FROM 2 FOR 3) FROM t", "SELECT SUBSTR(name, 2, 3) FROM t"},
-		{"P-5_substring_from", "SELECT SUBSTRING(name FROM 2) FROM t", "SELECT SUBSTR(name, 2) FROM t"},
-		{"P-5_substring_for", "SELECT SUBSTRING(name FOR 3) FROM t", "SELECT SUBSTR(name, 1, 3) FROM t"},
+		{"P-5_substring_from_for", "SELECT SUBSTRING(name FROM 2 FOR 3) FROM t", "SELECT SUBSTR(name, 2, 3) AS \"SUBSTRING(name FROM 2 FOR 3)\" FROM t"},
+		{"P-5_substring_from", "SELECT SUBSTRING(name FROM 2) FROM t", "SELECT SUBSTR(name, 2) AS \"SUBSTRING(name FROM 2)\" FROM t"},
+		{"P-5_substring_for", "SELECT SUBSTRING(name FOR 3) FROM t", "SELECT SUBSTR(name, 1, 3) AS \"SUBSTRING(name FOR 3)\" FROM t"},
 		{"P-5_substring_comma_passthrough", "SELECT SUBSTRING(name, 2, 3) FROM t", "SELECT SUBSTRING(name, 2, 3) FROM t"},
 
-		{"P-6_string_agg", "SELECT STRING_AGG(name, ', ') FROM t", "SELECT group_concat(name, ', ') FROM t"},
+		{"P-6_string_agg", "SELECT STRING_AGG(name, ', ') FROM t", "SELECT group_concat(name, ', ') AS \"STRING_AGG(name, ', ')\" FROM t"},
 
-		{"P-8_cast_int4", "SELECT CAST(x AS int4) FROM t", "SELECT postgresql_cast(x, 'int4') FROM t"},
-		{"P-8_cast_boolean", "SELECT CAST(x AS boolean)", "SELECT postgresql_cast(x, 'boolean')"},
-		{"P-8_cast_bytea", "SELECT CAST(x AS bytea)", "SELECT postgresql_cast(x, 'bytea')"},
+		{"P-8_cast_int4", "SELECT CAST(x AS int4) FROM t", "SELECT postgresql_cast(x, 'int4') AS \"CAST(x AS int4)\" FROM t"},
+		{"P-8_cast_boolean", "SELECT CAST(x AS boolean)", "SELECT postgresql_cast(x, 'boolean') AS \"CAST(x AS boolean)\""},
+		{"P-8_cast_bytea", "SELECT CAST(x AS bytea)", "SELECT postgresql_cast(x, 'bytea') AS \"CAST(x AS bytea)\""},
 
 		{"P-9_true_false", "SELECT * FROM t WHERE active = TRUE OR done = FALSE", "SELECT * FROM t WHERE active = TRUE OR done = FALSE"},
 
@@ -51,7 +51,7 @@ func TestPostgreSQLTranslate(t *testing.T) {
 		{"P-7_dollar_quote", "SELECT $$hi$$", "SELECT 'hi'"},
 
 		{"double_quoted_identifier_preserved", `SELECT "col" FROM "My Table"`, `SELECT "col" FROM "My Table"`},
-		{"nested_cast_in_position", "SELECT POSITION(x::text IN y) FROM t", "SELECT INSTR(y, postgresql_cast(x, 'text')) FROM t"},
+		{"nested_cast_in_position", "SELECT POSITION(x::text IN y) FROM t", "SELECT INSTR(y, postgresql_cast(x, 'text')) AS \"POSITION(x::text IN y)\" FROM t"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dialect_bridge_test.go
+++ b/dialect_bridge_test.go
@@ -331,3 +331,91 @@ func assertStrings(t *testing.T, got, want []string) {
 		}
 	}
 }
+
+// TestDialectQueryKeepsResultColumnNames runs the translated SQL against SQLite
+// and checks what the caller actually receives: the names of the result columns.
+// A rewrite renames an unaliased column, because SQLite names it after the text
+// of the expression, and that name is the CSV header or the JSON key the caller
+// ends up with.
+func TestDialectQueryKeepsResultColumnNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		dialect dialect.Dialect
+		query   string
+		want    []string
+	}{
+		{
+			name:    "postgresql cast operator",
+			dialect: dialect.PostgreSQL,
+			query:   `SELECT name, age::text FROM sample`,
+			want:    []string{"name", "age::text"},
+		},
+		{
+			name:    "mysql division",
+			dialect: dialect.MySQL,
+			query:   "SELECT age / 2 FROM sample",
+			want:    []string{"age / 2"},
+		},
+		{
+			// The label is the expression after lexical normalization, so a
+			// backtick identifier comes back double-quoted: backticks are not
+			// SQLite syntax and cannot appear in the statement that runs.
+			name:    "mysql backtick identifiers are normalized in the label",
+			dialect: dialect.MySQL,
+			query:   "SELECT `age` / 2 FROM `sample`",
+			want:    []string{`"age" / 2`},
+		},
+		{
+			name:    "googlesql safe cast",
+			dialect: dialect.GoogleSQL,
+			query:   "SELECT SAFE_CAST(age AS STRING) FROM sample",
+			want:    []string{"SAFE_CAST(age AS STRING)"},
+		},
+		{
+			name:    "an explicit alias still wins",
+			dialect: dialect.PostgreSQL,
+			query:   `SELECT age::text AS shown FROM sample`,
+			want:    []string{"shown"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(tt.dialect).Build(ctx)
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			db, err := builder.Open(ctx)
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer func() { _ = db.Close() }()
+
+			rows, err := db.QueryContext(ctx, tt.query)
+			if err != nil {
+				t.Fatalf("query: %v", err)
+			}
+			defer func() { _ = rows.Close() }()
+
+			got, err := rows.Columns()
+			if err != nil {
+				t.Fatalf("Columns: %v", err)
+			}
+			if err := rows.Err(); err != nil {
+				t.Fatalf("rows.Err: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("Columns() = %q, want %q", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("column %d = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/filesql.go
+++ b/filesql.go
@@ -834,11 +834,10 @@ func writeParquetTableData(w io.Writer, columns []string, rows *sql.Rows) error 
 		return fmt.Errorf("%w: no columns defined", ErrEmptyData)
 	}
 
-	// Read all rows into memory first. nulls runs parallel to rows and marks the
-	// cells that were SQL NULL, so the Parquet writer can store a real null rather
-	// than collapsing it into an empty string.
-	var allRows [][]string
-	var allNulls [][]bool
+	// Read all rows into memory first. The raw driver values are kept rather than
+	// their rendered text because Parquet is a typed format: which Arrow type each
+	// column is written as is decided from the values themselves, below.
+	var allRows [][]any
 
 	// Prepare for scanning
 	values := make([]any, len(columns))
@@ -851,25 +850,136 @@ func writeParquetTableData(w io.Writer, columns []string, rows *sql.Rows) error 
 		if err := rows.Scan(scanArgs...); err != nil {
 			return fmt.Errorf("%w: failed to scan row: %w", ErrDatabaseOperation, err)
 		}
-
-		row := make([]string, len(columns))
-		nullRow := make([]bool, len(columns))
-		for i, value := range values {
-			if value == nil {
-				nullRow[i] = true
-				continue
-			}
-			row[i] = formatDumpValue(value)
-		}
+		row := make([]any, len(columns))
+		copy(row, values)
 		allRows = append(allRows, row)
-		allNulls = append(allNulls, nullRow)
 	}
 
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("%w: error iterating rows: %w", ErrDatabaseOperation, err)
 	}
 
-	return writeParquetData(w, columns, allRows, allNulls)
+	declared := make([]string, len(columns))
+	if types, err := rows.ColumnTypes(); err == nil {
+		for i, ct := range types {
+			if i < len(declared) {
+				declared[i] = ct.DatabaseTypeName()
+			}
+		}
+	}
+
+	return writeParquetData(w, columns, allRows, declared)
+}
+
+// parquetKind is the Arrow type one column is written as.
+type parquetKind int
+
+const (
+	parquetString parquetKind = iota
+	parquetInt
+	parquetFloat
+)
+
+// parquetColumnKind decides how one column is written. A column is numeric only
+// when every value in it is, so a column that mixes a number with text is
+// written as STRING rather than losing the text: SQLite types values, not
+// columns, and a dump has to carry back whatever the rows actually held.
+//
+// The declared type decides an empty column, and only an empty one. It is what a
+// table emptied by the session still knows about itself, so an auto-save keeps
+// the schema instead of rewriting every column as STRING; for a column with rows
+// the values are the better witness, because a query's result columns carry no
+// declared type at all.
+func parquetColumnKind(rows [][]any, col int, declaredType string) parquetKind {
+	kind := parquetKind(-1)
+	for _, row := range rows {
+		if col >= len(row) || row[col] == nil {
+			continue
+		}
+		var cell parquetKind
+		switch row[col].(type) {
+		case int64:
+			cell = parquetInt
+		case float64:
+			cell = parquetFloat
+		default:
+			return parquetString
+		}
+		switch {
+		case kind < 0:
+			kind = cell
+		case kind != cell:
+			// int64 and float64 in one column widen to float64, which holds both
+			// without changing how the column compares.
+			kind = parquetFloat
+		}
+	}
+	if kind >= 0 {
+		return kind
+	}
+	switch strings.ToUpper(declaredType) {
+	case "INTEGER", "INT", "BIGINT":
+		return parquetInt
+	case "REAL", "FLOAT", "DOUBLE":
+		return parquetFloat
+	default:
+		return parquetString
+	}
+}
+
+// arrowTypeFor is the Arrow type a parquetKind is written as.
+func arrowTypeFor(kind parquetKind) arrow.DataType {
+	switch kind {
+	case parquetInt:
+		return arrow.PrimitiveTypes.Int64
+	case parquetFloat:
+		return arrow.PrimitiveTypes.Float64
+	default:
+		return arrow.BinaryTypes.String
+	}
+}
+
+// appendParquetValue appends one cell to the builder for its column. A nil value
+// is the SQL NULL the row carried; anything that does not match the column's
+// chosen kind cannot occur, because parquetColumnKind only chooses a numeric
+// kind when every value in the column is numeric.
+func appendParquetValue(b array.Builder, kind parquetKind, value any) error {
+	if value == nil {
+		b.AppendNull()
+		return nil
+	}
+	switch kind {
+	case parquetInt:
+		ib, ok := b.(*array.Int64Builder)
+		if !ok {
+			return fmt.Errorf("%w: expected an Int64Builder for an integer column", ErrInvalidData)
+		}
+		n, ok := value.(int64)
+		if !ok {
+			return fmt.Errorf("%w: %T in an integer column", ErrInvalidData, value)
+		}
+		ib.Append(n)
+	case parquetFloat:
+		fb, ok := b.(*array.Float64Builder)
+		if !ok {
+			return fmt.Errorf("%w: expected a Float64Builder for a real column", ErrInvalidData)
+		}
+		switch v := value.(type) {
+		case float64:
+			fb.Append(v)
+		case int64:
+			fb.Append(float64(v))
+		default:
+			return fmt.Errorf("%w: %T in a real column", ErrInvalidData, value)
+		}
+	default:
+		sb, ok := b.(*array.StringBuilder)
+		if !ok {
+			return fmt.Errorf("%w: expected a StringBuilder for a text column", ErrInvalidData)
+		}
+		sb.Append(formatDumpValue(value))
+	}
+	return nil
 }
 
 // writeOnly exposes only Write, so a library that would close or seek the
@@ -882,23 +992,36 @@ func (o writeOnly) Write(p []byte) (int, error) {
 	return o.w.Write(p)
 }
 
-// writeParquetData writes data to Parquet format. nulls, when non-nil, marks the
-// cells to store as a Parquet null; rows[r][c] is ignored for a cell marked null.
+// writeParquetData writes data to Parquet format. A nil cell in rows is stored
+// as a Parquet null, so a SQL NULL survives the round-trip instead of collapsing
+// into an empty string. declared holds each column's declared SQL type, which
+// decides a column that has no rows to speak for it.
+//
+// Each column is written as the Arrow type its values call for rather than as
+// STRING. Parquet states the type of every column in its schema and readers
+// trust it, so writing a numeric column as digit strings hands the next tool a
+// column it will compare and sort as text.
+//
 // A table with no rows is written as a schema with no row groups, which is a
 // valid Parquet file: the other formats write their header and nothing else, and
 // a dump that refused to write an emptied table let an auto-save keep the rows
 // the caller had deleted.
-func writeParquetData(w io.Writer, columns []string, rows [][]string, nulls [][]bool) error {
+func writeParquetData(w io.Writer, columns []string, rows [][]any, declared []string) error {
 	if len(columns) == 0 {
 		return fmt.Errorf("%w: no columns defined", ErrEmptyData)
 	}
 
-	// Create Arrow schema - for simplicity, treat all columns as strings
+	kinds := make([]parquetKind, len(columns))
 	fields := make([]arrow.Field, len(columns))
 	for i, col := range columns {
+		declaredType := ""
+		if i < len(declared) {
+			declaredType = declared[i]
+		}
+		kinds[i] = parquetColumnKind(rows, i, declaredType)
 		fields[i] = arrow.Field{
 			Name:     col,
-			Type:     arrow.BinaryTypes.String,
+			Type:     arrowTypeFor(kinds[i]),
 			Nullable: true, // allow a stored null so SQL NULL survives the round-trip
 		}
 	}
@@ -910,18 +1033,14 @@ func writeParquetData(w io.Writer, columns []string, rows [][]string, nulls [][]
 	defer builder.Release()
 
 	// Add data to builders
-	for r, row := range rows {
-		for i, value := range row {
-			if i < len(columns) {
-				strBuilder, ok := builder.Field(i).(*array.StringBuilder)
-				if !ok {
-					return fmt.Errorf("%w: failed to cast field %d to StringBuilder", ErrInvalidData, i)
-				}
-				if nulls != nil && r < len(nulls) && i < len(nulls[r]) && nulls[r][i] {
-					strBuilder.AppendNull()
-				} else {
-					strBuilder.Append(value)
-				}
+	for _, row := range rows {
+		for i := range columns {
+			var value any
+			if i < len(row) {
+				value = row[i]
+			}
+			if err := appendParquetValue(builder.Field(i), kinds[i], value); err != nil {
+				return err
 			}
 		}
 	}

--- a/filesql.go
+++ b/filesql.go
@@ -834,6 +834,18 @@ func writeParquetTableData(w io.Writer, columns []string, rows *sql.Rows) error 
 		return fmt.Errorf("%w: no columns defined", ErrEmptyData)
 	}
 
+	// The declared types are read before the scan loop. Draining Rows closes it,
+	// and ColumnTypes on a closed Rows fails, which would leave a table with no
+	// rows with nothing to take its schema from.
+	declared := make([]string, len(columns))
+	if types, err := rows.ColumnTypes(); err == nil {
+		for i, ct := range types {
+			if i < len(declared) {
+				declared[i] = ct.DatabaseTypeName()
+			}
+		}
+	}
+
 	// Read all rows into memory first. The raw driver values are kept rather than
 	// their rendered text because Parquet is a typed format: which Arrow type each
 	// column is written as is decided from the values themselves, below.
@@ -857,15 +869,6 @@ func writeParquetTableData(w io.Writer, columns []string, rows *sql.Rows) error 
 
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("%w: error iterating rows: %w", ErrDatabaseOperation, err)
-	}
-
-	declared := make([]string, len(columns))
-	if types, err := rows.ColumnTypes(); err == nil {
-		for i, ct := range types {
-			if i < len(declared) {
-				declared[i] = ct.DatabaseTypeName()
-			}
-		}
 	}
 
 	return writeParquetData(w, columns, allRows, declared)

--- a/parquet_types_test.go
+++ b/parquet_types_test.go
@@ -217,7 +217,45 @@ func TestParquetDumpWritesTypedColumns(t *testing.T) {
 		t.Fatalf("DumpDatabase: %v", err)
 	}
 
-	f, err := os.Open(filepath.Join(out, "goods.parquet")) //nolint:gosec // test-owned path
+	assertParquetSchema(t, filepath.Join(out, "goods.parquet"),
+		map[string]string{"name": "utf8", "price": "float64", "qty": "int64"})
+}
+
+// TestParquetDumpOfEmptyTableKeepsDeclaredTypes checks the one case the values
+// cannot decide. A table the session emptied still knows its declared types, and
+// an auto-save that rewrote them all as STRING would change the schema of a
+// table whose rows were merely deleted.
+func TestParquetDumpOfEmptyTableKeepsDeclaredTypes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "src.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.ExecContext(ctx,
+		`CREATE TABLE goods (name TEXT, price REAL, qty INTEGER);`); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(dir, "out")
+	if err := DumpDatabase(db, out, NewDumpOptions().WithFormat(OutputFormatParquet)); err != nil {
+		t.Fatalf("DumpDatabase: %v", err)
+	}
+
+	assertParquetSchema(t, filepath.Join(out, "goods.parquet"),
+		map[string]string{"name": "utf8", "price": "float64", "qty": "int64"})
+}
+
+// assertParquetSchema checks the Arrow type of each named column in a Parquet
+// file.
+func assertParquetSchema(t *testing.T, path string, want map[string]string) {
+	t.Helper()
+
+	f, err := os.Open(path) //nolint:gosec // test-owned path
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +276,6 @@ func TestParquetDumpWritesTypedColumns(t *testing.T) {
 		t.Fatalf("Schema: %v", err)
 	}
 
-	want := map[string]string{"name": "utf8", "price": "float64", "qty": "int64"}
 	for name, wantType := range want {
 		fields := schema.FieldIndices(name)
 		if len(fields) != 1 {

--- a/parquet_types_test.go
+++ b/parquet_types_test.go
@@ -1,0 +1,251 @@
+package filesql
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	pqfile "github.com/apache/arrow/go/v18/parquet/file"
+	"github.com/apache/arrow/go/v18/parquet/pqarrow"
+	_ "modernc.org/sqlite"
+)
+
+// Parquet declares the type of every column in its own schema, so an import has
+// no reason to guess and no reason to fall back to TEXT. A TEXT column carries
+// TEXT affinity into SQLite, which decides comparison and ordering: with it,
+// MAX picks the lexicographically largest value and a numeric predicate compares
+// digit strings. These tests pin the schema to what the file says.
+
+// TestParquetImportUsesSchemaTypes checks that the declared Parquet types reach
+// SQLite, so numeric columns compare and order as numbers.
+func TestParquetImportUsesSchemaTypes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	// products.parquet is written by testdata/generate_parquet.go with an
+	// explicit Arrow schema: id INT64, name STRING, price DOUBLE.
+	db, err := OpenContext(ctx, filepath.Join("testdata", "products.parquet"))
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	t.Run("typeof reports the declared type, not text", func(t *testing.T) {
+		var idType, nameType, priceType string
+		row := db.QueryRowContext(ctx,
+			"SELECT typeof(id), typeof(name), typeof(price) FROM products LIMIT 1")
+		if err := row.Scan(&idType, &nameType, &priceType); err != nil {
+			t.Fatal(err)
+		}
+		if idType != "integer" {
+			t.Errorf("typeof(id) = %q, want \"integer\"", idType)
+		}
+		if nameType != "text" {
+			t.Errorf("typeof(name) = %q, want \"text\"", nameType)
+		}
+		if priceType != "real" {
+			t.Errorf("typeof(price) = %q, want \"real\"", priceType)
+		}
+	})
+
+	t.Run("MAX compares numerically", func(t *testing.T) {
+		var maxPrice float64
+		if err := db.QueryRowContext(ctx, "SELECT MAX(price) FROM products").Scan(&maxPrice); err != nil {
+			t.Fatal(err)
+		}
+		// Lexicographically "999.99" > "79.99" > "29.99" agrees with the numeric
+		// answer here, so the assertion below is what separates the two.
+		if maxPrice != 999.99 {
+			t.Errorf("MAX(price) = %v, want 999.99", maxPrice)
+		}
+	})
+
+	t.Run("a numeric predicate filters numerically", func(t *testing.T) {
+		var got int
+		if err := db.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM products WHERE price > 100").Scan(&got); err != nil {
+			t.Fatal(err)
+		}
+		// With TEXT affinity every row matched, because SQLite compared the
+		// integer 100 as the string "100" against "999.99", "29.99", "79.99".
+		if got != 1 {
+			t.Errorf("COUNT(*) WHERE price > 100 = %d, want 1 (only 999.99)", got)
+		}
+	})
+}
+
+// TestParquetImportPrefersSchemaOverValueShape pins the reason the schema is
+// read at all: the values alone cannot tell these columns apart. A STRING column
+// of digits has to stay TEXT so its leading zeros survive, and a DOUBLE column
+// holding whole numbers has to stay REAL.
+func TestParquetImportPrefersSchemaOverValueShape(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// Build the file through a SQLite table whose declared types say what the
+	// values do not.
+	src, err := sql.Open("sqlite", filepath.Join(dir, "src.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = src.Close() }()
+	if _, err := src.ExecContext(ctx, `CREATE TABLE codes (zip TEXT, ratio REAL);`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := src.ExecContext(ctx, `INSERT INTO codes VALUES ('01234', 2.0),('00001', 3.0);`); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(dir, "out")
+	if err := DumpDatabase(src, out, NewDumpOptions().WithFormat(OutputFormatParquet)); err != nil {
+		t.Fatalf("DumpDatabase: %v", err)
+	}
+
+	db, err := OpenContext(ctx, filepath.Join(out, "codes.parquet"))
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var zip, zipType, ratioType string
+	row := db.QueryRowContext(ctx, "SELECT zip, typeof(zip), typeof(ratio) FROM codes ORDER BY zip LIMIT 1")
+	if err := row.Scan(&zip, &zipType, &ratioType); err != nil {
+		t.Fatal(err)
+	}
+	if zipType != "text" {
+		t.Errorf("typeof(zip) = %q, want \"text\": a STRING column of digits is still text", zipType)
+	}
+	if zip != "00001" {
+		t.Errorf("zip = %q, want \"00001\": the leading zeros must survive", zip)
+	}
+	if ratioType != "real" {
+		t.Errorf("typeof(ratio) = %q, want \"real\": a DOUBLE holding whole numbers is still real", ratioType)
+	}
+}
+
+// TestParquetAndCSVAgreeOnNumericQueries is the differential form of the same
+// property: the same rows loaded from Parquet and from CSV must answer the same
+// query the same way. CSV infers its types from the values, Parquet reads them
+// from its schema, and the two paths have to arrive at the same place.
+func TestParquetAndCSVAgreeOnNumericQueries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	// Values chosen so lexicographic and numeric order disagree on every query
+	// below: "9.99" sorts above "1000.5", and "100" sorts below "9".
+	csvPath := filepath.Join(dir, "goods.csv")
+	csvBody := "name,price,qty\ncheap,9.99,100\nmid,100,9\npricey,1000.5,20\n"
+	if err := os.WriteFile(csvPath, []byte(csvBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Round-trip the CSV through a Parquet dump so both inputs hold the same
+	// rows, then query each and compare.
+	csvDB, err := OpenContext(ctx, csvPath)
+	if err != nil {
+		t.Fatalf("OpenContext(csv): %v", err)
+	}
+	defer func() { _ = csvDB.Close() }()
+
+	out := filepath.Join(dir, "out")
+	if err := DumpDatabase(csvDB, out, NewDumpOptions().WithFormat(OutputFormatParquet)); err != nil {
+		t.Fatalf("DumpDatabase: %v", err)
+	}
+	parquetDB, err := OpenContext(ctx, filepath.Join(out, "goods.parquet"))
+	if err != nil {
+		t.Fatalf("OpenContext(parquet): %v", err)
+	}
+	defer func() { _ = parquetDB.Close() }()
+
+	queries := []struct {
+		name  string
+		query string
+	}{
+		{"max of a real column", "SELECT MAX(price) FROM goods"},
+		{"min of a real column", "SELECT MIN(price) FROM goods"},
+		{"max of an integer column", "SELECT MAX(qty) FROM goods"},
+		{"order by a real column", "SELECT group_concat(name) FROM (SELECT name FROM goods ORDER BY price)"},
+		{"filter on a real column", "SELECT COUNT(*) FROM goods WHERE price > 50"},
+	}
+	for _, tt := range queries {
+		t.Run(tt.name, func(t *testing.T) {
+			var fromCSV, fromParquet string
+			if err := csvDB.QueryRowContext(ctx, tt.query).Scan(&fromCSV); err != nil {
+				t.Fatalf("csv: %v", err)
+			}
+			if err := parquetDB.QueryRowContext(ctx, tt.query).Scan(&fromParquet); err != nil {
+				t.Fatalf("parquet: %v", err)
+			}
+			if fromCSV != fromParquet {
+				t.Errorf("%s\n csv     = %q\n parquet = %q", tt.query, fromCSV, fromParquet)
+			}
+		})
+	}
+}
+
+// TestParquetDumpWritesTypedColumns checks the export side. Parquet is a typed
+// format and a consumer reads its schema, so writing every column as STRING
+// hands the next tool a table of digit strings.
+func TestParquetDumpWritesTypedColumns(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "src.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.ExecContext(ctx,
+		`CREATE TABLE goods (name TEXT, price REAL, qty INTEGER);`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO goods VALUES ('cheap',9.99,100),('pricey',1000.5,20);`); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(dir, "out")
+	if err := DumpDatabase(db, out, NewDumpOptions().WithFormat(OutputFormatParquet)); err != nil {
+		t.Fatalf("DumpDatabase: %v", err)
+	}
+
+	f, err := os.Open(filepath.Join(out, "goods.parquet")) //nolint:gosec // test-owned path
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	reader, err := pqfile.NewParquetReader(f)
+	if err != nil {
+		t.Fatalf("NewParquetReader: %v", err)
+	}
+	defer func() { _ = reader.Close() }()
+
+	arrowReader, err := pqarrow.NewFileReader(reader, pqarrow.ArrowReadProperties{}, nil)
+	if err != nil {
+		t.Fatalf("NewFileReader: %v", err)
+	}
+	schema, err := arrowReader.Schema()
+	if err != nil {
+		t.Fatalf("Schema: %v", err)
+	}
+
+	want := map[string]string{"name": "utf8", "price": "float64", "qty": "int64"}
+	for name, wantType := range want {
+		fields := schema.FieldIndices(name)
+		if len(fields) != 1 {
+			t.Fatalf("column %q appears %d times in the parquet schema", name, len(fields))
+		}
+		if got := schema.Field(fields[0]).Type.Name(); got != wantType {
+			t.Errorf("column %q has parquet type %q, want %q", name, got, wantType)
+		}
+	}
+}

--- a/parser/parquet.go
+++ b/parser/parquet.go
@@ -111,11 +111,17 @@ func parseParquet(reader io.Reader) (*TableData, error) {
 		headers[i] = field.Name
 	}
 
+	// Parquet declares the type of every column, so the schema is read rather
+	// than inferred from the rendered values: inference cannot tell a STRING
+	// column of digits from an INT64 one, and would turn a zip code into a
+	// number.
+	columnTypes := arrowColumnTypes(schema)
+
 	if table.NumRows() == 0 {
 		return &TableData{
 			Headers:     headers,
 			Records:     [][]string{},
-			ColumnTypes: make([]ColumnType, len(headers)),
+			ColumnTypes: columnTypes,
 		}, nil
 	}
 
@@ -145,14 +151,41 @@ func parseParquet(reader io.Reader) (*TableData, error) {
 		return nil, fmt.Errorf("error reading table records: %w", err)
 	}
 
-	// Infer column types from the string records
-	columnTypes := inferColumnTypes(headers, records)
-
 	return &TableData{
 		Headers:     headers,
 		Records:     records,
 		ColumnTypes: columnTypes,
 	}, nil
+}
+
+// arrowColumnTypes maps a Parquet file's Arrow schema onto column types. The
+// type chosen for each column has to agree with what extractValueFromArrowArray
+// renders, because the value a caller reads back is parsed from that string.
+// Anything not named here stays text, which is the safe answer for a type whose
+// rendered shape is not known.
+func arrowColumnTypes(schema *arrow.Schema) []ColumnType {
+	fields := schema.Fields()
+	types := make([]ColumnType, len(fields))
+	for i, field := range fields {
+		types[i] = arrowColumnType(field.Type)
+	}
+	return types
+}
+
+// arrowColumnType is the column type for one Arrow type. Booleans render as
+// "true"/"false" and stay text; the temporal types render as the raw count they
+// store, which is an integer.
+func arrowColumnType(dt arrow.DataType) ColumnType {
+	switch dt.ID() {
+	case arrow.INT8, arrow.INT16, arrow.INT32, arrow.INT64,
+		arrow.UINT8, arrow.UINT16, arrow.UINT32, arrow.UINT64,
+		arrow.DATE32, arrow.DATE64, arrow.TIMESTAMP:
+		return TypeInteger
+	case arrow.FLOAT16, arrow.FLOAT32, arrow.FLOAT64:
+		return TypeReal
+	default:
+		return TypeText
+	}
 }
 
 // extractValueFromArrowArray extracts a value from an Arrow array at the given index.

--- a/parser/parquet_test.go
+++ b/parser/parquet_test.go
@@ -39,6 +39,9 @@ func TestParseParquet(t *testing.T) {
 		assert.Equal(t, "1", result.Records[0][0])
 		assert.Equal(t, "Laptop", result.Records[0][1])
 		assert.Equal(t, "999.99", result.Records[0][2])
+		// The types come from the Arrow schema (id INT64, name STRING, price
+		// DOUBLE), not from what the rendered values look like.
+		assert.Equal(t, []ColumnType{TypeInteger, TypeText, TypeReal}, result.ColumnTypes)
 	})
 
 	t.Run("returns error for empty data", func(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/apache/arrow/go/v18/arrow"
 	"github.com/apache/arrow/go/v18/arrow/array"
 	pqfile "github.com/apache/arrow/go/v18/parquet/file"
 	"github.com/apache/arrow/go/v18/parquet/pqarrow"
@@ -643,7 +644,50 @@ func (p *streamingParser) parseParquetStream(reader io.Reader) (*table, error) {
 		return nil, fmt.Errorf("error reading table records: %w", err)
 	}
 
-	return newTable(p.tableName, headerSlice, allRecords), nil
+	t := newTable(p.tableName, headerSlice, allRecords)
+	// The schema outranks what the values look like: a DOUBLE column holding
+	// whole numbers is still REAL, and a STRING column of digits is still TEXT.
+	t.columnInfo = arrowColumnInfoList(schema)
+	return t, nil
+}
+
+// arrowColumnInfoList maps a Parquet file's Arrow schema onto SQLite column
+// types. Parquet states the type of every column, so an import has nothing to
+// guess: reading the schema is both cheaper and more faithful than inferring
+// from the rendered values, which cannot tell a DOUBLE that happens to hold
+// whole numbers from an INT64, nor a STRING of digits from either.
+//
+// The type declared here has to agree with what extractValueFromArrowArray
+// renders, because SQLite applies the column's affinity to that string. A
+// mismatch is worse than TEXT: it would store a value the column claims not to
+// hold.
+func arrowColumnInfoList(schema *arrow.Schema) columnInfoList {
+	fields := schema.Fields()
+	columns := make(columnInfoList, len(fields))
+	for i, field := range fields {
+		columns[i] = columnInfo{Name: field.Name, Type: arrowColumnType(field.Type)}
+	}
+	return columns
+}
+
+// arrowColumnType is the SQLite type for one Arrow type. Anything not named
+// here stays TEXT, which is the safe answer: an unrecognized type is rendered by
+// extractValueFromArrowArray's default branch, and its shape is not known.
+func arrowColumnType(dt arrow.DataType) columnType {
+	switch dt.ID() {
+	// Booleans render as 1 and 0, and the temporal types render as the raw
+	// count they store (days, milliseconds, or ticks since the epoch), so all of
+	// them reach SQLite as integers.
+	case arrow.BOOL,
+		arrow.INT8, arrow.INT16, arrow.INT32, arrow.INT64,
+		arrow.UINT8, arrow.UINT16, arrow.UINT32, arrow.UINT64,
+		arrow.DATE32, arrow.DATE64, arrow.TIMESTAMP:
+		return columnTypeInteger
+	case arrow.FLOAT16, arrow.FLOAT32, arrow.FLOAT64:
+		return columnTypeReal
+	default:
+		return columnTypeText
+	}
 }
 
 // processParquetInChunks processes Parquet data in chunks
@@ -689,13 +733,7 @@ func (p *streamingParser) processParquetInChunks(reader io.Reader, processor chu
 		headerSlice[i] = field.Name
 	}
 
-	// Infer column types from first batch
-	columnInfoList := make(columnInfoList, len(headerSlice))
-	for i, name := range headerSlice {
-		// For Parquet files, we'll default to TEXT for simplicity in streaming
-		// Real type inference could be done from Arrow schema
-		columnInfoList[i] = newColumnInfoWithType(name)
-	}
+	columnInfoList := arrowColumnInfoList(schema)
 
 	// Handle header-only Parquet files (schema exists but no data rows)
 	if table.NumRows() == 0 {


### PR DESCRIPTION
## Parquet columns arrived as TEXT

Parquet states the type of every column in its own schema, and the streaming import ignored it: `processParquetInChunks` built every column as TEXT with a comment saying it was "for simplicity in streaming".

TEXT affinity decides comparison and ordering in SQLite, so the same rows answered the same query differently depending on which format they were loaded from:

| query | from Parquet | from CSV |
|:--|:--|:--|
| `MAX(price)` | `"9.99"` | `1000.5` |
| `MIN(price)` | `"100"` | `9.99` |
| `ORDER BY price` | mid, pricey, cheap | cheap, mid, pricey |
| `WHERE price > 50` | cheap | mid, pricey |

No error and no warning: the answers were simply wrong. The Arrow schema now decides the column type, in the streaming path and in `parser.Parse` alike. Reading the schema is also the only way to tell a `STRING` column of zip codes from an `INT64` one, which value inference cannot do.

## Parquet exports were written as all STRING

The writer declared every column `STRING` regardless of what it held, so a consumer that trusts the schema — which is the point of a typed format — received a table of digit strings. Each column is now written as the Arrow type its values call for. A column that mixes a number with text is still `STRING`, because SQLite types values rather than columns and a dump has to carry back what the rows held; a column with no rows takes the declared type of the table it came from.

## Dialect rewrites renamed the caller's result columns

SQLite names an unaliased result column after the text of the expression that produced it, so rewriting the expression renamed the column. `SELECT amt::text` came back as `postgresql_cast(amt, 'text')` and reached the caller under that name — as a CSV header, as a JSON key. MySQL's `/` and `CONCAT`, GoogleSQL's `SAFE_CAST`, and every other rewritten select item had the same problem.

A rewritten select item now carries its original text as an alias, so `amt::text` stays `amt::text`. The label is the expression as written rather than the name the source database would derive, because that is one rule for every dialect: PostgreSQL, MySQL, and GoogleSQL each name a bare cast differently, and guessing per dialect would be three rules that still all disagree with SQLite. An item the query already named, a bare column reference, and a `*` are left alone.

## Tests

- `parquet_types_test.go`: the declared types reach SQLite, a `STRING` column of digits stays text while a `DOUBLE` of whole numbers stays real, a differential test asserting Parquet and CSV answer five numeric queries identically, and a check that the exported schema is typed.
- `dialect/label_test.go`: seventeen cases covering each dialect's rewrites, explicit and implicit aliases, bare column references, `*`, `DISTINCT`, subqueries, `WHERE` clauses, and statements with no select list.
- `dialect_bridge_test.go`: the column names a caller reads back from a real query through SQLite.
- `parser/parquet_test.go`: the schema-derived column types.

The existing dialect expectation tables are updated for the added aliases. `go test ./...` passes and 20s of `FuzzTranslate` (700k executions) found no crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Parquet imports now preserve column types declared in the source schema, including empty tables.
  * Parquet exports now retain NULL values, preserve declared types, and infer appropriate numeric and text types.
  * Improved handling of dates, timestamps, integers, floating-point values, and booleans in Parquet workflows.
  * SQL dialect translation now preserves original result-column names when expressions are rewritten, including nested expressions and queries with aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->