### PR TITLE
chore: release v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-08-08
+
 ### Added
 
 - `DumpOptions.WithEncoding` writes csv, tsv, and ltsv output in Shift-JIS, EUC-JP, ISO-2022-JP, or UTF-16 as well as UTF-8. The read side has understood these encodings for a long time and the write side had no matching option, so a caller that decoded a legacy source before loading had no way to get one back: every save wrote UTF-8, which meant an in-place save silently changed the file's encoding on disk and the caller's next read of the same file returned mojibake. Output is UTF-8 unless the option says otherwise, and the UTF-16 encodings write a byte-order mark so the read side recognizes them without being told. A value the encoding cannot write fails the save with `ErrEncoding` and leaves the destination untouched, rather than being replaced with a substitute character. Parquet and XLSX carry their own encoding and are unaffected.


### PR DESCRIPTION
Release v0.38.0.

Adds `DumpOptions.WithEncoding` so csv, tsv, and ltsv output can be written in Shift-JIS, EUC-JP, ISO-2022-JP, or UTF-16 as well as UTF-8 (#248), fixes ACH write-back never recalculating batch controls, which made every entry amount edit unwritable (#250), and answers `STRING_AGG(DISTINCT x, s)` at translate time in the PostgreSQL and GoogleSQL dialects instead of letting it fail inside SQLite (#249).

Minor rather than patch: the encoding option is a new API surface. Nothing existing changes — output stays UTF-8 unless the option is called.