### PR TITLE
feat(save): write csv, tsv, and ltsv output in a chosen text encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `DumpOptions.WithEncoding` writes csv, tsv, and ltsv output in Shift-JIS, EUC-JP, ISO-2022-JP, or UTF-16 as well as UTF-8. The read side has understood these encodings for a long time and the write side had no matching option, so a caller that decoded a legacy source before loading had no way to get one back: every save wrote UTF-8, which meant an in-place save silently changed the file's encoding on disk and the caller's next read of the same file returned mojibake. Output is UTF-8 unless the option says otherwise, and the UTF-16 encodings write a byte-order mark so the read side recognizes them without being told. A value the encoding cannot write fails the save with `ErrEncoding` and leaves the destination untouched, rather than being replaced with a substitute character. Parquet and XLSX carry their own encoding and are unaffected.
+
 ### Fixed
 
 - `STRING_AGG(DISTINCT x, s)` is answered at translate time in the PostgreSQL and GoogleSQL dialects instead of reaching SQLite. Both dialects accept the form and SQLite cannot express it, because its DISTINCT aggregates take exactly one argument and the separator has nowhere to go. The call used to reach the engine and fail with "DISTINCT aggregates must have exactly one argument", which describes SQLite's parser rather than the query the caller wrote, so the construct was neither translated, rejected, nor runnable. A separator of `','` is now dropped, since that is already what `group_concat` joins with and the answer is unchanged; any other separator is refused by name, the way MySQL's `GROUP_CONCAT(DISTINCT x SEPARATOR s)` already was.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ filesql is for cases where the data is already in a file and the fastest useful 
 - Optionally query with MySQL, PostgreSQL, or GoogleSQL syntax via `WithDialect` (translated to SQLite).
 - Read from file paths, directories, `io.Reader`, and `embed.FS`.
 - Handle compressed CSV, TSV, LTSV, JSON, JSONL, Parquet, and XLSX files transparently.
+- Write csv, tsv, and ltsv output in Shift-JIS, EUC-JP, ISO-2022-JP, or UTF-16 as well as UTF-8.
 - Load into a new in-memory database or into a `*sql.DB` you already manage.
 - Save changes with `DumpDatabase`, `EnableAutoSave`, or `EnableAutoSaveOnCommit`.
 - Stay in one module for loading (`filesql`), cleanup (`prep`), and lightweight transforms (`frame`).
@@ -385,6 +386,18 @@ Changes live in memory until you save them.
 - `EnableAutoSave` saves when `db.Close()` runs.
 - `EnableAutoSaveOnCommit` saves after each committed transaction.
 
+`DumpOptions` decides the format, the compression, and the text encoding of csv, tsv, and ltsv output:
+
+```go
+options := filesql.NewDumpOptions().
+	WithFormat(filesql.OutputFormatCSV).
+	WithEncoding(filesql.EncodingShiftJIS)
+
+err := filesql.DumpDatabase(db, "./output", options)
+```
+
+Output is UTF-8 unless `WithEncoding` says otherwise, which is what a save wrote before the option existed. `EncodingShiftJIS`, `EncodingEUCJP`, `EncodingISO2022JP`, `EncodingUTF16LE`, and `EncodingUTF16BE` are the others; the UTF-16 pair write a byte-order mark, so the read side recognizes them without being told. A value the encoding has no way to write fails the save with `ErrEncoding` and leaves the destination as it was, rather than being replaced with a substitute character — the same answer the read side gives to bytes it cannot decode. Parquet and XLSX carry their own encoding and ignore the option.
+
 ### Excel sheet visibility
 
 A workbook can hide a sheet, and a hidden sheet often holds the spreadsheet's own working-out rather than data anyone meant to publish. filesql loads every sheet by default, hidden or not, so existing programs keep the tables they have.
@@ -436,7 +449,7 @@ The GoDoc examples are fully tested with `go test`. The tables below show the fa
 | Attach your own logger | `ExampleDBBuilder_WithLogger`, `ExampleNewSlogAdapter` | [example_api_test.go](./example_api_test.go) |
 | Open a read-only wrapper | `ExampleDBBuilder_OpenReadOnly` | [example_api_test.go](./example_api_test.go) |
 | Save on close or commit | `ExampleDBBuilder_EnableAutoSave`, `ExampleDBBuilder_EnableAutoSaveOnCommit`, `ExampleDBBuilder_DisableAutoSave` | [example_api_test.go](./example_api_test.go), [example_test.go](./example_test.go) |
-| Export tables with format/compression options | `ExampleDumpDatabase`, `ExampleNewDumpOptions`, `ExampleDumpOptions_WithFormat`, `ExampleDumpOptions_WithCompression` | [example_api_test.go](./example_api_test.go), [example_test.go](./example_test.go) |
+| Export tables with format/compression/encoding options | `ExampleDumpDatabase`, `ExampleNewDumpOptions`, `ExampleDumpOptions_WithFormat`, `ExampleDumpOptions_WithCompression`, `ExampleDumpOptions_WithEncoding` | [example_api_test.go](./example_api_test.go), [example_test.go](./example_test.go) |
 | Work with compression helpers directly | `ExampleNewCompressionHandler`, `ExampleNewCompressionFactory`, `ExampleCompressionFactory_DetectCompressionType` | [example_api_test.go](./example_api_test.go) |
 | Strip compression suffixes and inspect file types | `ExampleCompressionFactory_RemoveCompressionExtension`, `ExampleCompressionFactory_GetBaseFileType` | [example_api_test.go](./example_api_test.go) |
 | Inspect the malformed-row policy | `ExampleMalformedRowPolicy_String` | [example_api_test.go](./example_api_test.go) |

--- a/errors.go
+++ b/errors.go
@@ -67,6 +67,10 @@ var (
 	// ErrCompression indicates a compression/decompression operation failed.
 	ErrCompression = errors.New("filesql: compression operation failed")
 
+	// ErrEncoding indicates a text encoding operation failed, which for a save
+	// means the target encoding has no way to write a value the table holds.
+	ErrEncoding = errors.New("filesql: text encoding failed")
+
 	// ErrParsing indicates a file parsing operation failed.
 	ErrParsing = errors.New("filesql: parsing failed")
 

--- a/example_api_test.go
+++ b/example_api_test.go
@@ -353,6 +353,15 @@ func ExampleDumpOptions_WithCompression() {
 	// .csv.gz
 }
 
+func ExampleDumpOptions_WithEncoding() {
+	// Output is UTF-8 unless asked otherwise. A value the encoding cannot write
+	// fails the save rather than being replaced.
+	opts := filesql.NewDumpOptions().WithEncoding(filesql.EncodingShiftJIS)
+	fmt.Println(opts.Encoding)
+	// Output:
+	// shift-jis
+}
+
 func ExampleOutputFormat_Extension() {
 	fmt.Println(filesql.OutputFormatParquet.Extension())
 	// Output:

--- a/filesql.go
+++ b/filesql.go
@@ -506,21 +506,45 @@ func writeSQLiteTableDataTo(w io.Writer, tableName string, columns []string, row
 		err = joinCleanup(err, closeWriter(), "finish writing "+tableName)
 	}()
 
-	// Write data based on format
+	// Parquet and XLSX state their own encoding, so running their bytes through
+	// a transcoder would corrupt the container rather than translate it. Only the
+	// text formats below are encoded.
 	switch options.Format {
-	case OutputFormatCSV:
-		return writeCSVData(writer, columns, rows)
-	case OutputFormatTSV:
-		return writeTSVData(writer, columns, rows)
-	case OutputFormatLTSV:
-		return writeLTSVData(writer, columns, rows)
 	case OutputFormatParquet:
 		return writeParquetTableData(writer, columns, rows)
 	case OutputFormatXLSX:
 		return writeXLSXTableData(writer, tableName, columns, rows)
+	}
+
+	// The encoder wraps inside the compressor: what a compressor stores is the
+	// encoded text, so a reader decompresses and then decodes.
+	encoded, encoder := options.Encoding.encodingWriter(writer)
+	defer func() {
+		if encoder == nil {
+			return
+		}
+		// Closing the encoder is what flushes a sequence it was still holding, so
+		// dropping this error would commit a truncated file.
+		if closeErr := encoder.Close(); closeErr != nil && err == nil {
+			err = encodingError(options.Encoding, closeErr)
+		}
+	}()
+
+	var writeErr error
+	switch options.Format {
+	case OutputFormatCSV:
+		writeErr = writeCSVData(encoded, columns, rows)
+	case OutputFormatTSV:
+		writeErr = writeTSVData(encoded, columns, rows)
+	case OutputFormatLTSV:
+		writeErr = writeLTSVData(encoded, columns, rows)
 	default:
 		return fmt.Errorf("%w: unsupported output format: %v", ErrUnsupportedFormat, options.Format)
 	}
+	if writeErr != nil && encoder.encoderFailed() {
+		return encodingError(options.Encoding, writeErr)
+	}
+	return writeErr
 }
 
 // createCompressedWriter creates an appropriate writer based on compression type
@@ -545,7 +569,6 @@ func writeDelimitedData(writer io.Writer, columns []string, rows *sql.Rows, deli
 	if delimiter != csvDelimiter {
 		csvWriter.Comma = delimiter
 	}
-	defer csvWriter.Flush()
 
 	// writeRecord writes one record, taking the lone empty field around the csv
 	// writer. Flushing first keeps the two writers' output in order.
@@ -589,7 +612,15 @@ func writeDelimitedData(writer io.Writer, columns []string, rows *sql.Rows, deli
 		}
 	}
 
-	return rows.Err()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	// The flush is where a buffered write reaches the writer underneath, so it is
+	// the first place a failure there can be seen — csv.Writer holds the error
+	// rather than returning it from Write. Flushing in a defer discarded it, and
+	// an encoder refusing a value it cannot write is exactly such a failure.
+	csvWriter.Flush()
+	return csvWriter.Error()
 }
 
 // formatDumpValue renders one cell for a text-based dump.

--- a/save.go
+++ b/save.go
@@ -206,6 +206,9 @@ type DumpOptions struct {
 	Format OutputFormat
 	// Compression specifies the compression type
 	Compression CompressionType
+	// Encoding specifies the text encoding of csv, tsv, and ltsv output. It has
+	// no effect on Parquet and XLSX, which carry their own.
+	Encoding Encoding
 }
 
 // NewDumpOptions creates default export options (CSV, no compression).
@@ -217,6 +220,7 @@ func NewDumpOptions() DumpOptions {
 	return DumpOptions{
 		Format:      OutputFormatCSV,
 		Compression: CompressionNone,
+		Encoding:    EncodingUTF8,
 	}
 }
 
@@ -246,6 +250,30 @@ func (o DumpOptions) WithFormat(format OutputFormat) DumpOptions {
 //   - CompressionLZ4: LZ4 compression (.lz4)
 func (o DumpOptions) WithCompression(compression CompressionType) DumpOptions {
 	o.Compression = compression
+	return o
+}
+
+// WithEncoding sets the text encoding of csv, tsv, and ltsv output.
+//
+// It exists so a caller that decoded a legacy source before loading can write
+// one back: without it every save produced UTF-8, so an in-place save changed
+// the file's encoding on disk and the caller's next read of the same file
+// returned mojibake.
+//
+// A value the encoding cannot write fails the save with ErrEncoding, naming the
+// encoding, rather than being replaced — a substitution is the silent corruption
+// the read side already refuses. Parquet and XLSX carry their own encoding and
+// are unaffected.
+//
+// Options:
+//   - EncodingUTF8: UTF-8 (default)
+//   - EncodingShiftJIS: Shift-JIS (CP932)
+//   - EncodingEUCJP: EUC-JP
+//   - EncodingISO2022JP: ISO-2022-JP
+//   - EncodingUTF16LE: UTF-16 little-endian, with a byte-order mark
+//   - EncodingUTF16BE: UTF-16 big-endian, with a byte-order mark
+func (o DumpOptions) WithEncoding(enc Encoding) DumpOptions {
+	o.Encoding = enc
 	return o
 }
 

--- a/save_encoding.go
+++ b/save_encoding.go
@@ -1,0 +1,150 @@
+package filesql
+
+import (
+	"fmt"
+	"io"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+// Encoding is the text encoding a save writes its output in.
+//
+// The read side already understands these encodings; without a matching write
+// side a caller that decoded a legacy source before loading had no way to get
+// one back, so an in-place save changed the file's encoding on disk without
+// saying so. Compression is the same shape of decision and has had an option
+// since the beginning; this is the one for text.
+type Encoding int
+
+const (
+	// EncodingUTF8 writes UTF-8, which is what a save wrote before this option
+	// existed and remains the default.
+	EncodingUTF8 Encoding = iota
+	// EncodingShiftJIS writes Shift-JIS (CP932).
+	EncodingShiftJIS
+	// EncodingEUCJP writes EUC-JP.
+	EncodingEUCJP
+	// EncodingISO2022JP writes ISO-2022-JP.
+	EncodingISO2022JP
+	// EncodingUTF16LE writes little-endian UTF-16 with a byte-order mark.
+	EncodingUTF16LE
+	// EncodingUTF16BE writes big-endian UTF-16 with a byte-order mark.
+	EncodingUTF16BE
+)
+
+// String returns the name a user types for the encoding.
+func (e Encoding) String() string {
+	switch e {
+	case EncodingUTF8:
+		return "utf-8"
+	case EncodingShiftJIS:
+		return "shift-jis"
+	case EncodingEUCJP:
+		return "euc-jp"
+	case EncodingISO2022JP:
+		return "iso-2022-jp"
+	case EncodingUTF16LE:
+		return "utf-16le"
+	case EncodingUTF16BE:
+		return "utf-16be"
+	default:
+		return "unknown"
+	}
+}
+
+// encoder returns the transformer that writes e, and whether e needs one at all.
+// UTF-8 needs none: the values are already UTF-8, so a transformer would only
+// copy them.
+//
+// The UTF-16 encoders write a byte-order mark, because that is what lets the
+// read side recognize the file without being told the encoding — a UTF-16 file
+// with no mark is indistinguishable from single-byte data, which is the case
+// the mark exists to settle.
+//
+// None of these is wrapped in encoding.ReplaceUnsupported. The x/text encoders
+// fail on a rune the target has no way to write, and that failure is the point:
+// substituting would put back the silent corruption the read side refuses.
+func (e Encoding) encoder() (transform.Transformer, bool) {
+	var enc encoding.Encoding
+	switch e {
+	case EncodingUTF8:
+		return nil, false
+	case EncodingShiftJIS:
+		enc = japanese.ShiftJIS
+	case EncodingEUCJP:
+		enc = japanese.EUCJP
+	case EncodingISO2022JP:
+		enc = japanese.ISO2022JP
+	case EncodingUTF16LE:
+		enc = unicode.UTF16(unicode.LittleEndian, unicode.UseBOM)
+	case EncodingUTF16BE:
+		enc = unicode.UTF16(unicode.BigEndian, unicode.UseBOM)
+	default:
+		return nil, false
+	}
+	return enc.NewEncoder(), true
+}
+
+// encodedWriter is the text writer for one save, and remembers whether the
+// encoder was what failed.
+//
+// Telling the two apart matters and cannot be done after the fact: x/text
+// reports a rune outside the target repertoire with an internal.RepertoireError,
+// an unexported type, so a caller has no sentinel to match and would have to
+// compare message text. Recording it at the point it happens is exact, and it
+// keeps a disk error from being reported as an encoding one.
+type encodedWriter struct {
+	w      io.Writer
+	closer func() error
+	failed bool
+}
+
+// Write encodes p, noting a failure as the encoder's rather than the file's.
+func (e *encodedWriter) Write(p []byte) (int, error) {
+	n, err := e.w.Write(p)
+	if err != nil {
+		e.failed = true
+	}
+	return n, err
+}
+
+// Close flushes the encoder, which is where a rune held back as a partial
+// sequence is finally refused.
+func (e *encodedWriter) Close() error {
+	err := e.closer()
+	if err != nil {
+		e.failed = true
+	}
+	return err
+}
+
+// encoderFailed reports whether the encoder refused something, which is what
+// separates "this encoding cannot write this table" from a failure to write the
+// bytes at all.
+func (e *encodedWriter) encoderFailed() bool { return e != nil && e.failed }
+
+// encodingWriter wraps w so text written to it is encoded as e. It returns w
+// unchanged for UTF-8, where the values are already in the target encoding and a
+// transformer would only copy them.
+//
+// It wraps inside the compressor rather than outside it: the bytes a compressor
+// stores are the encoded ones, so a reader decompresses and then decodes, which
+// is the order the read side already applies.
+func (e Encoding) encodingWriter(w io.Writer) (io.Writer, *encodedWriter) {
+	transformer, ok := e.encoder()
+	if !ok {
+		return w, nil
+	}
+	tw := transform.NewWriter(w, transformer)
+	wrapped := &encodedWriter{w: tw, closer: tw.Close}
+	return wrapped, wrapped
+}
+
+// encodingError wraps a failure from the encoder so a caller can match it with
+// errors.Is and read which encoding refused the value.
+func encodingError(e Encoding, err error) error {
+	return fmt.Errorf("%w: %s cannot write a value in this table: %w", ErrEncoding, e, err)
+}

--- a/save_encoding_test.go
+++ b/save_encoding_test.go
@@ -1,0 +1,190 @@
+package filesql
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+// The save path could preserve a source's compression but not its text
+// encoding: every text file it wrote was UTF-8. A caller that decoded a
+// Shift-JIS source before loading had no way to get one back, so an in-place
+// save silently changed the file's encoding on disk and the caller's own next
+// run read mojibake. These tests are the round trip that was missing.
+
+func TestDumpOptions_WithEncoding(t *testing.T) {
+	t.Parallel()
+
+	options := NewDumpOptions()
+	newOptions := options.WithEncoding(EncodingShiftJIS)
+
+	assert.Equal(t, EncodingUTF8, options.Encoding, "the original options should not be modified")
+	assert.Equal(t, EncodingShiftJIS, newOptions.Encoding, "WithEncoding should update the encoding")
+	assert.Equal(t, OutputFormatCSV, newOptions.Format, "WithEncoding should not change the format")
+	assert.Equal(t, CompressionNone, newOptions.Compression, "WithEncoding should not change the compression")
+}
+
+func TestNewDumpOptions_DefaultsToUTF8(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, EncodingUTF8, NewDumpOptions().Encoding,
+		"a save says nothing about encoding unless asked, and UTF-8 is what it wrote before the option existed")
+}
+
+// TestDumpDatabase_WritesTheRequestedEncoding is the round trip: a table saved
+// in an encoding reads back as that encoding, values intact.
+func TestDumpDatabase_WritesTheRequestedEncoding(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name     string
+		encoding Encoding
+		decoder  transform.Transformer
+	}{
+		// ソ is the classic Shift-JIS trap: its second byte is 0x5C, the ASCII
+		// backslash, so a writer that is not encoding-aware corrupts the line.
+		{name: "shift-jis", encoding: EncodingShiftJIS, decoder: japanese.ShiftJIS.NewDecoder()},
+		{name: "euc-jp", encoding: EncodingEUCJP, decoder: japanese.EUCJP.NewDecoder()},
+		{name: "utf-16le", encoding: EncodingUTF16LE, decoder: unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder()},
+		{name: "utf-16be", encoding: EncodingUTF16BE, decoder: unicode.UTF16(unicode.BigEndian, unicode.UseBOM).NewDecoder()},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			source := filepath.Join(dir, "src.csv")
+			require.NoError(t, os.WriteFile(source, []byte("name,city\n山田ソ,東京\n"), 0o600))
+
+			ctx := context.Background()
+			db, err := OpenContext(ctx, source)
+			require.NoError(t, err)
+			defer db.Close()
+
+			out := filepath.Join(dir, "out")
+			require.NoError(t, os.MkdirAll(out, 0o750))
+			require.NoError(t, DumpDatabase(db, out, NewDumpOptions().WithEncoding(tt.encoding)))
+
+			written, err := os.ReadFile(filepath.Join(out, "src.csv")) //nolint:gosec // path built by the test
+			require.NoError(t, err)
+
+			decoded, err := io.ReadAll(transform.NewReader(bytes.NewReader(written), tt.decoder))
+			require.NoError(t, err)
+			assert.Contains(t, string(decoded), "山田ソ", "the values should survive the encoding")
+			assert.Contains(t, string(decoded), "東京")
+
+			// Re-opening through filesql is the other half: the reader's BOM
+			// handling has to recognize what the writer produced.
+			if tt.encoding == EncodingUTF16LE || tt.encoding == EncodingUTF16BE {
+				reopened, err := OpenContext(ctx, filepath.Join(out, "src.csv"))
+				require.NoError(t, err)
+				defer reopened.Close()
+
+				var city string
+				require.NoError(t, reopened.QueryRowContext(ctx, "SELECT city FROM src").Scan(&city))
+				assert.Equal(t, "東京", city)
+			}
+		})
+	}
+}
+
+// TestDumpDatabase_RefusesAValueTheEncodingCannotCarry is the other half of the
+// contract. A silent substitution is what the read side already refuses, so the
+// write side refuses it too rather than writing a replacement character.
+func TestDumpDatabase_RefusesAValueTheEncodingCannotCarry(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "src.csv")
+	require.NoError(t, os.WriteFile(source, []byte("name\n🎌\n"), 0o600))
+
+	ctx := context.Background()
+	db, err := OpenContext(ctx, source)
+	require.NoError(t, err)
+	defer db.Close()
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0o750))
+
+	err = DumpDatabase(db, out, NewDumpOptions().WithEncoding(EncodingShiftJIS))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrEncoding), "want ErrEncoding, got %v", err)
+
+	// A refused save leaves nothing behind, as every other failed write does.
+	entries, err := os.ReadDir(out)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "a refused save should leave no file")
+}
+
+// TestDumpDatabase_EncodingAndCompressionCombine pins the layering: the text is
+// encoded first and the bytes compressed after, so a reader decompresses and
+// then decodes.
+func TestDumpDatabase_EncodingAndCompressionCombine(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "src.csv")
+	require.NoError(t, os.WriteFile(source, []byte("name\n山田\n"), 0o600))
+
+	ctx := context.Background()
+	db, err := OpenContext(ctx, source)
+	require.NoError(t, err)
+	defer db.Close()
+
+	out := filepath.Join(dir, "out")
+	require.NoError(t, os.MkdirAll(out, 0o750))
+	require.NoError(t, DumpDatabase(db, out,
+		NewDumpOptions().WithEncoding(EncodingShiftJIS).WithCompression(CompressionGZ)))
+
+	written := filepath.Join(out, "src.csv.gz")
+	require.FileExists(t, written)
+
+	factory := NewCompressionFactory()
+	reader, cleanup, err := factory.CreateReaderForFile(written)
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	decoded, err := io.ReadAll(transform.NewReader(reader, japanese.ShiftJIS.NewDecoder()))
+	require.NoError(t, err)
+	assert.Contains(t, string(decoded), "山田")
+}
+
+// TestDumpDatabase_BinaryFormatsIgnoreEncoding pins that the option applies to
+// text only. Parquet and XLSX state their own encoding, so running their bytes
+// through a transcoder would corrupt the container.
+func TestDumpDatabase_BinaryFormatsIgnoreEncoding(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	source := filepath.Join(dir, "src.csv")
+	require.NoError(t, os.WriteFile(source, []byte("name\n山田\n"), 0o600))
+
+	ctx := context.Background()
+	db, err := OpenContext(ctx, source)
+	require.NoError(t, err)
+	defer db.Close()
+
+	for _, format := range []OutputFormat{OutputFormatParquet, OutputFormatXLSX} {
+		out := filepath.Join(dir, format.Extension())
+		require.NoError(t, os.MkdirAll(out, 0o750))
+		require.NoError(t, DumpDatabase(db, out,
+			NewDumpOptions().WithFormat(format).WithEncoding(EncodingShiftJIS)))
+
+		reopened, err := OpenContext(ctx, filepath.Join(out, "src"+format.Extension()))
+		require.NoError(t, err)
+
+		var name string
+		require.NoError(t, reopened.QueryRowContext(ctx, "SELECT name FROM src").Scan(&name))
+		assert.Equal(t, "山田", name, "%v should keep its own encoding", format)
+		require.NoError(t, reopened.Close())
+	}
+}


### PR DESCRIPTION
The save path could preserve a source's compression but not its text encoding: every text file it wrote was UTF-8. A caller that decoded a Shift-JIS, EUC-JP, or UTF-16 source before loading had no way to get one back, so an in-place save silently changed the file's encoding on disk and the caller's own next read of the same file returned mojibake. nao1215/sqly#879 is that bug seen from the CLI.

`DumpOptions.WithEncoding` names the encoding, mirroring `WithCompression`. Output stays UTF-8 unless it is called, so nothing existing changes. The encoder wraps inside the compressor, because what a compressor stores is the encoded text and a reader decompresses before it decodes — the order the read side already applies. The UTF-16 encodings write a byte-order mark, which is what lets the read side recognize them without being told; a UTF-16 file with no mark is indistinguishable from single-byte data.

A rune the target has no repertoire for fails the save with `ErrEncoding`, naming the encoding, and leaves the destination untouched through the existing atomic staging. The x/text encoders already refuse rather than substitute, and they are deliberately not wrapped in `encoding.ReplaceUnsupported`: a substitution would put back exactly the silent corruption the read side refuses. Telling an encoder failure from a disk failure is done by recording it where it happens, because x/text reports an unrepresentable rune with `internal.RepertoireError` — an unexported type, so there is no sentinel to match and the alternative would be comparing message text.

Parquet and XLSX carry their own encoding and are written before the encoder is applied, so their containers are never transcoded.

One existing behavior had to change to make the refusal reachable. `writeDelimitedData` flushed its `csv.Writer` in a defer, which discards the flush error — and a buffered write only reaches the writer underneath at the flush, so that was the one place an encoder refusal could be seen. It now flushes explicitly and returns `csv.Writer.Error()`, so a write that failed is reported instead of committing a file missing the value that failed.

Tests cover the round trip for all four non-UTF-8 encodings (including ソ, whose Shift-JIS second byte is the ASCII backslash), re-opening the UTF-16 output through filesql so the BOM contract is pinned from both sides, the refusal leaving no file behind, encoding combined with compression, and Parquet and XLSX ignoring the option.

Closes #248