### PR TITLE
fix: ask every value whether a numeric column would damage it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A value that only a TEXT column holds losslessly keeps its column TEXT wherever it sits in the file ([#255](https://github.com/nao1215/filesql/issues/255)). Three kinds of value are damaged by a numeric column — a zero-padded code, an integer literal past int64, and Go-only numeric syntax — and the classifier already refused to call any of them numeric. It only ever saw a sample: at most 1000 values per column, taken from the first chunk. A code arriving after that met a column that was already INTEGER, and SQLite's affinity rewrote it on the way in, so `007` came back as `7` and an account number past int64 as `1.104032026e+19`, at exit 0 with nothing on stderr. Whether a column is INTEGER or REAL is still decided from a sample; whether a cell survives is now asked of every value, and a chunk that widens a column rebuilds the table before its rows are inserted.
+
+### Documentation
+
+- README describes what column-type inference guarantees and what it does not ([#256](https://github.com/nao1215/filesql/issues/256)). Decimal spelling is not preserved: `2.50` loads as the REAL `2.5`, `1.00` as `1`, and `1e3` as `1000`. Keeping the spelling would mean a TEXT column, and SQLite compares a TEXT column against a number as text, so `WHERE amount > 9.5` over `9.00` and `10.00` matches nothing — the arithmetic is worth more than the formatting. The rule is now written down beside the three cases that do force TEXT, rather than left to be discovered.
+
 ## [0.38.0] - 2026-08-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -353,6 +353,20 @@ north,apple,1,100
 
 ## Important Notes
 
+### Column types
+
+CSV, TSV, LTSV, and XLSX carry no types, so filesql reads the values and picks INTEGER, REAL, or TEXT per column. Parquet, ACH, and Fedwire bring their own schema and are not inferred.
+
+Which of the three a column gets is decided from a sample. Whether a cell survives the load is not: three kinds of value are damaged by a numeric column, so any one of them anywhere in the file makes the column TEXT, wherever it sits.
+
+| Value | Column | Why |
+|:--|:--|:--|
+| `007`, `02134` | TEXT | A leading zero is part of a code, and INTEGER drops it |
+| `11040320260000000000` | TEXT | Past int64, and float64 would render it `1.104032026e+19` |
+| `1_000`, `0x1p4` | TEXT | Go parses these, SQLite's affinity does not convert them |
+
+What is not on that list is decimal formatting. `2.50` loads as the REAL `2.5`, `1.00` as `1`, and `1e3` as `1000`: the quantity is preserved and the way it was written is not. Storing those as TEXT would keep the spelling and break the arithmetic — SQLite compares a TEXT column against a number as text, so `WHERE amount > 9.5` over `9.00` and `10.00` returns nothing at all. A column of money is worth more as numbers than as the string it was typed as, so the trailing zeros go. Keep the source file if you need the original spelling, or read the column into a TEXT column of your own before loading.
+
 ### Memory and streaming
 
 filesql loads data into an in-memory SQLite database. CSV, TSV, and JSON arrays are read in chunks while loading. LTSV, non-array JSON/JSONL values, Parquet, XLSX, ACH, and Fedwire are read in full before they are turned into rows.

--- a/column_overflow_test.go
+++ b/column_overflow_test.go
@@ -2,8 +2,10 @@ package filesql
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -60,6 +62,35 @@ func TestInferColumnTypeInt64Overflow(t *testing.T) {
 		"11040320260000000002",
 	})
 	require.Equal(t, columnTypeText, got)
+}
+
+// TestOpenContextPreservesLargeIntegerPastTheFirstChunk is the same rule across
+// the boundary that decides the schema. Column types come from the first chunk,
+// so an account number past int64 arriving later met a column that was already
+// INTEGER, and came back as 1.104032026e+19 — the loss the classifier refuses
+// to allow in the first chunk, reached by arriving after it.
+func TestOpenContextPreservesLargeIntegerPastTheFirstChunk(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	b.WriteString("account\n")
+	for i := range DefaultRowsPerChunk * 2 {
+		fmt.Fprintf(&b, "%d\n", i+1)
+	}
+	b.WriteString("11040320260000000000\n")
+
+	path := filepath.Join(t.TempDir(), "accounts.csv")
+	require.NoError(t, os.WriteFile(path, []byte(b.String()), 0600))
+
+	ctx := context.Background()
+	db, err := OpenContext(ctx, path)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var got string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT account FROM accounts WHERE length(account) = 20`).Scan(&got))
+	require.Equal(t, "11040320260000000000", got)
 }
 
 // TestOpenContextPreservesLargeIntegerExactly is the end-to-end regression test

--- a/column_zero_padded_test.go
+++ b/column_zero_padded_test.go
@@ -2,8 +2,11 @@ package filesql
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -80,6 +83,62 @@ func TestInferColumnTypeZeroPadded(t *testing.T) {
 
 	got := inferColumnType([]string{"02134", "00501", "10001"})
 	require.Equal(t, columnTypeText, got)
+}
+
+// TestInferColumnTypePreservesLateZeroPadded covers a value the sampler would
+// skip. Inference samples at most maxSampleSize values per column, and the
+// guards that keep a zero-padded code out of an INTEGER column only run on what
+// is sampled — so whether a code survived depended on where in the file it sat.
+func TestInferColumnTypePreservesLateZeroPadded(t *testing.T) {
+	t.Parallel()
+
+	values := make([]string, 0, maxSampleSize*2)
+	for i := range maxSampleSize * 2 {
+		values = append(values, strconv.Itoa(i+1))
+	}
+	values[len(values)-1] = "007"
+
+	require.Equal(t, columnTypeText, inferColumnType(values))
+}
+
+// TestOpenContextPreservesZeroPaddedCodesPastTheFirstChunk is the end-to-end
+// half of the same rule, across the boundary that decides the schema. Types are
+// inferred from the first chunk alone, so a code arriving in a later one met a
+// column that was already INTEGER and was rewritten by SQLite's affinity: 007
+// came back as 7, at no error and no warning.
+func TestOpenContextPreservesZeroPaddedCodesPastTheFirstChunk(t *testing.T) {
+	t.Parallel()
+
+	var b strings.Builder
+	b.WriteString("code\n")
+	for i := range DefaultRowsPerChunk * 2 {
+		fmt.Fprintf(&b, "%d\n", i+1)
+	}
+	b.WriteString("007\n")
+
+	path := filepath.Join(t.TempDir(), "codes.csv")
+	require.NoError(t, os.WriteFile(path, []byte(b.String()), 0600))
+
+	ctx := context.Background()
+	db, err := OpenContext(ctx, path)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var got string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT code FROM codes WHERE code LIKE '0%'`).Scan(&got))
+	require.Equal(t, "007", got)
+
+	// The rows that arrived before the promotion keep their own values: a plain
+	// integer's text form is the digits it was read from.
+	var first string
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT code FROM codes LIMIT 1`).Scan(&first))
+	require.Equal(t, "1", first)
+
+	var rows int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM codes`).Scan(&rows))
+	require.Equal(t, DefaultRowsPerChunk*2+1, rows)
 }
 
 // TestOpenContextPreservesZeroPaddedCodes is the end-to-end regression test: a

--- a/stream.go
+++ b/stream.go
@@ -356,8 +356,12 @@ func (p *streamingParser) processDelimitedInChunks(reader io.Reader, processor c
 
 		// Process chunk when it reaches the target size
 		if len(chunkrecords) >= chunkSize {
-			// Infer column types on first chunk
-			if len(columnInfo) == 0 {
+			// Infer column types on first chunk. A later chunk does not
+			// re-infer, but it can still hold a value a numeric column would
+			// damage, so it is asked. See promoteForRecords.
+			if len(columnInfo) != 0 {
+				columnInfo.promoteForRecords(chunkrecords)
+			} else {
 				columnInfo = newColumnInfoListFromValues(header, columnValues)
 			}
 
@@ -381,7 +385,9 @@ func (p *streamingParser) processDelimitedInChunks(reader io.Reader, processor c
 	// Process remaining records
 	if len(chunkrecords) > 0 {
 		// Infer column types if we haven't yet (small dataset)
-		if len(columnInfo) == 0 {
+		if len(columnInfo) != 0 {
+			columnInfo.promoteForRecords(chunkrecords)
+		} else {
 			columnInfo = newColumnInfoListFromValues(header, columnValues)
 		}
 
@@ -529,8 +535,12 @@ func (p *streamingParser) processLTSVInChunks(reader io.Reader, processor chunkP
 
 		// Process chunk when it reaches the target size
 		if len(chunkrecords) >= chunkSize {
-			// Infer column types on first chunk
-			if len(columnInfo) == 0 {
+			// Infer column types on first chunk. A later chunk does not
+			// re-infer, but it can still hold a value a numeric column would
+			// damage, so it is asked. See promoteForRecords.
+			if len(columnInfo) != 0 {
+				columnInfo.promoteForRecords(chunkrecords)
+			} else {
 				columnInfo = newColumnInfoListFromValues(header, columnValues)
 			}
 
@@ -554,7 +564,9 @@ func (p *streamingParser) processLTSVInChunks(reader io.Reader, processor chunkP
 	// Process remaining records
 	if len(chunkrecords) > 0 {
 		// Infer column types if we haven't yet
-		if len(columnInfo) == 0 {
+		if len(columnInfo) != 0 {
+			columnInfo.promoteForRecords(chunkrecords)
+		} else {
 			columnInfo = newColumnInfoListFromValues(header, columnValues)
 		}
 
@@ -1010,8 +1022,12 @@ func (p *streamingParser) processXLSXInChunks(reader io.Reader, processor chunkP
 
 		// Process chunk when it reaches the target size
 		if len(chunkRecords) >= chunkSize {
-			// Infer column types on first chunk
-			if len(columnInfo) == 0 {
+			// Infer column types on first chunk. A later chunk does not
+			// re-infer, but it can still hold a value a numeric column would
+			// damage, so it is asked. See promoteForRecords.
+			if len(columnInfo) != 0 {
+				columnInfo.promoteForRecords(chunkRecords)
+			} else {
 				columnInfo = newColumnInfoListFromValues(headers, columnValues)
 			}
 
@@ -1037,7 +1053,9 @@ func (p *streamingParser) processXLSXInChunks(reader io.Reader, processor chunkP
 	// Process remaining records
 	if len(chunkRecords) > 0 {
 		// Infer column types if we haven't yet (small dataset)
-		if len(columnInfo) == 0 {
+		if len(columnInfo) != 0 {
+			columnInfo.promoteForRecords(chunkRecords)
+		} else {
 			columnInfo = newColumnInfoListFromValues(headers, columnValues)
 		}
 

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -290,6 +290,8 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, 
 	var insertStmt *sql.Stmt
 	var tx *sql.Tx
 	ownTx := false
+	// createdTypes is the schema on disk, which a later chunk can widen.
+	var createdTypes columnInfoList
 
 	// Process data in chunks with transaction batching for performance
 	var chunkCount int
@@ -331,7 +333,21 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, 
 			}
 
 			tableCreated = true
+			createdTypes = columnInfoList(chunk.getColumnInfo()).clone()
 			sp.logger.Info("table created", logKeyTable, input.tableName)
+		}
+
+		// A chunk can widen a column the table was already created with, when a
+		// value only a TEXT column holds losslessly arrives after the schema was
+		// decided. Rebuild before inserting it, so the value never meets the
+		// affinity that would rewrite it.
+		if !createdTypes.equalTypes(chunk.getColumnInfo()) {
+			newStmt, err := sp.rebuildTableForWidenedColumns(ctx, tx, chunk, insertStmt) //nolint:sqlclosecheck // Statement is closed after processing
+			if err != nil {
+				return err
+			}
+			insertStmt = newStmt
+			createdTypes = columnInfoList(chunk.getColumnInfo()).clone()
 		}
 
 		// Insert chunk data
@@ -441,6 +457,54 @@ func (sp *streamProcessor) createTableFromChunk(ctx context.Context, db DBTX, ch
 
 	_, err := db.ExecContext(ctx, query)
 	return err
+}
+
+// rebuildTableForWidenedColumns recreates the table with the chunk's column
+// types and moves the rows already loaded into it, returning an insert
+// statement prepared against the new table.
+//
+// SQLite cannot change a column's declared type in place, so this is the
+// standard rename-copy-drop. Copying is lossless for what it copies: a column
+// is only widened to TEXT, and every row already inserted held a value the
+// numeric column accepted without altering it, so its text form is the text it
+// was read from.
+func (sp *streamProcessor) rebuildTableForWidenedColumns(ctx context.Context, tx *sql.Tx, chunk *tableChunk, insertStmt *sql.Stmt) (*sql.Stmt, error) {
+	table := chunk.getTableName()
+	sp.logger.Debug("widening column types", logKeyTable, table)
+
+	// The old statement is bound to the table this is about to drop.
+	if insertStmt != nil {
+		if err := insertStmt.Close(); err != nil {
+			return nil, fmt.Errorf("%w: failed to close insert statement before widening: %w", ErrDatabaseOperation, err)
+		}
+	}
+
+	staging := table + "_filesql_widen"
+	columnInfo := chunk.getColumnInfo()
+	columns := make([]string, 0, len(columnInfo))
+	names := make([]string, 0, len(columnInfo))
+	for _, col := range columnInfo {
+		columns = append(columns, fmt.Sprintf(`"%s" %s`, col.Name, col.Type.string()))
+		names = append(names, fmt.Sprintf(`"%s"`, col.Name))
+	}
+
+	statements := []string{
+		fmt.Sprintf(`ALTER TABLE "%s" RENAME TO "%s"`, table, staging),
+		fmt.Sprintf(`CREATE TABLE "%s" (%s)`, table, strings.Join(columns, ", ")),
+		fmt.Sprintf(`INSERT INTO "%s" SELECT %s FROM "%s"`, table, strings.Join(names, ", "), staging),
+		fmt.Sprintf(`DROP TABLE "%s"`, staging),
+	}
+	for _, statement := range statements {
+		if _, err := tx.ExecContext(ctx, statement); err != nil {
+			return nil, fmt.Errorf("%w: failed to widen column types: %w", ErrDatabaseOperation, err)
+		}
+	}
+
+	stmt, err := sp.prepareInsertStatementTx(ctx, tx, chunk)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to prepare insert statement after widening: %w", ErrDatabaseOperation, err)
+	}
+	return stmt, nil
 }
 
 // prepareInsertStatement prepares an insert statement for the table

--- a/types.go
+++ b/types.go
@@ -311,6 +311,47 @@ func newColumnInfoListFromValues(header header, columnValues [][]string) columnI
 	return columnInfos
 }
 
+// promoteForRecords widens any numeric column that these records show cannot
+// hold its values losslessly.
+//
+// Types are inferred once, from the first chunk, and a file is not obliged to
+// introduce its awkward values early. A zero-padded code or an int64-overflowing
+// literal arriving in a later chunk met a column that was already INTEGER, and
+// SQLite's affinity rewrote it on the way in — the same loss the guards prevent
+// in the first chunk, reached by arriving late. Only widening to TEXT is needed:
+// nothing here can make a TEXT column numeric again.
+func (c columnInfoList) promoteForRecords(records []record) {
+	for _, r := range records {
+		for i, value := range r {
+			if i >= len(c) || c[i].Type == columnTypeText {
+				continue
+			}
+			if mustStayText(value) {
+				c[i].Type = columnTypeText
+			}
+		}
+	}
+}
+
+// equalTypes reports whether both lists declare the same column types.
+func (c columnInfoList) equalTypes(other columnInfoList) bool {
+	if len(c) != len(other) {
+		return false
+	}
+	for i := range c {
+		if c[i].Type != other[i].Type {
+			return false
+		}
+	}
+	return true
+}
+
+// clone returns a copy that later promotions cannot reach, so a caller can hold
+// on to the types a table was actually created with.
+func (c columnInfoList) clone() columnInfoList {
+	return append(columnInfoList(nil), c...)
+}
+
 // datetimePattern represents a cached datetime pattern with compiled regex
 type datetimePattern struct {
 	pattern *regexp.Regexp
@@ -435,6 +476,13 @@ func isDatetime(value string) bool {
 func inferColumnType(values []string) columnType {
 	if len(values) == 0 {
 		return columnTypeText
+	}
+
+	// Asked of every value, not of the sample: see mustStayText.
+	for _, value := range values {
+		if mustStayText(value) {
+			return columnTypeText
+		}
 	}
 
 	// Use sampling for large datasets to improve performance
@@ -671,8 +719,36 @@ func isFloat(value string) bool {
 		return false
 	}
 
+	// Decimal spelling is deliberately not guarded the way the three cases above
+	// are. "2.50" loads as the REAL 2.5 and "1e3" as 1000: the quantity survives
+	// and the way it was written does not. Keeping the spelling would mean a
+	// TEXT column, and SQLite compares a TEXT column against a number as text —
+	// "WHERE amount > 9.5" over "9.00" and "10.00" then matches nothing at all.
+	// A column of money is worth more as numbers than as the strings it was
+	// typed as, so the trailing zeros go and the arithmetic stays.
 	_, err := strconv.ParseFloat(value, 64)
 	return err == nil
+}
+
+// mustStayText reports whether a numeric column would damage this value, so the
+// column holding it has to be TEXT.
+//
+// These are the three cases the classifier already refuses to call numeric, and
+// they differ from the rest of inference in kind rather than degree. Whether a
+// column is INTEGER or REAL is a judgement about the column, and a sample is a
+// reasonable way to make it. Whether a cell survives the load is not a
+// judgement: a zero-padded code, a literal past int64, or Go-only numeric
+// syntax is rewritten by SQLite's affinity the moment it reaches a numeric
+// column, and no later inspection can recover what it said. So every value is
+// asked this question, and only the leftovers are sampled.
+func mustStayText(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	return isZeroPaddedIntegerLiteral(value) ||
+		isIntegerLiteralOverflowingInt64(value) ||
+		hasGoOnlyNumericSyntax(value)
 }
 
 // hasGoOnlyNumericSyntax reports whether value uses numeric syntax that Go's


### PR DESCRIPTION
Three kinds of value are rewritten by SQLite affinity the moment they reach a numeric column: a zero-padded code, an integer literal past int64, and Go-only numeric syntax such as `1_000`. `classifyValue` already refuses to call any of them numeric, and that refusal is the reason a ZIP code survives a load at all.

It only ever saw a sample. `getSampleValues` caps inference at 1000 values per column, and those values come from the first chunk, which is 1000 rows — so on any file longer than that the schema was fixed before most of the file had been read. A code arriving later met a column that was already INTEGER: `007` loaded as `7`, and an account number past int64 as `1.104032026e+19`. Exit 0, nothing on stderr, and whether a value survived depended on which row it happened to sit in. The same file with the code in row 1 kept every value verbatim.

The split this PR draws is between the two questions inference answers. Whether a column is INTEGER or REAL is a judgement about the column, and sampling is a fair way to make it — that is unchanged. Whether a cell survives the load is not a judgement, so `mustStayText` is now asked of every value, ahead of the sampling.

That fixes the columns decided in one pass. For a file longer than a chunk, a later chunk that turns up such a value widens its column and the table is rebuilt before that chunk is inserted, so the value never meets the affinity that would rewrite it. The rebuild is the standard SQLite rename-copy-drop, and copying is lossless for what it copies: only widening to TEXT happens, and every row already inserted held a value the numeric column accepted without altering, so its text form is the text it was read from. The rebuild runs inside the load transaction and re-prepares the insert statement, since the old one is bound to the table being dropped.

Decimal spelling is deliberately not in that set, and issue #256 asked for it to be. It is not fixed, it is documented, because fixing it costs more than it buys: `2.50` would keep its spelling only in a TEXT column, and SQLite compares a TEXT column against a number as text, so `WHERE amount > 9.5` over `9.00` and `10.00` returns no rows at all. A column of money is worth more as numbers than as the strings it was typed as. The README now carries a "Column types" section stating both halves — the three cases that force TEXT wherever they appear, and the decimal formatting that is not preserved — and the same reasoning sits beside `isFloat`.

Tests go into the existing zero-padded and overflow files: a sampler-skipping value in `inferColumnType`, and two end-to-end loads whose protected value sits after `DefaultRowsPerChunk * 2` rows, asserting the exact string, the untouched earlier rows, and the row count.

Closes #255
Closes #256