### PR TITLE
fix(ach): rebuild batch controls on write so an edited amount is writable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- ACH write-back rebuilds each batch control from the entries, so an edited amount can be written at all. `File.Create` builds the file control from the batch controls and leaves the batch controls alone — that is `Batch.Create`'s job — so each batch kept the control the original file arrived with, and every amount edit failed the write with "TotalDebitEntryDollarAmount calculated N is out-of-balance with batch control M". Editing the control column instead did not help, because the recalculation it was waiting for never ran. Control records are derived values: the write recalculates them, for IAT batches too, and an edit to a control column is overwritten rather than honored.
+
 ## [0.37.1] - 2026-08-07
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ for _, sheet := range sheets {
 
 ACH (`.ach`) and Fedwire (`.fed`) support are experimental. They are useful for inspection, joins, and controlled updates, but the exported files still need domain knowledge from the caller.
 
+Control records are derived, not stored: writing an ACH file rebuilds each batch control and the file control from the entries, so an edited amount is balanced by the write rather than by the caller. An edit to a control column (`total_debit`, `total_credit`, `entry_hash`, `entry_addenda_count`) is therefore overwritten by the recalculation.
+
 ## Examples
 
 ### API example index

--- a/ach_test.go
+++ b/ach_test.go
@@ -220,6 +220,52 @@ func TestOpenACHFile_UpdateAndWrite(t *testing.T) {
 	assert.Equal(t, "Updated Name", name, "name should be updated")
 }
 
+// TestOpenACHFile_UpdateAmountAndWrite covers the edit the test above steps
+// around. An amount is what a batch control totals, so changing one is the case
+// that decides whether write-back recalculates the controls or writes the file
+// with the totals it was read with. It used to be the latter, and every amount
+// edit failed to write as out-of-balance, which left no way to change an amount
+// at all.
+func TestOpenACHFile_UpdateAmountAndWrite(t *testing.T) {
+	testFile := findTestACHFile(t)
+	if testFile == "" {
+		t.Skip("No test ACH file found")
+	}
+
+	ctx := context.Background()
+	db, err := OpenContext(ctx, testFile)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var before int
+	require.NoError(t, db.QueryRowContext(ctx,
+		"SELECT amount FROM ppd_debit_entries WHERE entry_index = 0").Scan(&before))
+
+	after := before + 1
+	_, err = db.ExecContext(ctx,
+		"UPDATE ppd_debit_entries SET amount = ? WHERE entry_index = 0", after)
+	require.NoError(t, err)
+
+	tmpFile := filepath.Join(t.TempDir(), "output.ach")
+	require.NoError(t, DumpACH(ctx, db, "ppd_debit", tmpFile))
+
+	// Re-opening runs the reader's own balance check, so a file that opens is a
+	// file whose controls agree with its entries.
+	db2, err := OpenContext(ctx, tmpFile)
+	require.NoError(t, err)
+	defer db2.Close()
+
+	var got int
+	require.NoError(t, db2.QueryRowContext(ctx,
+		"SELECT amount FROM output_entries WHERE entry_index = 0").Scan(&got))
+	assert.Equal(t, after, got, "the edited amount should survive the write")
+
+	var totalDebit int
+	require.NoError(t, db2.QueryRowContext(ctx,
+		"SELECT total_debit FROM output_batches WHERE batch_index = 0").Scan(&totalDebit))
+	assert.Equal(t, after, totalDebit, "the batch control should follow the entries")
+}
+
 func TestOpenACHFile_IATFile(t *testing.T) {
 	testFile := findACHTestFile(t, "iat-credit.ach")
 	if testFile == "" {

--- a/parser/ach/convert.go
+++ b/parser/ach/convert.go
@@ -660,7 +660,25 @@ func (ts *TableSet) ToFile() (*ach.File, error) {
 		}
 	}
 
-	// Recalculate control records
+	// Recalculate control records. Each batch first, then the file.
+	//
+	// File.Create builds the file control from the batch controls and does not
+	// touch the batch controls themselves — that is Batch.Create's job. Without
+	// this loop each batch kept the control the deep copy carried over from the
+	// original file, so an edited entry amount was checked against the total the
+	// source was written with and every write failed as out-of-balance. The
+	// controls are derived values, so recalculating them is what makes an edit
+	// writable at all.
+	for i, batch := range newFile.Batches {
+		if err := batch.Create(); err != nil {
+			return nil, fmt.Errorf("failed to create batch control for batch %d: %w", i+1, err)
+		}
+	}
+	for i := range newFile.IATBatches {
+		if err := newFile.IATBatches[i].Create(); err != nil {
+			return nil, fmt.Errorf("failed to create IAT batch control for batch %d: %w", i+1, err)
+		}
+	}
 	if err := newFile.Create(); err != nil {
 		return nil, fmt.Errorf("failed to create file control: %w", err)
 	}

--- a/parser/ach/convert_test.go
+++ b/parser/ach/convert_test.go
@@ -142,6 +142,68 @@ func TestToFile_ModifyAmount(t *testing.T) {
 	assert.Equal(t, 50000000, entries[0].Amount)
 }
 
+// TestToFile_ModifiedAmountIsWritable is the half TestToFile_ModifyAmount above
+// does not reach. That test reads the amount back off the returned file, which
+// the deep copy already carried; the writer is where the batch control is
+// checked against the entries, and it was still the control the original file
+// arrived with. Every amount edit was therefore unwritable: the value changed,
+// the control did not, and the write failed as out-of-balance.
+func TestToFile_ModifiedAmountIsWritable(t *testing.T) {
+	original := createTestACHFile(t)
+	ts := FromFile(original)
+	require.NotNil(t, ts)
+
+	amountIdx := findHeaderIndex(t, ts.Entries.Headers, "amount")
+
+	const newAmount = 50000000
+	ts.Entries.Records[0][amountIdx] = strconv.Itoa(newAmount)
+
+	var buf bytes.Buffer
+	require.NoError(t, ts.WriteToWriter(&buf))
+
+	// Re-parsing is what proves the file is valid ACH rather than merely bytes:
+	// the reader runs the same balance check the writer does.
+	reparsed, err := ParseReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+
+	entries := reparsed.originalFile.Batches[0].GetEntries()
+	require.Len(t, entries, 1)
+	assert.Equal(t, newAmount, entries[0].Amount)
+
+	// The controls are derived from the entries, so they follow the edit rather
+	// than keeping the value the source file was written with.
+	control := reparsed.originalFile.Batches[0].GetControl()
+	require.NotNil(t, control)
+	assert.Equal(t, newAmount, control.TotalDebitEntryDollarAmount)
+	assert.Equal(t, newAmount, reparsed.originalFile.Control.TotalDebitEntryDollarAmountInFile)
+}
+
+// TestToFile_ModifiedIATAmountIsWritable is the IAT half of the recalculation.
+// IAT batches carry their own control record and are rebuilt by IATBatch.Create,
+// which File.Create does not call either, so they had the same defect.
+func TestToFile_ModifiedIATAmountIsWritable(t *testing.T) {
+	file, err := ach.ReadFile(findTestFile(t, "iat-credit.ach"))
+	require.NoError(t, err)
+
+	ts := FromFile(file)
+	require.NotNil(t, ts)
+	require.NotNil(t, ts.IATEntries)
+	require.NotEmpty(t, ts.IATEntries.Records)
+
+	amountIdx := findHeaderIndex(t, ts.IATEntries.Headers, "amount")
+	const newAmount = 50000
+	ts.IATEntries.Records[0][amountIdx] = strconv.Itoa(newAmount)
+
+	var buf bytes.Buffer
+	require.NoError(t, ts.WriteToWriter(&buf))
+
+	reparsed, err := ParseReader(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	entries := reparsed.originalFile.IATBatches[0].GetEntries()
+	require.NotEmpty(t, entries)
+	assert.Equal(t, newAmount, entries[0].Amount)
+}
+
 func TestToFile_RejectsNegativeBatchIndexInBatches(t *testing.T) {
 	file := createTestACHFile(t)
 	ts := FromFile(file)


### PR DESCRIPTION
Editing an ACH entry amount and writing the file back always failed. `TableSet.ToFile` documents that "the file's control records are automatically recalculated", and it called `File.Create` to do it — but `File.Create` builds the file control from the batch controls and leaves the batch controls alone, which is `Batch.Create`'s job. Each batch therefore kept the control the deep copy carried over from the original file, so the writer compared the recalculated entry total against the total the source was written with and refused every edit as out-of-balance.

Editing the control column instead did not help. Those edits are read into the TableSet and then overwritten by nothing, because the recalculation they were waiting for never ran, so the imbalance was unreachable from either side and there was no way to change an amount at all. The capability is advertised — sqly's `.save` writes ACH files back — so this was a dead end in a documented feature (nao1215/sqly#879 hit it from that direction).

Each batch, and each IAT batch, is now rebuilt before the file control is. Control records are derived values: the write recalculates them, and an edit to a control column is overwritten rather than honored. The README's ACH section says so.

The existing `TestToFile_ModifyAmount` passed throughout, because it reads the amount back off the returned file, which the deep copy already carried — the writer is where the check lives. The tests added here write the file and re-parse it at both levels: `parser/ach` for the PPD and IAT paths, and the public `DumpACH` path in `ach_test.go`, which is the one sqly reaches. The latter is the case `TestOpenACHFile_UpdateAndWrite` explicitly stepped around, with the comment "doesn't affect batch control totals".

Closes #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ACH files now automatically recalculate batch and file control totals when written, including IAT batches.
  * Updated entry amounts are reflected in the resulting control totals.

* **Bug Fixes**
  * Prevented outdated or manually edited control values from being retained during ACH file generation.

* **Documentation**
  * Clarified that ACH and Fedwire control records are derived during writing and may be overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->