### PR TITLE
fix: do not rename a select item that already has an implicit alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-08-06
+
+### Fixed
+
+- A select item whose expression was rewritten and which already carried an
+  implicit alias is no longer given a second name. `SELECT CONCAT(a,b) z`
+  became `SELECT strict_concat(a,b) z AS "CONCAT(a,b) z"`, which does not
+  parse, so a query that worked in 0.34.0 failed in 0.35.0 with a syntax error
+  near `AS`. The alias detection read a closing parenthesis as an operator and
+  so took the name after it for part of the expression; a bare word after `)`
+  is an alias. Only the implicit form was affected — `AS z` was always
+  detected — and only for expressions a dialect rewrites.
+
 ## [0.35.0] - 2026-08-06
 
 ### Fixed

--- a/dialect/label.go
+++ b/dialect/label.go
@@ -129,7 +129,12 @@ func hasAlias(tokens []token, span tokenSpan) bool {
 	if prev < 0 {
 		return false
 	}
-	if tokens[prev].kind == tokOp {
+	// A closing paren ends an expression, so a bare word after it is an alias:
+	// "CONCAT(c,c) z" names its column z. Every other operator expects an operand,
+	// and the word after one belongs to the expression. Reading ")" as an operator
+	// here appended a second name to an item that already had one, and the
+	// statement no longer parsed.
+	if tokens[prev].kind == tokOp && !isOpEq(tokens[prev], ")") {
 		return false
 	}
 	if tokens[prev].kind == tokWord && operandExpectingKeywords[strings.ToUpper(tokens[prev].text)] {

--- a/dialect/label_test.go
+++ b/dialect/label_test.go
@@ -138,6 +138,28 @@ func TestTranslatePreservesResultColumnLabels(t *testing.T) {
 			want:    `SELECT postgresql_cast(amt, 'text') COLLATE NOCASE AS "amt::text COLLATE NOCASE" FROM t`,
 		},
 		{
+			// A bare word after a closing paren is an alias, not part of the
+			// expression. Reading ")" as an operator appended a second name and
+			// produced "strict_concat(c,c) z AS \"CONCAT(c,c) z\"", which does
+			// not parse.
+			name:    "an implicit alias after a rewritten call is left alone",
+			dialect: MySQL,
+			query:   "SELECT CONCAT(a,b) z FROM t",
+			want:    "SELECT strict_concat(a,b) z FROM t",
+		},
+		{
+			name:    "an implicit alias after a rewritten cast call is left alone",
+			dialect: PostgreSQL,
+			query:   "SELECT CAST(amt AS text) label FROM t",
+			want:    "SELECT postgresql_cast(amt, 'text') label FROM t",
+		},
+		{
+			name:    "an implicit alias after a parenthesized expression is left alone",
+			dialect: MySQL,
+			query:   "SELECT (a / b) z FROM t",
+			want:    "SELECT (mysql_divide(a, b)) z FROM t",
+		},
+		{
 			name:    "an implicit alias after a keyword-ending expression is left alone",
 			dialect: PostgreSQL,
 			query:   "SELECT amt::text IS NULL flag FROM t",

--- a/dialect_label_execution_test.go
+++ b/dialect_label_execution_test.go
@@ -1,0 +1,106 @@
+package filesql
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nao1215/filesql/dialect"
+	_ "modernc.org/sqlite"
+)
+
+// TestTranslatedQueriesStillExecute is the property the label pass has to keep:
+// a query SQLite accepts must still be accepted after translation. Checking the
+// translated text alone cannot see this — the text looked reasonable, and only
+// running it showed the statement no longer parsed.
+//
+// The case that got through: an implicit alias after a rewritten call.
+// "SELECT CONCAT(a,b) z" became "strict_concat(a,b) z AS \"CONCAT(a,b) z\"",
+// two names for one item, because a closing paren was read as an operator and
+// the alias after it as part of the expression.
+func TestTranslatedQueriesStillExecute(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.csv")
+	if err := os.WriteFile(path, []byte("a,b,c\n1,2,x\n3,4,y\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	plain, err := OpenContext(ctx, path)
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	// t.Cleanup, not defer: the subtests below are parallel, so they run after
+	// this function returns. A deferred Close would shut the database before the
+	// first one queried it, and every assertion would pass on "database is
+	// closed" instead of on what it meant to check.
+	t.Cleanup(func() { _ = plain.Close() })
+
+	// Expression shapes crossed with the ways a select item can be named. Each
+	// atom that a dialect rewrites is what makes the naming matter.
+	atoms := []string{
+		"a", "a / b", "a + b", "CONCAT(c,c)", "ABS(a)", "a DIV b", "COUNT(*)",
+		"MAX(a)", "CASE WHEN a>1 THEN a ELSE b END", "(SELECT MAX(a) FROM f)",
+		"a IS NULL", "c LIKE 'x'", "a * 2", "-a", "(a)", "(a / b)", "LENGTH(c)",
+		"CAST(a AS CHAR)",
+	}
+	suffixes := []string{"", " AS z", " z", " COLLATE NOCASE"}
+	tails := []string{"", " FROM f", " FROM f WHERE a > 0", " FROM f GROUP BY c ORDER BY c"}
+
+	for _, atom := range atoms {
+		for _, suffix := range suffixes {
+			for _, tail := range tails {
+				query := "SELECT " + atom + suffix + tail
+				t.Run(strings.NewReplacer(" ", "_", "/", "div", "*", "star").Replace(query), func(t *testing.T) {
+					t.Parallel()
+					// The property is that translation never turns SQL that parses
+					// into SQL that does not. A query holding syntax only the source
+					// dialect has — MySQL's DIV, say — does not parse to begin with,
+					// so a dialect that leaves it alone has broken nothing.
+					if runErr := execErr(plain, query); runErr != nil && isSyntaxError(runErr) {
+						t.Skipf("SQLite cannot parse %q on its own", query)
+					}
+					// A syntax error is the only failure in scope. The translated
+					// query may still name a helper this connection has not
+					// registered, or a function SQLite lacks — those are the
+					// caller's contract with the dialect, not malformed SQL. What
+					// translation must never do is produce something that does not
+					// parse, and asserting on the text alone cannot see that.
+					for _, d := range []dialect.Dialect{dialect.MySQL, dialect.PostgreSQL, dialect.GoogleSQL} {
+						translated, err := dialect.Translate(d, query)
+						if err != nil {
+							continue // a construct the dialect refuses by name is a different contract
+						}
+						if runErr := execErr(plain, translated); runErr != nil && isSyntaxError(runErr) {
+							t.Errorf("%s translated a query into one that does not parse\n  in:  %s\n  out: %s\n  err: %v",
+								d, query, translated, runErr)
+						}
+					}
+				})
+			}
+		}
+	}
+}
+
+// execErr runs the statement and returns whatever stopped it, or nil.
+func execErr(db *sql.DB, query string) error {
+	rows, err := db.QueryContext(context.Background(), query)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+	}
+	return rows.Err()
+}
+
+// isSyntaxError reports whether SQLite refused to parse the statement, as
+// opposed to refusing to run one it understood.
+func isSyntaxError(err error) bool {
+	return strings.Contains(err.Error(), "syntax error")
+}


### PR DESCRIPTION
A regression in v0.35.0, found by running translated queries against SQLite instead of only inspecting their text.

## What broke

```
SELECT CONCAT(a,b) z FROM t
```

translated to

```
SELECT strict_concat(a,b) z AS "CONCAT(a,b) z" FROM t
```

Two names for one select item. SQLite reports `near "AS": syntax error`, so a query that worked in v0.34.0 fails in v0.35.0. It affects any expression a dialect rewrites that carries an **implicit** alias — `CONCAT(a,b) z`, `LENGTH(c) z`, `CAST(amt AS text) label`, `(a / b) z`. The explicit `AS z` form was always detected correctly.

`hasAlias` treated every operator token before the final word as evidence that the word is an operand. That is right for `+`, `::`, `/`, and the rest, and wrong for `)`, which ends an expression: a bare word after a closing parenthesis is a name.

## Why the tests did not catch it

The label tests assert on the translated text, and the text looked plausible — the alias was well-formed, it was simply in a place another name already occupied. Nothing ran the result.

`TestTranslatedQueriesStillExecute` runs it. It crosses eighteen expression shapes with four naming forms and four clause tails, translates each under all three dialects, and asserts the one property translation owes: SQL that parses must still parse afterwards. A query SQLite cannot parse on its own — MySQL's `DIV`, say — is skipped, because a dialect that leaves it alone has broken nothing. Against the broken rule the test reports 32 failing combinations; with the fix it is clean.

The test needed one correction of its own before it could see anything: `t.Cleanup` rather than `defer` for the database handle. Its subtests are parallel, so they run after the test function returns, and a deferred `Close` had all 289 of them passing on `sql: database is closed`.

## Scope

`sqly` at v0.35.0 is affected — `sqly --dialect mysql --sql "SELECT CONCAT(a,b) z FROM t"` fails there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed translated `SELECT` expressions with implicit aliases to prevent duplicate aliases and SQL syntax errors.
  * Preserved explicit aliases and unaffected expressions without changing their behavior.

* **Tests**
  * Added coverage for rewritten function calls, casts, and parenthesized expressions.
  * Added execution checks across MySQL, PostgreSQL, and GoogleSQL translations to catch invalid generated queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->