### PR TITLE
chore: release v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+## [0.37.0] - 2026-08-07
+
+### Changed
 
 - One rule for duplicate column names, whatever format the header arrived in. Names are compared with surrounding whitespace removed, which is what reading a CSV has always done; a workbook was the exception on both counts. The loader that reads a workbook checked nothing, so `name` beside ` name ` became two columns there and a duplicate everywhere else, while an exact duplicate reached SQLite and came back as its own "duplicate column name" wrapped in a database-operation error — an error no caller can match with `errors.Is(err, ErrDuplicateColumn)`. A workbook now fails the same check a CSV does, with the same error and the offending column named.
 


### PR DESCRIPTION
Cuts v0.37.0.

Minor rather than patch: a workbook whose headers differ only by surrounding whitespace no longer loads. It loaded before, as two columns, while the same header in a CSV was refused as a duplicate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the 0.37.0 release entry dated August 7, 2026.
  * Documented the duplicate-column-name workbook update under “Changed.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->