### PR TITLE
fix: fold case when comparing header names for duplicates

### DIFF
--- a/encoding_test.go
+++ b/encoding_test.go
@@ -409,6 +409,55 @@ func TestDuplicateColumnCheckIsTheSameEverywhere(t *testing.T) {
 		assert.Contains(t, err.Error(), "column 2")
 	})
 
+	// SQLite compares column names without regard to case, so a header that
+	// differs only in case is a duplicate to the engine. The guard compared the
+	// names verbatim, so it passed them through and SQLite refused the CREATE
+	// TABLE in its own words, three wraps deep, with no sentinel to match and no
+	// column position — the outcome this guard exists to replace.
+	t.Run("csv rejects names that differ only by case", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "cased.csv")
+		require.NoError(t, os.WriteFile(path, []byte("ID,id\n1,2\n"), 0o600))
+
+		db, err := OpenContext(context.Background(), path)
+		if db != nil {
+			defer db.Close()
+		}
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrDuplicateColumn)
+		assert.Contains(t, err.Error(), "column 2")
+	})
+
+	t.Run("xlsx rejects names that differ only by case", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "cased.xlsx")
+		writeXLSXHeaderFixture(t, path, []string{"Name", "nAmE"}, []string{"1", "2"})
+
+		db, err := OpenContext(context.Background(), path)
+		if db != nil {
+			defer db.Close()
+		}
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrDuplicateColumn)
+	})
+
+	// Case and whitespace are one rule, not two applied in sequence by luck.
+	t.Run("csv rejects names that differ only by case and whitespace", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "both.csv")
+		require.NoError(t, os.WriteFile(path, []byte("name, NAME \n1,2\n"), 0o600))
+
+		db, err := OpenContext(context.Background(), path)
+		if db != nil {
+			defer db.Close()
+		}
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrDuplicateColumn)
+	})
+
 	// Names that are distinct after trimming stay distinct, so the rule refuses
 	// a collision rather than every header that holds a space.
 	t.Run("xlsx keeps headers that differ by more than whitespace", func(t *testing.T) {

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -349,6 +349,22 @@ func TestDuplicateColumnErrorNamesTheColumn(t *testing.T) {
 	}
 }
 
+// requireDuplicateColumnRefusal asserts the whole contract of the duplicate
+// header guard: the sentinel a caller matches on, the offending name quoted so
+// whitespace is visible, its 1-based position, and — the reason the guard
+// exists — that the header never reached SQLite, whose refusal arrives as
+// ErrDatabaseOperation carrying neither the sentinel nor the position.
+func requireDuplicateColumnRefusal(t *testing.T, err error, want ...string) {
+	t.Helper()
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDuplicateColumn)
+	assert.NotErrorIs(t, err, ErrDatabaseOperation)
+	for _, w := range want {
+		assert.Contains(t, err.Error(), w)
+	}
+}
+
 // TestDuplicateColumnCheckIsTheSameEverywhere pins one rule for duplicate
 // column names across the formats and the loaders.
 //
@@ -424,9 +440,7 @@ func TestDuplicateColumnCheckIsTheSameEverywhere(t *testing.T) {
 		if db != nil {
 			defer db.Close()
 		}
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrDuplicateColumn)
-		assert.Contains(t, err.Error(), "column 2")
+		requireDuplicateColumnRefusal(t, err, `"id"`, "column 2")
 	})
 
 	t.Run("xlsx rejects names that differ only by case", func(t *testing.T) {
@@ -439,8 +453,7 @@ func TestDuplicateColumnCheckIsTheSameEverywhere(t *testing.T) {
 		if db != nil {
 			defer db.Close()
 		}
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrDuplicateColumn)
+		requireDuplicateColumnRefusal(t, err, `"nAmE"`, "column 2")
 	})
 
 	// Case and whitespace are one rule, not two applied in sequence by luck.
@@ -454,8 +467,7 @@ func TestDuplicateColumnCheckIsTheSameEverywhere(t *testing.T) {
 		if db != nil {
 			defer db.Close()
 		}
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrDuplicateColumn)
+		requireDuplicateColumnRefusal(t, err, `" NAME "`, "column 2")
 	})
 
 	// Names that are distinct after trimming stay distinct, so the rule refuses

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -845,9 +845,11 @@ func parseLTSV(reader io.Reader) (*TableData, error) {
 }
 
 // validateColumnNames checks for duplicate column names, comparing them with
-// surrounding whitespace removed: " name " beside "name" is one name twice, not
-// two columns. Every loader in filesql applies that rule, so a header cannot be
-// a duplicate in one format and a second column in another.
+// surrounding whitespace removed and case folded: " name " and "NAME" beside
+// "name" are one name three times, not three columns. Every loader in filesql
+// applies that rule, so a header cannot be a duplicate in one format and a
+// second column in another — and case is folded because SQLite, which ends up
+// holding the columns, compares their names that way too.
 //
 // This is a deliberate difference from github.com/nao1215/fileparser, which
 // parser is a fork of and which compares the names as they stand. The message
@@ -857,11 +859,11 @@ func parseLTSV(reader io.Reader) (*TableData, error) {
 func validateColumnNames(columns []string) error {
 	seen := make(map[string]bool, len(columns))
 	for _, col := range columns {
-		trimmed := strings.TrimSpace(col)
-		if seen[trimmed] {
+		key := strings.ToLower(strings.TrimSpace(col))
+		if seen[key] {
 			return fmt.Errorf("duplicate column name: %s", col)
 		}
-		seen[trimmed] = true
+		seen[key] = true
 	}
 	return nil
 }

--- a/types.go
+++ b/types.go
@@ -172,7 +172,6 @@ func (ct columnType) String() string {
 }
 
 // validateColumnNames checks for duplicate column names and returns error if found.
-// Column name comparison is case-sensitive to maintain backward compatibility.
 //
 // The message quotes the name and gives its 1-based position, because a header
 // can duplicate the empty name — two unnamed columns — and an unquoted empty
@@ -180,13 +179,27 @@ func (ct columnType) String() string {
 func validateColumnNames(columns []string) error {
 	columnsSeen := make(map[string]bool)
 	for i, col := range columns {
-		trimmedCol := strings.TrimSpace(col)
-		if columnsSeen[trimmedCol] {
+		key := columnNameKey(col)
+		if columnsSeen[key] {
 			return fmt.Errorf("%w: %q (column %d)", errDuplicateColumnName, col, i+1)
 		}
-		columnsSeen[trimmedCol] = true
+		columnsSeen[key] = true
 	}
 	return nil
+}
+
+// columnNameKey reduces a header cell to what decides whether two of them are
+// the same column: surrounding whitespace is not part of the name, and neither
+// is case.
+//
+// Case is folded because SQLite is what ends up holding these columns and it
+// compares their names without regard to it. Keeping the comparison
+// case-sensitive here did not make "ID" and "id" two columns; it only moved the
+// refusal to SQLite, which reported it as a failed CREATE TABLE wrapped in a
+// database-operation error — no ErrDuplicateColumn to match, and no column
+// position — which is the outcome this check exists to replace.
+func columnNameKey(column string) string {
+	return strings.ToLower(strings.TrimSpace(column))
 }
 
 // chunkSizeValue represents a chunk size with validation. The name carries the


### PR DESCRIPTION
The duplicate-header guard exists so a repeated column name fails as `ErrDuplicateColumn`, naming the column and its 1-based position, rather than reaching SQLite and coming back as a failed CREATE TABLE wrapped in a database-operation error that no caller can match with `errors.Is`.

It compared the names verbatim. SQLite compares column names without regard to case, so a header differing only in case was a duplicate to the engine and two distinct columns to the guard. `ID,id` passed the check and was refused by SQLite, in exactly the words and exactly the shape the guard was written to replace — three wraps deep, no sentinel, no column position. `name, NAME ` slipped past both halves of the rule at once, since neither the trim nor the comparison caught it alone.

Case is now folded alongside the whitespace trim, in both copies of the check: `validateColumnNames` in `types.go`, which builds filesql own quoted-and-positioned message, and the fork copy in `parser/parser.go`. The rule is one rule again, so a header cannot be a duplicate in one format and a second column in another.

The deliberate divergence from `nao1215/fileparser` documented on the parser copy grows by one clause and no more: the comparison differs, the message does not. The differential fixture is an exact duplicate, which both implementations reject identically, so the legacy compatibility test is unaffected.

Tests go into the existing `TestDuplicateColumnCheckIsTheSameEverywhere`, which already pins one rule across formats: CSV and XLSX each reject a case-only duplicate, and CSV rejects one that differs by case and whitespace together.

Closes #258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duplicate-column detection for CSV and XLSX files.
  * Column names are now compared without regard to capitalization or surrounding whitespace.
  * Duplicate-column errors continue to identify the conflicting column and its position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->