### PR TITLE
fix: stop declaring a column type the storage will not match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Column type detection no longer declares a type the storage will not match. `strconv.ParseFloat` accepts Go source syntax that SQL does not have, so a digit-separating underscore (`1_000`) or a hexadecimal float (`0x1p4`) made the column `REAL` while SQLite stored every value in it as text. A datetime alongside a number did the same: the numeric type won on confidence and the datetime was stored as text under it. Both are TEXT now, which is what the storage always was. A caller reading the schema to plan a numeric comparison had no way to detect the difference.
+- Column type detection no longer declares a type the storage will not match. `strconv.ParseFloat` accepts Go source syntax that SQLite's numeric affinity does not convert, so a digit-separating underscore (`1_000`) or a hexadecimal float (`0x1p4`) made the column `REAL` while every value in it was stored as text. A datetime alongside a number did the same: the numeric type won on confidence and the datetime was stored as text under it. Both are TEXT now, which is what the storage always was. A caller reading the schema to plan a numeric comparison had no way to detect the difference.
 
 ## [0.35.1] - 2026-08-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Column type detection no longer declares a type the storage will not match. `strconv.ParseFloat` accepts Go source syntax that SQL does not have, so a digit-separating underscore (`1_000`) or a hexadecimal float (`0x1p4`) made the column `REAL` while SQLite stored every value in it as text. A datetime alongside a number did the same: the numeric type won on confidence and the datetime was stored as text under it. Both are TEXT now, which is what the storage always was. A caller reading the schema to plan a numeric comparison had no way to detect the difference.
+
 ## [0.35.1] - 2026-08-06
 
 ### Fixed

--- a/types.go
+++ b/types.go
@@ -659,10 +659,10 @@ func isFloat(value string) bool {
 		return false
 	}
 
-	// strconv.ParseFloat accepts Go source syntax, which SQL does not have:
-	// digit-separating underscores ("1_000") and hexadecimal floats ("0x1p4").
-	// Calling those numeric declared a REAL column that SQLite then stored as
-	// text, so the schema said REAL and typeof() said text.
+	// strconv.ParseFloat accepts Go source syntax: digit-separating underscores
+	// ("1_000") and hexadecimal floats ("0x1p4"). SQLite's numeric affinity
+	// converts neither, so calling them numeric declared a REAL column whose
+	// values it then stored as text, leaving the schema and typeof() disagreeing.
 	if hasGoOnlyNumericSyntax(value) {
 		return false
 	}
@@ -672,8 +672,9 @@ func isFloat(value string) bool {
 }
 
 // hasGoOnlyNumericSyntax reports whether value uses numeric syntax that Go's
-// parsers accept but SQL does not: an underscore separator, or the "0x" prefix
-// that introduces a hexadecimal (and possibly p-exponent) literal.
+// parsers accept and SQLite's numeric affinity does not convert: an underscore
+// separator, or the "0x" prefix that introduces a hexadecimal (and possibly
+// p-exponent) literal.
 func hasGoOnlyNumericSyntax(value string) bool {
 	digits := strings.TrimSpace(value)
 	digits = strings.TrimPrefix(strings.TrimPrefix(digits, "+"), "-")

--- a/types.go
+++ b/types.go
@@ -659,8 +659,28 @@ func isFloat(value string) bool {
 		return false
 	}
 
+	// strconv.ParseFloat accepts Go source syntax, which SQL does not have:
+	// digit-separating underscores ("1_000") and hexadecimal floats ("0x1p4").
+	// Calling those numeric declared a REAL column that SQLite then stored as
+	// text, so the schema said REAL and typeof() said text.
+	if hasGoOnlyNumericSyntax(value) {
+		return false
+	}
+
 	_, err := strconv.ParseFloat(value, 64)
 	return err == nil
+}
+
+// hasGoOnlyNumericSyntax reports whether value uses numeric syntax that Go's
+// parsers accept but SQL does not: an underscore separator, or the "0x" prefix
+// that introduces a hexadecimal (and possibly p-exponent) literal.
+func hasGoOnlyNumericSyntax(value string) bool {
+	digits := strings.TrimSpace(value)
+	digits = strings.TrimPrefix(strings.TrimPrefix(digits, "+"), "-")
+	if strings.Contains(digits, "_") {
+		return true
+	}
+	return len(digits) > 1 && digits[0] == '0' && (digits[1] == 'x' || digits[1] == 'X')
 }
 
 // isIntegerLiteralOverflowingInt64 reports whether value is an integer literal
@@ -694,6 +714,15 @@ func isIntegerLiteralOverflowingInt64(value string) bool {
 func selectColumnType(typeCounts map[columnType]int, totalCount int) columnType {
 	// If any text values exist with reasonable confidence, choose text
 	if typeCounts[columnTypeText] > 0 {
+		return columnTypeText
+	}
+
+	// A datetime is stored as text, so a column that also holds a number has no
+	// type covering both, exactly as a column holding text does. Picking the
+	// numeric one declared INTEGER or REAL over values SQLite then stored as
+	// text, leaving the schema and typeof() disagreeing.
+	if typeCounts[columnTypeDatetime] > 0 &&
+		typeCounts[columnTypeInteger]+typeCounts[columnTypeReal] > 0 {
 		return columnTypeText
 	}
 

--- a/types_test.go
+++ b/types_test.go
@@ -713,9 +713,9 @@ func TestIsFloat(t *testing.T) {
 		{"multiple dots", "12.34.56", false},
 		{"invalid scientific", "1e", false},
 
-		// Go accepts these literals and SQL does not. Calling them numeric
-		// declared a REAL column that SQLite then stored as text, so the schema
-		// said one thing and typeof() said another.
+		// Go's parser accepts these spellings and SQLite's numeric affinity does
+		// not convert them. Calling them numeric declared a REAL column that
+		// stored every value as text, so the schema and typeof() disagreed.
 		{"underscore separators", "1_000", false},
 		{"underscore in a decimal", "1_000.5", false},
 		{"short underscore form", "1_0", false},

--- a/types_test.go
+++ b/types_test.go
@@ -712,6 +712,17 @@ func TestIsFloat(t *testing.T) {
 		{"no digits", "abc", false},
 		{"multiple dots", "12.34.56", false},
 		{"invalid scientific", "1e", false},
+
+		// Go accepts these literals and SQL does not. Calling them numeric
+		// declared a REAL column that SQLite then stored as text, so the schema
+		// said one thing and typeof() said another.
+		{"underscore separators", "1_000", false},
+		{"underscore in a decimal", "1_000.5", false},
+		{"short underscore form", "1_0", false},
+		{"hexadecimal float", "0x1p4", false},
+		{"hexadecimal integer", "0x10", false},
+		{"binary literal", "0b101", false},
+		{"octal literal", "0o17", false},
 	}
 
 	for _, tt := range tests {
@@ -757,6 +768,31 @@ func TestSelectColumnType(t *testing.T) {
 			expected:   columnTypeText,
 		},
 		{
+			// A datetime is stored as text, so a column holding one alongside a
+			// number has no type that covers both. Answering INTEGER declared a
+			// schema the storage did not match.
+			name: "datetime mixed with integer falls back to text",
+			typeCounts: map[columnType]int{
+				columnTypeInteger:  1,
+				columnTypeReal:     0,
+				columnTypeDatetime: 1,
+				columnTypeText:     0,
+			},
+			totalCount: 2,
+			expected:   columnTypeText,
+		},
+		{
+			name: "datetime mixed with real falls back to text",
+			typeCounts: map[columnType]int{
+				columnTypeInteger:  0,
+				columnTypeReal:     3,
+				columnTypeDatetime: 1,
+				columnTypeText:     0,
+			},
+			totalCount: 4,
+			expected:   columnTypeText,
+		},
+		{
 			name: "high confidence datetime",
 			typeCounts: map[columnType]int{
 				columnTypeInteger:  0,
@@ -772,11 +808,24 @@ func TestSelectColumnType(t *testing.T) {
 			typeCounts: map[columnType]int{
 				columnTypeInteger:  3,
 				columnTypeReal:     4,
+				columnTypeDatetime: 0,
+				columnTypeText:     0,
+			},
+			totalCount: 7,
+			expected:   columnTypeReal,
+		},
+		{
+			// REAL used to win this on confidence, and the two datetimes in it
+			// were then stored as text under a REAL declaration.
+			name: "low confidence numerics with a datetime fall back to text",
+			typeCounts: map[columnType]int{
+				columnTypeInteger:  3,
+				columnTypeReal:     4,
 				columnTypeDatetime: 2,
 				columnTypeText:     0,
 			},
 			totalCount: 10,
-			expected:   columnTypeReal,
+			expected:   columnTypeText,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Column type detection could declare `INTEGER` or `REAL` for a column whose values SQLite then stored as text, so the schema a caller reads and `typeof()` disagreed with no way to tell from the outside. Two independent triggers, both fixed here.

## Changes

- `types.go`: `isFloat` rejects numeric syntax that only Go accepts, via a new `hasGoOnlyNumericSyntax` helper. `strconv.ParseFloat` takes a digit-separating underscore (`1_000`, `1_000.5`) and a hexadecimal float (`0x1p4`); SQL takes neither, so those values were called REAL and stored as text.
- `types.go`: `selectColumnType` returns text when a column holds a datetime alongside a number. A datetime is stored as text, so there is no type covering both, which is the rule the function already applied to text values.
- `types_test.go`: cases for both triggers in `TestIsFloat` and `TestSelectColumnType`.
- `CHANGELOG.md`.

## Design Decisions

The rule for text was already at the top of `selectColumnType`: if any value in the column is text, the column is text, because no other type holds it. A datetime value is stored as text too, so the same reasoning applies and the fix is that rule extended rather than a new confidence tweak. Going by confidence instead is what let three integers and four reals outvote two datetimes and declare REAL over values that were never numeric.

For the literal syntax the check is a small explicit test rather than a stricter regex over the whole value, because `ParseFloat` is otherwise the right acceptor and only these two Go-only spellings need excluding. Binary (`0b101`) and octal (`0o17`) literals already failed `ParseFloat` and need no handling.

## Limitations

One existing `TestSelectColumnType` case pinned the old answer: three integers, four reals, and two datetimes returned REAL. That is the behavior being fixed, so its expectation is now text, and a datetime-free version of the case keeps covering the numeric fallback it was written for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected column type detection for unsupported numeric formats, including hexadecimal, binary, octal, and underscore-separated values.
  * Columns mixing date/time and numeric values are now classified as `TEXT`, matching SQLite behavior.
  * Improved handling of mixed integer and decimal values based on the most common type.

* **Tests**
  * Added coverage for numeric parsing and mixed-type column classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->