### PR TITLE
fix: reject text input that is not valid UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- A text source that is not valid UTF-8 is rejected instead of loaded. SQLite stores TEXT as UTF-8, so bytes in a legacy encoding were stored verbatim and read back as mojibake: `LENGTH` counted the wrong number of characters, `LIKE` and `UPPER` worked on fragments of characters, and the load reported success. A Shift-JIS CSV exported from Excel is the ordinary way to reach this. The load now fails with `ErrInvalidUTF8`, naming the offending byte and its offset, and the caller transcodes before loading. Validation is not detection: nothing in the byte stream says which encoding it is, and a wrong guess would be the same silent corruption in another shape. It covers CSV, TSV, LTSV, JSON, and JSONL, whose readers already share one entry point; UTF-16 with a byte-order mark is still transcoded as before, and valid UTF-8 passes through byte for byte.
+
+### Fixed
+
+- A duplicate column name error says which column it means. The name was printed unquoted, so a header with two unnamed columns (`a,,`) produced `duplicate column name: ` with nothing after the colon, and neither the name nor its position was recoverable from the message. It now reads `duplicate column name: "" (column 3)`.
+
 ## [0.35.2] - 2026-08-06
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A duplicate column name error says which column it means. The name was printed unquoted, so a header with two unnamed columns (`a,,`) produced `duplicate column name: ` with nothing after the colon, and neither the name nor its position was recoverable from the message. It now reads `duplicate column name: "" (column 3)`.
+- A duplicate column name error says which column it means. The name was printed unquoted, so a header with two unnamed columns (`a,,`) produced `duplicate column name:` with nothing after the colon, and neither the name nor its position was recoverable from the message. It now reads `duplicate column name: "" (column 3)`.
 
 ## [0.35.2] - 2026-08-06
 

--- a/builder.go
+++ b/builder.go
@@ -955,11 +955,12 @@ func (b *DBBuilder) createTableFromXLSXSheet(ctx context.Context, db *sql.DB, ta
 		return fmt.Errorf("%w: no columns in sheet header", ErrEmptyData)
 	}
 
-	// Check for duplicate column names
+	// Check for duplicate column names. The name is quoted and located so a
+	// duplicate of the empty name still says which column it was.
 	columnsSeen := make(map[string]bool)
-	for _, col := range headers {
+	for i, col := range headers {
 		if columnsSeen[col] {
-			return fmt.Errorf("%w: %s", errDuplicateColumnName, col)
+			return fmt.Errorf("%w: %q (column %d)", errDuplicateColumnName, col, i+1)
 		}
 		columnsSeen[col] = true
 	}

--- a/encoding.go
+++ b/encoding.go
@@ -1,7 +1,10 @@
 package filesql
 
 import (
+	"errors"
+	"fmt"
 	"io"
+	"unicode/utf8"
 
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
@@ -26,9 +29,109 @@ func isTextBaseType(ft FileType) bool {
 // UTF-16 file is misread as single-byte data.
 //
 // Input without a recognized BOM passes through unchanged, so ordinary UTF-8 is
-// untouched and a non-Unicode legacy encoding (for example Shift-JIS) keeps its
-// original bytes instead of being lossily replaced. Only call this for text
-// formats; see isTextBaseType.
+// untouched. What follows the BOM handling must still be UTF-8: a non-Unicode
+// legacy encoding (for example Shift-JIS) carries no mark to detect and would
+// otherwise be stored as bytes that are not characters, so it is rejected rather
+// than guessed at. Only call this for text formats; see isTextBaseType.
 func decodeTextReader(reader io.Reader) io.Reader {
-	return transform.NewReader(reader, unicode.BOMOverride(transform.Nop))
+	return newUTF8ValidatingReader(transform.NewReader(reader, unicode.BOMOverride(transform.Nop)))
+}
+
+// utf8ValidatingReader passes its input through unchanged and fails the read
+// that carries a byte sequence which is not UTF-8.
+//
+// SQLite stores TEXT as UTF-8. Bytes in another encoding are not rejected by the
+// engine — they are stored as given and come back as mojibake, so LENGTH counts
+// the wrong number of characters, LIKE and UPPER operate on fragments of
+// characters, and a caller that reads the column gets bytes no consumer can
+// decode. None of that reports an error, which is why validation happens at the
+// one place every text format is read through rather than at each parser.
+//
+// It validates rather than transcodes because nothing in the byte stream says
+// which encoding it is. Detection is a guess, and a wrong guess is the same
+// silent corruption in a different shape; the caller knows what it wrote and can
+// transcode before loading.
+type utf8ValidatingReader struct {
+	reader io.Reader
+	// pending holds the trailing bytes of a rune whose encoding was split across
+	// two reads. They are validated with the next chunk rather than on their own,
+	// where they would look like a truncated sequence.
+	pending []byte
+	// offset counts the bytes validated so far, so the error can say where the
+	// input stopped being UTF-8.
+	offset int64
+}
+
+// newUTF8ValidatingReader returns reader with UTF-8 validation applied to
+// everything read from it.
+func newUTF8ValidatingReader(reader io.Reader) io.Reader {
+	return &utf8ValidatingReader{reader: reader}
+}
+
+// Read reads from the underlying reader and reports an error when what it read
+// is not UTF-8. The bytes themselves are passed through untouched, so validation
+// costs a scan and never changes what a parser sees.
+func (r *utf8ValidatingReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n > 0 {
+		if invalid := r.validate(p[:n]); invalid != nil {
+			return n, invalid
+		}
+	}
+	// A rune encoding left incomplete when the input ends is invalid: there is no
+	// longer a next chunk to complete it.
+	if errors.Is(err, io.EOF) && len(r.pending) > 0 {
+		return n, fmt.Errorf("%w: incomplete character at byte offset %d", ErrInvalidUTF8, r.offset)
+	}
+	return n, err
+}
+
+// validate scans one chunk, carrying over a rune encoding that the previous
+// chunk ended in the middle of.
+func (r *utf8ValidatingReader) validate(chunk []byte) error {
+	buf := chunk
+	if len(r.pending) > 0 {
+		buf = append(r.pending, chunk...)
+	}
+
+	// A trailing incomplete rune is not an error yet, so it is held back and the
+	// rest is validated in one pass. utf8.Valid is the fast path; the byte-wise
+	// walk below runs only to say where an invalid sequence starts.
+	head, tail := splitTrailingPartialRune(buf)
+	if utf8.Valid(head) {
+		r.offset += int64(len(head))
+		r.pending = append(r.pending[:0], tail...)
+		return nil
+	}
+
+	for len(head) > 0 {
+		// DecodeRune reports (RuneError, 1) for a byte that cannot begin or
+		// continue a valid encoding. A genuine U+FFFD in the input decodes to the
+		// same rune with size 3, so the size is what separates the two.
+		char, size := utf8.DecodeRune(head)
+		if char == utf8.RuneError && size == 1 {
+			return fmt.Errorf("%w: byte 0x%02X at offset %d is not part of a valid character",
+				ErrInvalidUTF8, head[0], r.offset)
+		}
+		head = head[size:]
+		r.offset += int64(size)
+	}
+	return nil
+}
+
+// splitTrailingPartialRune divides buf into the part that can be validated now
+// and the trailing bytes that may still become a valid rune once more input
+// arrives. Only the last utf8.UTFMax-1 bytes can be such a remainder.
+func splitTrailingPartialRune(buf []byte) (head, tail []byte) {
+	for back := 1; back < utf8.UTFMax && back <= len(buf); back++ {
+		start := len(buf) - back
+		if !utf8.RuneStart(buf[start]) {
+			continue
+		}
+		if utf8.FullRune(buf[start:]) {
+			break
+		}
+		return buf[:start], buf[start:]
+	}
+	return buf, nil
 }

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,13 +1,22 @@
 package filesql
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"testing/quick"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/encoding/japanese"
 	"golang.org/x/text/encoding/unicode"
 )
 
@@ -95,6 +104,246 @@ func TestOpenHonorsUnicodeBOM(t *testing.T) {
 			var got string
 			require.NoError(t, db.QueryRowContext(context.Background(), tt.query).Scan(&got))
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestOpenRejectsInvalidUTF8 pins what happens to a text source that is not
+// valid UTF-8. SQLite stores TEXT as UTF-8, so bytes in a legacy encoding were
+// stored verbatim and came back as mojibake: the load succeeded, every string
+// function operated on bytes that are not characters, and nothing said so. A
+// caller can transcode before loading, but only if it is told.
+func TestOpenRejectsInvalidUTF8(t *testing.T) {
+	t.Parallel()
+
+	// "名前,年齢\n田中,30\n" encoded as Shift-JIS: the header bytes are invalid
+	// UTF-8, which is what a Japanese CSV exported from Excel looks like.
+	shiftJIS := func(t *testing.T, s string) []byte {
+		t.Helper()
+		out, err := japanese.ShiftJIS.NewEncoder().Bytes([]byte(s))
+		require.NoError(t, err)
+		return out
+	}
+
+	tests := []struct {
+		name    string
+		file    string
+		content []byte
+	}{
+		{
+			name:    "shift-jis CSV",
+			file:    "sjis.csv",
+			content: shiftJIS(t, "名前,年齢\n田中,30\n"),
+		},
+		{
+			name:    "shift-jis TSV",
+			file:    "sjis.tsv",
+			content: shiftJIS(t, "名前\t年齢\n田中\t30\n"),
+		},
+		{
+			name:    "shift-jis LTSV",
+			file:    "sjis.ltsv",
+			content: shiftJIS(t, "name:田中\tage:30\n"),
+		},
+		{
+			name:    "shift-jis JSONL",
+			file:    "sjis.jsonl",
+			content: shiftJIS(t, "{\"name\":\"田中\"}\n"),
+		},
+		{
+			// A lone continuation byte is invalid wherever it appears, including
+			// in the middle of an otherwise ASCII file.
+			name:    "stray continuation byte in a data row",
+			file:    "stray.csv",
+			content: []byte("name,age\nal\x80ice,30\n"),
+		},
+		{
+			// A truncated multi-byte sequence at end of file is invalid too: the
+			// validator must not accept it just because the input ran out.
+			name:    "truncated multi-byte sequence at end of file",
+			file:    "truncated.csv",
+			content: []byte("name\nalice\n\xe3\x81"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), tt.file)
+			require.NoError(t, os.WriteFile(path, tt.content, 0o600))
+
+			db, err := OpenContext(context.Background(), path)
+			if db != nil {
+				defer db.Close()
+			}
+			require.Error(t, err, "loading a non-UTF-8 source must fail rather than store mojibake")
+			assert.ErrorIs(t, err, ErrInvalidUTF8)
+			assert.Contains(t, err.Error(), "UTF-8")
+		})
+	}
+}
+
+// TestOpenAcceptsValidUTF8Beyond the ASCII range keeps the validator from
+// rejecting the multi-byte text it exists to protect, including a sequence that
+// straddles the boundary between two reads.
+func TestOpenAcceptsValidUTF8(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	b.WriteString("name,note\n")
+	// Enough rows that the content spans several read buffers, so a multi-byte
+	// rune lands across a buffer boundary somewhere in here.
+	for i := range 4000 {
+		fmt.Fprintf(&b, "名前%d,日本語のテキストと絵文字🍣\n", i)
+	}
+
+	path := filepath.Join(t.TempDir(), "utf8.csv")
+	require.NoError(t, os.WriteFile(path, []byte(b.String()), 0o600))
+
+	db, err := OpenContext(context.Background(), path)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var got string
+	require.NoError(t, db.QueryRowContext(context.Background(),
+		"SELECT note FROM utf8 WHERE name = '名前3999'").Scan(&got))
+	assert.Equal(t, "日本語のテキストと絵文字🍣", got)
+}
+
+// TestUTF8ValidatingReaderPassesThroughUnchanged is the property the validator
+// must not break: it is a filter that judges, not one that edits. For any input
+// it accepts, the bytes a parser reads are byte-for-byte the bytes it was given,
+// whatever size the reads happen to be.
+func TestUTF8ValidatingReaderPassesThroughUnchanged(t *testing.T) {
+	t.Parallel()
+
+	property := func(text string, chunk uint8) bool {
+		if !utf8.ValidString(text) {
+			return true // only accepted input has a pass-through contract
+		}
+		size := int(chunk)%7 + 1
+		got, err := io.ReadAll(newUTF8ValidatingReader(&chunkedReader{
+			data: []byte(text),
+			size: size,
+		}))
+		return err == nil && string(got) == text
+	}
+
+	if err := quick.Check(property, &quick.Config{
+		MaxCount: 500,
+		Rand:     rand.New(rand.NewSource(1)), //nolint:gosec // deterministic input generation, not security
+	}); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestUTF8ValidatingReaderVerdictIndependentOfChunking pins the property a
+// streaming validator is most likely to get wrong: a rune whose encoding is
+// split across two reads must not be judged on its first half. The verdict has
+// to match utf8.Valid over the whole input at every read size.
+func TestUTF8ValidatingReaderVerdictIndependentOfChunking(t *testing.T) {
+	t.Parallel()
+
+	inputs := [][]byte{
+		[]byte("日本語のテキストと絵文字🍣"),
+		[]byte("ascii only"),
+		{0x80},                   // lone continuation byte
+		{0xE3, 0x81},             // truncated three-byte sequence
+		{0xE3, 0x81, 0x82},       // complete three-byte sequence
+		{0xF0, 0x9F, 0x8D},       // truncated four-byte sequence
+		{0xF0, 0x9F, 0x8D, 0xA3}, // complete four-byte sequence
+		{0xEF, 0xBF, 0xBD},       // an encoded U+FFFD is valid input
+		[]byte("a\xC3\xA9b"),     // valid two-byte sequence between ASCII
+		[]byte("a\xC3b"),         // two-byte sequence cut short mid-string
+		{0xED, 0xA0, 0x80},       // surrogate half, invalid in UTF-8
+		{0xC0, 0x80},             // overlong encoding of NUL
+	}
+
+	for _, input := range inputs {
+		for size := 1; size <= len(input)+2; size++ {
+			got, err := io.ReadAll(newUTF8ValidatingReader(&chunkedReader{
+				data: input,
+				size: size,
+			}))
+			wantValid := utf8.Valid(input)
+			if wantValid != (err == nil) {
+				t.Errorf("input %x read %d bytes at a time: err = %v, want valid = %v",
+					input, size, err, wantValid)
+				continue
+			}
+			if err == nil && !bytes.Equal(got, input) {
+				t.Errorf("input %x read %d bytes at a time: got %x", input, size, got)
+			}
+			if err != nil && !errors.Is(err, ErrInvalidUTF8) {
+				t.Errorf("input %x read %d bytes at a time: err = %v, want ErrInvalidUTF8", input, size, err)
+			}
+		}
+	}
+}
+
+// chunkedReader hands out at most size bytes per Read, so a test can put a rune
+// boundary wherever it needs one.
+type chunkedReader struct {
+	data []byte
+	size int
+	pos  int
+}
+
+func (r *chunkedReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := min(min(r.size, len(p)), len(r.data)-r.pos)
+	copy(p, r.data[r.pos:r.pos+n])
+	r.pos += n
+	return n, nil
+}
+
+// TestDuplicateColumnErrorNamesTheColumn covers the message a caller acts on.
+// A header with two unnamed columns is a duplicate of the empty name, and the
+// message said so by printing nothing after the colon: "duplicate column name: ".
+// Which column, out of a header the user cannot see the parse of, was left to
+// guess.
+func TestDuplicateColumnErrorNamesTheColumn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		file    string
+		content string
+		want    []string
+	}{
+		{
+			name:    "two unnamed columns",
+			file:    "unnamed.csv",
+			content: "a,,\n1,2,3\n",
+			want:    []string{`""`, "column 3"},
+		},
+		{
+			name:    "two columns with the same name",
+			file:    "same.csv",
+			content: "a,b,a\n1,2,3\n",
+			want:    []string{`"a"`, "column 3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), tt.file)
+			require.NoError(t, os.WriteFile(path, []byte(tt.content), 0o600))
+
+			db, err := OpenContext(context.Background(), path)
+			if db != nil {
+				defer db.Close()
+			}
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrDuplicateColumn)
+			for _, want := range tt.want {
+				assert.Contains(t, err.Error(), want)
+			}
 		})
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -34,6 +34,12 @@ var (
 	// ErrDuplicateColumn indicates duplicate column names in the data source.
 	ErrDuplicateColumn = errors.New("filesql: duplicate column name")
 
+	// ErrInvalidUTF8 indicates a text source that is not valid UTF-8. SQLite
+	// stores TEXT as UTF-8, so such bytes would be stored verbatim and read back
+	// as mojibake by every consumer; the load fails instead, and the caller
+	// transcodes.
+	ErrInvalidUTF8 = errors.New("filesql: invalid UTF-8")
+
 	// ErrDuplicateTable indicates a table with the same name already exists.
 	ErrDuplicateTable = errors.New("filesql: duplicate table name")
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -845,6 +845,11 @@ func parseLTSV(reader io.Reader) (*TableData, error) {
 }
 
 // validateColumnNames checks for duplicate column names.
+//
+// The message matches github.com/nao1215/fileparser exactly: parser is a fork of
+// it and a differential test holds the two to the same errors, so the quoting and
+// position filesql adds to its own duplicate-column message are added where
+// filesql builds that message rather than here.
 func validateColumnNames(columns []string) error {
 	seen := make(map[string]bool, len(columns))
 	for _, col := range columns {

--- a/types.go
+++ b/types.go
@@ -173,12 +173,16 @@ func (ct columnType) String() string {
 
 // validateColumnNames checks for duplicate column names and returns error if found.
 // Column name comparison is case-sensitive to maintain backward compatibility.
+//
+// The message quotes the name and gives its 1-based position, because a header
+// can duplicate the empty name — two unnamed columns — and an unquoted empty
+// name printed nothing at all after the colon.
 func validateColumnNames(columns []string) error {
 	columnsSeen := make(map[string]bool)
-	for _, col := range columns {
+	for i, col := range columns {
 		trimmedCol := strings.TrimSpace(col)
 		if columnsSeen[trimmedCol] {
-			return fmt.Errorf("%w: %s", errDuplicateColumnName, col)
+			return fmt.Errorf("%w: %q (column %d)", errDuplicateColumnName, col, i+1)
 		}
 		columnsSeen[trimmedCol] = true
 	}


### PR DESCRIPTION
SQLite stores TEXT as UTF-8. Bytes in another encoding were not rejected by the engine — they were stored as given and came back as mojibake, so `LENGTH` counted the wrong number of characters, `LIKE` and `UPPER` operated on fragments of characters, and a caller reading the column got bytes no consumer can decode. None of it reported an error. A Shift-JIS CSV exported from Excel is the ordinary way to reach this.

Loading such a file now fails with `ErrInvalidUTF8`, naming the offending byte and its offset, so the caller transcodes before loading rather than discovering the damage downstream.

## Where

Validation goes in `decodeTextReader`, the one place CSV, TSV, LTSV, JSON, and JSONL are all read through on every load path, so no parser needs to know about it. The reader passes bytes through untouched and fails the read carrying an invalid sequence. A rune whose encoding straddles two reads is carried over and validated with the next chunk rather than judged on its first half, and an encoding left incomplete when the input ends is invalid. `utf8.Valid` is the fast path; the byte-wise walk runs only to report where the input stopped being UTF-8.

It validates rather than detects. Nothing in the byte stream says which encoding it is, so detection is a guess, and a wrong guess is the same silent corruption in a different shape.

UTF-16 with a byte-order mark is still transcoded as before, and valid UTF-8 passes through byte for byte.

## Also

A duplicate column name error now says which column it means. The name was printed unquoted, so a header with two unnamed columns (`a,,`) produced `duplicate column name: ` with nothing after the colon. It reads `duplicate column name: "" (column 3)` now. The `parser` package keeps the upstream `nao1215/fileparser` wording, which `TestLegacyCompatibility_ParseRepresentativeErrors` holds it to; the quoting is added where filesql builds its own message.

## Tests

Table-driven cases for Shift-JIS CSV/TSV/LTSV/JSONL, a stray continuation byte mid-file, and a sequence truncated at EOF. Two properties guard the streaming validator, which is where this kind of code goes wrong: the bytes a parser reads are byte-for-byte what it was given (`testing/quick`, fixed seed), and the verdict matches `utf8.Valid` over the whole input at every read size from 1 upward — including surrogate halves and overlong encodings, and with a rune boundary deliberately placed at each offset.

## Compatibility

Breaking for a caller that loads non-UTF-8 text, which until now received corrupt data without being told. `--encoding` in sqly already stages a transcoded copy, so that path is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid UTF-8 text sources are now rejected with a clear error identifying the offending byte and offset.
  * UTF-16 BOM transcoding remains supported, while valid UTF-8 input is preserved.
  * Duplicate-column errors now include the quoted column name and its one-based position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->