### PR TITLE
fix: check duplicate column names the same way for every format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- One rule for duplicate column names, whatever format the header arrived in. Names are compared with surrounding whitespace removed, which is what reading a CSV has always done; a workbook was the exception on both counts. The loader that reads a workbook checked nothing, so `name` beside ` name ` became two columns there and a duplicate everywhere else, while an exact duplicate reached SQLite and came back as its own "duplicate column name" wrapped in a database-operation error — an error no caller can match with `errors.Is(err, ErrDuplicateColumn)`. A workbook now fails the same check a CSV does, with the same error and the offending column named.
+
 ## [0.36.0] - 2026-08-07
 
 ### Changed

--- a/builder.go
+++ b/builder.go
@@ -955,14 +955,12 @@ func (b *DBBuilder) createTableFromXLSXSheet(ctx context.Context, db *sql.DB, ta
 		return fmt.Errorf("%w: no columns in sheet header", ErrEmptyData)
 	}
 
-	// Check for duplicate column names. The name is quoted and located so a
-	// duplicate of the empty name still says which column it was.
-	columnsSeen := make(map[string]bool)
-	for i, col := range headers {
-		if columnsSeen[col] {
-			return fmt.Errorf("%w: %q (column %d)", errDuplicateColumnName, col, i+1)
-		}
-		columnsSeen[col] = true
+	// One rule for duplicate column names, wherever the header came from. This
+	// path compared the names as they stand while every other one compared them
+	// trimmed, so " name " beside "name" was a second column when it arrived in a
+	// workbook and a duplicate when it arrived in a CSV.
+	if err := validateColumnNames(headers); err != nil {
+		return err
 	}
 
 	// Collect data rows for type inference

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xuri/excelize/v2"
 	"golang.org/x/text/encoding/japanese"
 	"golang.org/x/text/encoding/unicode"
 )
@@ -346,4 +347,104 @@ func TestDuplicateColumnErrorNamesTheColumn(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDuplicateColumnCheckIsTheSameEverywhere pins one rule for duplicate
+// column names across the formats and the loaders.
+//
+// The rule is CSV's: names are compared with surrounding whitespace removed, so
+// "name" and " name " are the same name. Reading a CSV said so and reading a
+// workbook did not, which made a header a duplicate or not depending on which
+// file it arrived in.
+func TestDuplicateColumnCheckIsTheSameEverywhere(t *testing.T) {
+	t.Parallel()
+
+	t.Run("csv rejects names that differ only by surrounding whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "dup.csv")
+		require.NoError(t, os.WriteFile(path, []byte("name, name \n1,2\n"), 0o600))
+
+		db, err := OpenContext(context.Background(), path)
+		if db != nil {
+			defer db.Close()
+		}
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrDuplicateColumn)
+	})
+
+	t.Run("xlsx rejects names that differ only by surrounding whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "book.xlsx")
+		writeXLSXHeaderFixture(t, path, []string{"name", " name "}, []string{"1", "2"})
+
+		db, err := OpenContext(context.Background(), path)
+		if db != nil {
+			defer db.Close()
+		}
+		require.Error(t, err, "a workbook header must follow the same rule a CSV header does")
+		assert.ErrorIs(t, err, ErrDuplicateColumn)
+		// The quoting is what makes this message readable: the two names differ
+		// only by the space the quotes show.
+		assert.Contains(t, err.Error(), `" name "`)
+	})
+
+	// An exact duplicate in a workbook reached SQLite, which refused it in its
+	// own words wrapped in a database-operation error. A caller matching on
+	// ErrDuplicateColumn saw a workbook fail for what looked like a different
+	// reason than a CSV failing the same way.
+	t.Run("xlsx reports an exact duplicate as a duplicate column", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "exact.xlsx")
+		writeXLSXHeaderFixture(t, path, []string{"name", "name"}, []string{"1", "2"})
+
+		db, err := OpenContext(context.Background(), path)
+		if db != nil {
+			defer db.Close()
+		}
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrDuplicateColumn)
+		assert.Contains(t, err.Error(), "column 2")
+	})
+
+	// Names that are distinct after trimming stay distinct, so the rule refuses
+	// a collision rather than every header that holds a space.
+	t.Run("xlsx keeps headers that differ by more than whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "ok.xlsx")
+		writeXLSXHeaderFixture(t, path, []string{"name", " other "}, []string{"1", "2"})
+
+		db, err := OpenContext(context.Background(), path)
+		require.NoError(t, err)
+		defer db.Close()
+
+		// A workbook becomes one table per sheet, named file_sheet.
+		var got string
+		require.NoError(t, db.QueryRowContext(context.Background(),
+			`SELECT "name" FROM ok_Sheet1`).Scan(&got))
+		assert.Equal(t, "1", got)
+	})
+}
+
+// writeXLSXHeaderFixture writes a one-sheet workbook whose first row is headers
+// and whose second row is values.
+func writeXLSXHeaderFixture(t *testing.T, path string, headers, values []string) {
+	t.Helper()
+
+	f := excelize.NewFile()
+	defer func() { _ = f.Close() }()
+	for i, header := range headers {
+		cell, err := excelize.CoordinatesToCellName(i+1, 1)
+		require.NoError(t, err)
+		require.NoError(t, f.SetCellValue("Sheet1", cell, header))
+	}
+	for i, value := range values {
+		cell, err := excelize.CoordinatesToCellName(i+1, 2)
+		require.NoError(t, err)
+		require.NoError(t, f.SetCellValue("Sheet1", cell, value))
+	}
+	require.NoError(t, f.SaveAs(path))
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -844,19 +844,24 @@ func parseLTSV(reader io.Reader) (*TableData, error) {
 	}, nil
 }
 
-// validateColumnNames checks for duplicate column names.
+// validateColumnNames checks for duplicate column names, comparing them with
+// surrounding whitespace removed: " name " beside "name" is one name twice, not
+// two columns. Every loader in filesql applies that rule, so a header cannot be
+// a duplicate in one format and a second column in another.
 //
-// The message matches github.com/nao1215/fileparser exactly: parser is a fork of
-// it and a differential test holds the two to the same errors, so the quoting and
-// position filesql adds to its own duplicate-column message are added where
-// filesql builds that message rather than here.
+// This is a deliberate difference from github.com/nao1215/fileparser, which
+// parser is a fork of and which compares the names as they stand. The message
+// still matches it exactly, because a differential test holds the two to the
+// same errors and only the comparison is meant to differ; the quoting and
+// position filesql adds are added where filesql builds its own message.
 func validateColumnNames(columns []string) error {
 	seen := make(map[string]bool, len(columns))
 	for _, col := range columns {
-		if seen[col] {
+		trimmed := strings.TrimSpace(col)
+		if seen[trimmed] {
 			return fmt.Errorf("duplicate column name: %s", col)
 		}
-		seen[col] = true
+		seen[trimmed] = true
 	}
 	return nil
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -93,6 +93,19 @@ func TestParse_CSV(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "duplicate column name")
 	})
+
+	// Surrounding whitespace does not make a second column: filesql compares
+	// header names trimmed, so this is the same duplicate as the case above. It
+	// is where this fork deliberately differs from github.com/nao1215/fileparser,
+	// which compares the names as they stand.
+	t.Run("returns error for names that differ only by surrounding whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Parse(strings.NewReader("name, name ,city\nAlice,30,Tokyo"), CSV)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate column name")
+	})
 }
 
 func TestParse_TSV(t *testing.T) {

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -683,6 +683,15 @@ func (sp *streamProcessor) streamXLSXFileToDatabase(ctx context.Context, db DBTX
 		// Convert XLSX rows to table headers and records
 		headers, records := convertXLSXRowsToTable(rows)
 
+		// A workbook header follows the same rule a CSV header does. This path
+		// checked nothing: an exact duplicate reached SQLite and came back as its
+		// "duplicate column name" wrapped in a database-operation error, which no
+		// caller can match with errors.Is, and names differing only by surrounding
+		// whitespace were two columns here and one duplicate in every other format.
+		if err := validateColumnNames(headers); err != nil {
+			return fmt.Errorf("sheet %s: %w", sheetName, err)
+		}
+
 		// Create table chunk for processing
 		columnInfo := inferColumnsInfo(headers, records)
 		chunk := &tableChunk{


### PR DESCRIPTION
Names are compared with surrounding whitespace removed — `name` and ` name ` are one name twice — which is what reading a CSV has always done. A workbook was the exception, twice over.

## What a workbook did instead

`streamXLSXFileToDatabase`, the loader `Open`/`OpenContext` actually uses for a workbook, validated the header not at all:

- an exact duplicate reached SQLite and came back as `filesql: database operation failed: failed to create table for sheet Sheet1: SQL logic error: duplicate column name: name (1)` — the engine's words, in an error class `errors.Is(err, ErrDuplicateColumn)` cannot match, naming no column position
- names differing only by surrounding whitespace collided with nothing, so they became two columns in a workbook and one duplicate in a CSV

Both now fail the shared check, with `ErrDuplicateColumn` and the offending column quoted and located.

## The other two copies

`parser` compares trimmed as well, so the `frame` and `prep` subpackages follow the same rule for CSV and XLSX alike. That is a deliberate divergence from `github.com/nao1215/fileparser`, which `parser` is a fork of: the message still matches upstream exactly, which is what `TestLegacyCompatibility_ParseRepresentativeErrors` holds the two to, and only the comparison differs. Stated in a parser test rather than left for a reader to find.

`builder.go`'s `createTableFromXLSXSheet` reuses the shared validator instead of repeating the loop a third time.

## A finding this turned up, not fixed here

`builder.go`'s `streamXLSXFileToSQLite` is a second full XLSX loader that no production path reaches — only its own tests do; the streaming processor took that job. A parallel implementation only tests exercise is how these two rules drifted apart, so it is worth removing, but that is a separate change with its own tests to retire.

## Tests

`TestDuplicateColumnCheckIsTheSameEverywhere` covers the rule from both sides: a CSV and a workbook rejecting whitespace-variant duplicates, a workbook reporting an exact duplicate as `ErrDuplicateColumn` with its position, and a workbook whose headers differ by more than whitespace still loading. The parser test records the intentional difference from upstream.

Verified against sqly with a local `replace`: its unit tests and all 980 e2e scenarios pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workbook and CSV imports now consistently trim surrounding whitespace from column headers.
  * Duplicate column names—including names that differ only by whitespace—are rejected with a clear validation error identifying the conflicting column.
  * Invalid workbook headers are reported during sheet processing instead of causing database-level errors.
  * Distinct, properly trimmed column names continue to import successfully.

* **Documentation**
  * Added an unreleased changelog entry describing the updated duplicate-column validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->