### PR TITLE
fix(dialect): answer STRING_AGG(DISTINCT x, s) at translate time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `STRING_AGG(DISTINCT x, s)` is answered at translate time in the PostgreSQL and GoogleSQL dialects instead of reaching SQLite. Both dialects accept the form and SQLite cannot express it, because its DISTINCT aggregates take exactly one argument and the separator has nowhere to go. The call used to reach the engine and fail with "DISTINCT aggregates must have exactly one argument", which describes SQLite's parser rather than the query the caller wrote, so the construct was neither translated, rejected, nor runnable. A separator of `','` is now dropped, since that is already what `group_concat` joins with and the answer is unchanged; any other separator is refused by name, the way MySQL's `GROUP_CONCAT(DISTINCT x SEPARATOR s)` already was.
+
 ## [0.37.1] - 2026-08-07
 
 ### Removed

--- a/dialect/aggregate.go
+++ b/dialect/aggregate.go
@@ -163,6 +163,10 @@ const sqliteDefaultSeparator = ","
 // Joining with a comma regardless would answer a question nobody asked, which is
 // the one thing a translation must not do.
 //
+// A trailing ORDER BY belongs to the aggregate rather than to the separator, and
+// SQLite accepts it inside group_concat, so it is carried over rather than read
+// as part of the separator and refused.
+//
 // It reports false for a call it does not handle — no DISTINCT, or no separator —
 // leaving the caller's own rewrite to run.
 func rewriteStringAggDistinct(tokens []token, open, closeIdx int, recurse callRecurser) ([]token, bool, error) {
@@ -175,7 +179,15 @@ func rewriteStringAggDistinct(tokens []token, open, closeIdx int, recurse callRe
 		return nil, false, nil
 	}
 
-	separator := trimSpaceTokens(tokens[comma+1 : closeIdx])
+	// The separator ends where the aggregate's own ORDER BY begins, when there is
+	// one. Everything to the end of the call is the separator otherwise.
+	separatorEnd := closeIdx
+	orderBy := topLevelWord(tokens, open, closeIdx, "ORDER")
+	if orderBy > comma {
+		separatorEnd = orderBy
+	}
+
+	separator := trimSpaceTokens(tokens[comma+1 : separatorEnd])
 	if len(separator) != 1 || separator[0].kind != tokString || separator[0].text != sqliteDefaultSeparator {
 		return nil, false, fmt.Errorf(
 			"%w: STRING_AGG cannot combine DISTINCT with a separator other than ',' on the SQLite backend; drop DISTINCT, or use ','",
@@ -188,6 +200,14 @@ func rewriteStringAggDistinct(tokens []token, open, closeIdx int, recurse callRe
 	}
 	repl := []token{wordToken("group_concat"), opToken("("), wordToken("DISTINCT"), spaceToken()}
 	repl = append(repl, trimSpaceTokens(value)...)
+	if separatorEnd != closeIdx {
+		order, err := recurse(tokens[orderBy:closeIdx])
+		if err != nil {
+			return nil, false, err
+		}
+		repl = append(repl, spaceToken())
+		repl = append(repl, trimSpaceTokens(order)...)
+	}
 	return append(repl, opToken(")")), true, nil
 }
 

--- a/dialect/aggregate.go
+++ b/dialect/aggregate.go
@@ -143,6 +143,54 @@ func applyAggregateRule(rule aggregateRule, arg []token) ([]token, error) {
 	}
 }
 
+// sqliteDefaultSeparator is what SQLite joins with when group_concat is given no
+// separator, which is what makes dropping an explicit "," a translation rather
+// than a change of answer.
+const sqliteDefaultSeparator = ","
+
+// rewriteStringAggDistinct rewrites STRING_AGG(DISTINCT x, s), which PostgreSQL
+// and GoogleSQL both accept and SQLite cannot express as written: its DISTINCT
+// aggregates take exactly one argument, so the separator has nowhere to go.
+//
+// Left alone the call reached the engine and failed with "DISTINCT aggregates
+// must have exactly one argument", which describes SQLite's parser rather than
+// the query the caller wrote — and STRING_AGG was neither translated, rejected,
+// nor runnable, so it belonged to none of the three classes the dialect contract
+// defines.
+//
+// A separator of "," is dropped, because that is already what group_concat joins
+// with, so the answer is unchanged. Any other separator is refused by name.
+// Joining with a comma regardless would answer a question nobody asked, which is
+// the one thing a translation must not do.
+//
+// It reports false for a call it does not handle — no DISTINCT, or no separator —
+// leaving the caller's own rewrite to run.
+func rewriteStringAggDistinct(tokens []token, open, closeIdx int, recurse callRecurser) ([]token, bool, error) {
+	distinct := nextSig(tokens, open+1)
+	if distinct < 0 || !isWordEq(tokens[distinct], "DISTINCT") {
+		return nil, false, nil
+	}
+	comma := topLevelComma(tokens, open, closeIdx)
+	if comma < 0 {
+		return nil, false, nil
+	}
+
+	separator := trimSpaceTokens(tokens[comma+1 : closeIdx])
+	if len(separator) != 1 || separator[0].kind != tokString || separator[0].text != sqliteDefaultSeparator {
+		return nil, false, fmt.Errorf(
+			"%w: STRING_AGG cannot combine DISTINCT with a separator other than ',' on the SQLite backend; drop DISTINCT, or use ','",
+			ErrUnsupportedSyntax)
+	}
+
+	value, err := recurse(tokens[distinct+1 : comma])
+	if err != nil {
+		return nil, false, err
+	}
+	repl := []token{wordToken("group_concat"), opToken("("), wordToken("DISTINCT"), spaceToken()}
+	repl = append(repl, trimSpaceTokens(value)...)
+	return append(repl, opToken(")")), true, nil
+}
+
 // varianceExpr builds the variance of expr from the sums SQLite does have. The
 // 1.0 factors keep the arithmetic in floating point, and dividing by the
 // (COUNT - 1) of a single row yields NULL, which is what the source dialects

--- a/dialect/googlesql.go
+++ b/dialect/googlesql.go
@@ -26,6 +26,7 @@ import (
 //	G-15 COUNTIF / LOGICAL_AND / STDDEV       -> SQLite aggregate expressions
 //	G-16 UNION DISTINCT                       -> UNION
 //	G-17 JSON_VALUE / BYTE_LENGTH / CHAR_LENGTH
+//	G-18 STRING_AGG(DISTINCT x, ',')           -> group_concat(DISTINCT x)
 func rewriteGoogleSQL(tokens []token) ([]token, error) {
 	if err := checkUnsupportedGoogleSQL(tokens); err != nil {
 		return nil, err
@@ -144,6 +145,10 @@ func googlesqlRewriteCall(tokens []token, nameIdx, open, closeIdx int) ([]token,
 		return rewriteRenameCall(tokens, open, closeIdx, "length", googlesqlCallPass)
 	case "DATE_TRUNC", "TIMESTAMP_TRUNC", "DATETIME_TRUNC":
 		return rewriteTruncCall(tokens, open, closeIdx, googlesqlCallPass)
+	case fnNameStringAgg:
+		// SQLite has string_agg as an alias of group_concat, so the plain form
+		// runs as written and only the DISTINCT one needs rewriting.
+		return rewriteStringAggDistinct(tokens, open, closeIdx, googlesqlCallPass)
 	default:
 		return nil, false, nil
 	}

--- a/dialect/googlesql_test.go
+++ b/dialect/googlesql_test.go
@@ -37,6 +37,9 @@ func TestGoogleSQLTranslate(t *testing.T) {
 		{"G-18_string_agg", "SELECT STRING_AGG(name, ', ') FROM t", "SELECT STRING_AGG(name, ', ') FROM t"},
 		{"G-18_string_agg_distinct_comma", "SELECT STRING_AGG(DISTINCT name, ',') FROM t", "SELECT group_concat(DISTINCT name) AS \"STRING_AGG(DISTINCT name, ',')\" FROM t"},
 		{"G-18_string_agg_distinct_expression", "SELECT STRING_AGG(DISTINCT UPPER(name), ',') FROM t", "SELECT group_concat(DISTINCT UPPER(name)) AS \"STRING_AGG(DISTINCT UPPER(name), ',')\" FROM t"},
+		// An ORDER BY belongs to the aggregate, not to the separator, and SQLite
+		// takes it inside group_concat.
+		{"G-18_string_agg_distinct_order_by", "SELECT STRING_AGG(DISTINCT name, ',' ORDER BY name) FROM t", "SELECT group_concat(DISTINCT name ORDER BY name) AS \"STRING_AGG(DISTINCT name, ',' ORDER BY name)\" FROM t"},
 
 		{"G-7_date_add", "SELECT DATE_ADD(d, INTERVAL 3 DAY)", "SELECT interval_add(d, 3, 'day') AS \"DATE_ADD(d, INTERVAL 3 DAY)\""},
 		{"G-7_timestamp_sub", "SELECT TIMESTAMP_SUB(ts, INTERVAL 2 HOUR)", "SELECT interval_add(ts, -(2), 'hour') AS \"TIMESTAMP_SUB(ts, INTERVAL 2 HOUR)\""},

--- a/dialect/googlesql_test.go
+++ b/dialect/googlesql_test.go
@@ -32,6 +32,12 @@ func TestGoogleSQLTranslate(t *testing.T) {
 
 		{"G-6_format", "SELECT FORMAT('%d', n) FROM t", "SELECT printf('%d', n) AS \"FORMAT('%d', n)\" FROM t"},
 
+		// SQLite's DISTINCT aggregates take one argument, so the separator has to
+		// go. Dropping it is only correct when it is the comma SQLite defaults to.
+		{"G-18_string_agg", "SELECT STRING_AGG(name, ', ') FROM t", "SELECT STRING_AGG(name, ', ') FROM t"},
+		{"G-18_string_agg_distinct_comma", "SELECT STRING_AGG(DISTINCT name, ',') FROM t", "SELECT group_concat(DISTINCT name) AS \"STRING_AGG(DISTINCT name, ',')\" FROM t"},
+		{"G-18_string_agg_distinct_expression", "SELECT STRING_AGG(DISTINCT UPPER(name), ',') FROM t", "SELECT group_concat(DISTINCT UPPER(name)) AS \"STRING_AGG(DISTINCT UPPER(name), ',')\" FROM t"},
+
 		{"G-7_date_add", "SELECT DATE_ADD(d, INTERVAL 3 DAY)", "SELECT interval_add(d, 3, 'day') AS \"DATE_ADD(d, INTERVAL 3 DAY)\""},
 		{"G-7_timestamp_sub", "SELECT TIMESTAMP_SUB(ts, INTERVAL 2 HOUR)", "SELECT interval_add(ts, -(2), 'hour') AS \"TIMESTAMP_SUB(ts, INTERVAL 2 HOUR)\""},
 
@@ -71,6 +77,10 @@ func TestGoogleSQLTranslateUnsupported(t *testing.T) {
 		{"G-9_struct_type", "SELECT STRUCT<a INT64>(1)"},
 		{"G-9_except", "SELECT * EXCEPT(col) FROM t"},
 		{"G-9_replace", "SELECT * REPLACE(a AS b) FROM t"},
+		// A separator SQLite cannot keep alongside DISTINCT. Answering with a
+		// comma-joined string would be a different answer, not a translation.
+		{"G-18_string_agg_distinct_other_separator", "SELECT STRING_AGG(DISTINCT name, '-') FROM t"},
+		{"G-18_string_agg_distinct_separator_expression", "SELECT STRING_AGG(DISTINCT name, sep) FROM t"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dialect/postgresql.go
+++ b/dialect/postgresql.go
@@ -15,7 +15,8 @@ import (
 //	P-3  x ~ p / !~ / ~* / !~*     -> x REGEXP p / NOT REGEXP / case-insensitive
 //	P-4  POSITION(x IN y)          -> INSTR(y, x)
 //	P-5  SUBSTRING(x FROM n FOR m) -> SUBSTR(x, n, m)
-//	P-6  STRING_AGG(x, s)          -> group_concat(x, s)
+//	P-6  STRING_AGG(x, s)          -> group_concat(x, s), and the DISTINCT form
+//	                                  -> group_concat(DISTINCT x) for s = ','
 //	P-8  CAST(x AS pg_type)        -> postgresql_cast(x, 'pg_type')
 //	P-10 DISTINCT ON (...), LATERAL -> ErrUnsupportedSyntax
 //	P-11 a ^ b                     -> power(a, b)
@@ -152,6 +153,10 @@ func pgRewriteCall(tokens []token, nameIdx, open, closeIdx int) ([]token, bool, 
 		return rewriteRenameCall(tokens, open, closeIdx, "length", pgCallPass)
 	case fnNameCast:
 		return rewriteCastCall(tokens, open, closeIdx, PostgreSQL, "postgresql_cast", pgCallPass)
+	case fnNameStringAgg:
+		// Only the DISTINCT form is handled here; the plain one is renamed by the
+		// word pass below, which keeps the separator SQLite accepts there.
+		return rewriteStringAggDistinct(tokens, open, closeIdx, pgCallPass)
 	default:
 		return nil, false, nil
 	}

--- a/dialect/postgresql_test.go
+++ b/dialect/postgresql_test.go
@@ -44,6 +44,10 @@ func TestPostgreSQLTranslate(t *testing.T) {
 		{"P-6_string_agg_distinct_comma", "SELECT STRING_AGG(DISTINCT name, ',') FROM t", "SELECT group_concat(DISTINCT name) AS \"STRING_AGG(DISTINCT name, ',')\" FROM t"},
 		{"P-6_string_agg_distinct_comma_spaced", "SELECT STRING_AGG( DISTINCT name , ',' ) FROM t", "SELECT group_concat(DISTINCT name) AS \"STRING_AGG( DISTINCT name , ',' )\" FROM t"},
 		{"P-6_string_agg_distinct_expression", "SELECT STRING_AGG(DISTINCT UPPER(name), ',') FROM t", "SELECT group_concat(DISTINCT UPPER(name)) AS \"STRING_AGG(DISTINCT UPPER(name), ',')\" FROM t"},
+		// An ORDER BY belongs to the aggregate, not to the separator, and SQLite
+		// takes it inside group_concat.
+		{"P-6_string_agg_distinct_order_by", "SELECT STRING_AGG(DISTINCT name, ',' ORDER BY name) FROM t", "SELECT group_concat(DISTINCT name ORDER BY name) AS \"STRING_AGG(DISTINCT name, ',' ORDER BY name)\" FROM t"},
+		{"P-6_string_agg_distinct_order_by_desc", "SELECT STRING_AGG(DISTINCT name, ',' ORDER BY name DESC) FROM t", "SELECT group_concat(DISTINCT name ORDER BY name DESC) AS \"STRING_AGG(DISTINCT name, ',' ORDER BY name DESC)\" FROM t"},
 
 		{"P-8_cast_int4", "SELECT CAST(x AS int4) FROM t", "SELECT postgresql_cast(x, 'int4') AS \"CAST(x AS int4)\" FROM t"},
 		{"P-8_cast_boolean", "SELECT CAST(x AS boolean)", "SELECT postgresql_cast(x, 'boolean') AS \"CAST(x AS boolean)\""},

--- a/dialect/postgresql_test.go
+++ b/dialect/postgresql_test.go
@@ -39,6 +39,11 @@ func TestPostgreSQLTranslate(t *testing.T) {
 		{"P-5_substring_comma_passthrough", "SELECT SUBSTRING(name, 2, 3) FROM t", "SELECT SUBSTRING(name, 2, 3) FROM t"},
 
 		{"P-6_string_agg", "SELECT STRING_AGG(name, ', ') FROM t", "SELECT group_concat(name, ', ') AS \"STRING_AGG(name, ', ')\" FROM t"},
+		// SQLite's DISTINCT aggregates take one argument, so the separator has to
+		// go. Dropping it is only correct when it is the comma SQLite defaults to.
+		{"P-6_string_agg_distinct_comma", "SELECT STRING_AGG(DISTINCT name, ',') FROM t", "SELECT group_concat(DISTINCT name) AS \"STRING_AGG(DISTINCT name, ',')\" FROM t"},
+		{"P-6_string_agg_distinct_comma_spaced", "SELECT STRING_AGG( DISTINCT name , ',' ) FROM t", "SELECT group_concat(DISTINCT name) AS \"STRING_AGG( DISTINCT name , ',' )\" FROM t"},
+		{"P-6_string_agg_distinct_expression", "SELECT STRING_AGG(DISTINCT UPPER(name), ',') FROM t", "SELECT group_concat(DISTINCT UPPER(name)) AS \"STRING_AGG(DISTINCT UPPER(name), ',')\" FROM t"},
 
 		{"P-8_cast_int4", "SELECT CAST(x AS int4) FROM t", "SELECT postgresql_cast(x, 'int4') AS \"CAST(x AS int4)\" FROM t"},
 		{"P-8_cast_boolean", "SELECT CAST(x AS boolean)", "SELECT postgresql_cast(x, 'boolean') AS \"CAST(x AS boolean)\""},
@@ -76,6 +81,10 @@ func TestPostgreSQLTranslateUnsupported(t *testing.T) {
 		{"P-10_distinct_on", "SELECT DISTINCT ON (a) a, b FROM t"},
 		{"P-10_lateral", "SELECT * FROM t, LATERAL (SELECT 1) s"},
 		{"P-3_ci_non_literal", "SELECT * FROM t WHERE a ~* b"},
+		// A separator SQLite cannot keep alongside DISTINCT. Answering with a
+		// comma-joined string would be a different answer, not a translation.
+		{"P-6_string_agg_distinct_other_separator", "SELECT STRING_AGG(DISTINCT name, '-') FROM t"},
+		{"P-6_string_agg_distinct_separator_expression", "SELECT STRING_AGG(DISTINCT name, sep) FROM t"},
 		{"P-1_missing_type", "SELECT a::"},
 		{"P-1_type_not_word", "SELECT a:: , b"},
 	}

--- a/dialect/rewrite.go
+++ b/dialect/rewrite.go
@@ -14,11 +14,12 @@ import (
 
 // Function-name keywords recognized by more than one dialect's call pass.
 const (
-	fnNameCast     = "CAST"
-	fnNameExtract  = "EXTRACT"
-	fnNameTrim     = "TRIM"
-	fnNameCharLen  = "CHAR_LENGTH"
-	fnNameCharLen2 = "CHARACTER_LENGTH"
+	fnNameCast      = "CAST"
+	fnNameExtract   = "EXTRACT"
+	fnNameTrim      = "TRIM"
+	fnNameCharLen   = "CHAR_LENGTH"
+	fnNameCharLen2  = "CHARACTER_LENGTH"
+	fnNameStringAgg = "STRING_AGG"
 )
 
 // callRecurser rewrites a slice of argument tokens with a dialect's call pass so

--- a/dialect_bridge_test.go
+++ b/dialect_bridge_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql/driver"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/nao1215/filesql/dialect"
@@ -103,6 +104,55 @@ func TestOpenWithDialectGoogleSQL(t *testing.T) {
 	}
 	if half != 15 {
 		t.Fatalf("SAFE_DIVIDE = %v, want 15", half)
+	}
+}
+
+// TestStringAggDistinctExecutes is the execution half of the STRING_AGG(DISTINCT)
+// rewrite. The translated text alone proves nothing here: the whole point is that
+// the old translation reached SQLite and failed there, so the check that matters
+// is that the query now returns a row.
+func TestStringAggDistinctExecutes(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name    string
+		dialect dialect.Dialect
+		query   string
+	}{
+		{
+			name:    "postgresql",
+			dialect: dialect.PostgreSQL,
+			query:   "SELECT STRING_AGG(DISTINCT name, ',') AS names FROM sample",
+		},
+		{
+			name:    "googlesql",
+			dialect: dialect.GoogleSQL,
+			query:   "SELECT STRING_AGG(DISTINCT name, ',') AS names FROM sample",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(tt.dialect).Build(ctx)
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			db, err := builder.Open(ctx)
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			defer db.Close()
+
+			var names string
+			if err := db.QueryRowContext(ctx, tt.query).Scan(&names); err != nil {
+				t.Fatalf("query: %v", err)
+			}
+			// group_concat's default separator is the comma the query asked for,
+			// which is what makes dropping the argument a translation.
+			if !strings.Contains(names, ",") {
+				t.Errorf("names = %q, want the values joined by a comma", names)
+			}
+		})
 	}
 }
 

--- a/dialect_bridge_test.go
+++ b/dialect_bridge_test.go
@@ -129,6 +129,11 @@ func TestStringAggDistinctExecutes(t *testing.T) {
 			dialect: dialect.GoogleSQL,
 			query:   "SELECT STRING_AGG(DISTINCT name, ',') AS names FROM sample",
 		},
+		{
+			name:    "postgresql_ordered",
+			dialect: dialect.PostgreSQL,
+			query:   "SELECT STRING_AGG(DISTINCT name, ',' ORDER BY name) AS names FROM sample",
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
PostgreSQL and GoogleSQL both accept `STRING_AGG(DISTINCT x, s)` and SQLite cannot express it: its DISTINCT aggregates take exactly one argument, so the separator has nowhere to go. The call reached the engine and failed with `DISTINCT aggregates must have exactly one argument`, which describes SQLite's parser rather than the query the caller wrote. STRING_AGG was therefore neither translated, rejected, nor runnable, so it belonged to none of the three classes the dialect contract defines.

A separator of `','` is now dropped, because that is already what `group_concat` joins with, so the answer is unchanged. Any other separator is refused by name at translate time, the way MySQL's `GROUP_CONCAT(DISTINCT x SEPARATOR s)` already was. Joining with a comma regardless would answer a question nobody asked, which is the one thing a translation must not do.

The rewrite lives in `aggregate.go` and is shared by both dialects, so they cannot drift apart on it. PostgreSQL reaches it from its call pass before the existing word rename, which still handles the plain form; GoogleSQL reaches it from its own call pass, where the plain form passes through to SQLite's native `string_agg` alias.

Tests cover the translated text for both dialects (bare column, expression argument, spaced spelling), the named rejection for a non-comma separator and for a separator that is not a literal, and the execution half in `dialect_bridge_test.go` — the old translation's whole problem was that it only failed once SQLite saw it, so a text-level assertion alone would not have caught it.

Closes #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PostgreSQL and GoogleSQL support for translating `STRING_AGG(DISTINCT value, ',')` into SQLite-compatible aggregation.
  * Comma-separated distinct values now execute correctly across supported dialects.

* **Bug Fixes**
  * Unsupported custom separators are now rejected clearly instead of producing invalid translations.

* **Documentation**
  * Updated the unreleased changelog with the new translation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->