### PR TITLE
feat: report the rows the malformed-row policy skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `DBBuilder.SkippedRows` reports what `MalformedRowSkip` discarded, per table, with the count and the number of data rows it was choosing from. Skipping is an instruction from the caller, but an instruction that reports nothing left an import that dropped one row and one that dropped most of the file looking identical — and a write-back afterwards makes either one permanent. A load that dropped nothing is not listed, so a non-empty result is always worth reporting to a user.
+
 ### Fixed
 
 - A value that only a TEXT column holds losslessly keeps its column TEXT wherever it sits in the file ([#255](https://github.com/nao1215/filesql/issues/255)). Three kinds of value are damaged by a numeric column — a zero-padded code, an integer literal past int64, and Go-only numeric syntax — and the classifier already refused to call any of them numeric. It only ever saw a sample: at most 1000 values per column, taken from the first chunk. A code arriving after that met a column that was already INTEGER, and SQLite's affinity rewrote it on the way in, so `007` came back as `7` and an account number past int64 as `1.104032026e+19`, at exit 0 with nothing on stderr. Whether a column is INTEGER or REAL is still decided from a sample; whether a cell survives is now asked of every value, and a chunk that widens a column rebuilds the table before its rows are inserted.

--- a/builder.go
+++ b/builder.go
@@ -483,6 +483,21 @@ func (b *DBBuilder) Build(ctx context.Context) (*DBBuilder, error) {
 	return b, nil
 }
 
+// SkippedRows reports what WithMalformedRowPolicy(MalformedRowSkip) discarded
+// during the loads this builder has performed, one entry per table that lost
+// rows. A load that dropped nothing is not listed, so a non-empty result is
+// always something worth telling a user about.
+//
+// Skipping is an instruction from the caller, but an instruction that reports
+// nothing leaves one dropped row and most of the file dropped looking exactly
+// alike — and a write-back afterwards makes either one permanent. The counts
+// are what lets a caller say which of the two happened before that.
+//
+// It is valid after Open, OpenContext, LoadInto, or LoadIntoTx have run.
+func (b *DBBuilder) SkippedRows() []SkippedRows {
+	return b.streamProcessor.skippedRows()
+}
+
 // Open creates and returns a database connection using the configured and validated inputs.
 // This method can only be called after Build() has been successfully executed.
 // It creates an in-memory SQLite database and loads all configured files as tables using streaming.

--- a/file.go
+++ b/file.go
@@ -136,6 +136,13 @@ type streamingParser struct {
 	// excelSheetPolicy controls which sheets of a workbook this parser may take
 	// its table from. The zero value is ExcelSheetPolicyAll.
 	excelSheetPolicy ExcelSheetPolicy
+	// skippedRows and totalRows record what MalformedRowSkip discarded and how
+	// many data rows it was choosing from, so a caller can say how much of the
+	// file it is holding. Skipping is an instruction, and an instruction that
+	// reports nothing leaves one dropped row and most of the file dropped
+	// looking the same.
+	skippedRows int
+	totalRows   int
 }
 
 // newFile creates a new file

--- a/malformed_row_test.go
+++ b/malformed_row_test.go
@@ -44,6 +44,67 @@ func openWithPolicy(t *testing.T, content string, ft FileType, policy MalformedR
 	return b.Open(context.Background())
 }
 
+// TestSkippedRowsReportsWhatWasDropped covers what a caller has to be able to
+// say after MalformedRowSkip has done its work. Skipping is an instruction, not
+// a silence: an import that dropped one row and one that dropped most of the
+// file looked identical, and there was no number a caller could put in front of
+// a user before a write-back made the loss permanent.
+func TestSkippedRowsReportsWhatWasDropped(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a skipping import counts the rows it dropped", func(t *testing.T) {
+		t.Parallel()
+
+		b, err := NewBuilder().
+			AddReader(strings.NewReader("a,b\n1,2\n3\n5,6\n7\n"), "t", FileTypeCSV).
+			WithMalformedRowPolicy(MalformedRowSkip).
+			Build(context.Background())
+		if err != nil {
+			t.Fatalf("build failed: %v", err)
+		}
+		db, err := b.Open(context.Background())
+		if err != nil {
+			t.Fatalf("open failed: %v", err)
+		}
+		defer db.Close()
+
+		got := b.SkippedRows()
+		if len(got) != 1 {
+			t.Fatalf("SkippedRows() = %v, want one entry", got)
+		}
+		if got[0].Table != "t" {
+			t.Errorf("Table = %q, want %q", got[0].Table, "t")
+		}
+		if got[0].Count != 2 {
+			t.Errorf("Count = %d, want 2 (rows 2 and 4 are short)", got[0].Count)
+		}
+		if got[0].Total != 4 {
+			t.Errorf("Total = %d, want 4 data rows seen", got[0].Total)
+		}
+	})
+
+	t.Run("an import that dropped nothing reports nothing", func(t *testing.T) {
+		t.Parallel()
+
+		b, err := NewBuilder().
+			AddReader(strings.NewReader("a,b\n1,2\n3,4\n"), "t", FileTypeCSV).
+			WithMalformedRowPolicy(MalformedRowSkip).
+			Build(context.Background())
+		if err != nil {
+			t.Fatalf("build failed: %v", err)
+		}
+		db, err := b.Open(context.Background())
+		if err != nil {
+			t.Fatalf("open failed: %v", err)
+		}
+		defer db.Close()
+
+		if got := b.SkippedRows(); len(got) != 0 {
+			t.Errorf("SkippedRows() = %v, want none: a clean import has nothing to report", got)
+		}
+	})
+}
+
 func TestMalformedRowPolicy_Stop(t *testing.T) {
 	t.Parallel()
 

--- a/stream.go
+++ b/stream.go
@@ -116,11 +116,13 @@ func (p *streamingParser) parseDelimitedStream(reader io.Reader, delimiter rune,
 
 	tablerecords := make([]record, 0, len(records)-1)
 	for i := 1; i < len(records); i++ {
+		p.totalRows++
 		record, skip, err := reconcileFieldCount(records[i], len(header), i, p.malformedRowPolicy)
 		if err != nil {
 			return nil, err
 		}
 		if skip {
+			p.skippedRows++
 			continue
 		}
 		tablerecords = append(tablerecords, newRecord(record))
@@ -332,11 +334,13 @@ func (p *streamingParser) processDelimitedInChunks(reader io.Reader, processor c
 		}
 		rowNum++
 
+		p.totalRows++
 		record, skip, err := reconcileFieldCount(record, len(header), rowNum, p.malformedRowPolicy)
 		if err != nil {
 			return err
 		}
 		if skip {
+			p.skippedRows++
 			continue
 		}
 

--- a/stream_processor.go
+++ b/stream_processor.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/xuri/excelize/v2"
 )
@@ -35,6 +36,42 @@ type streamProcessor struct {
 	// excelSheetPolicy controls which sheets of a workbook are loaded. The zero
 	// value is ExcelSheetPolicyAll.
 	excelSheetPolicy ExcelSheetPolicy
+	// skipped records what MalformedRowSkip discarded, per table, so a caller
+	// can report it. Loads run one file at a time here, but a builder can hold
+	// several, so the mutex covers a future that runs them together.
+	skippedMu sync.Mutex
+	skipped   []SkippedRows
+}
+
+// SkippedRows is how much of one table's input the malformed-row policy
+// discarded.
+type SkippedRows struct {
+	// Table is the table the rows would have gone into.
+	Table string
+	// Count is how many data rows were dropped.
+	Count int
+	// Total is how many data rows the input held, dropped ones included, so a
+	// caller can say "2 of 4" rather than a bare number.
+	Total int
+}
+
+// recordSkippedRows keeps what one load discarded. Nothing is recorded for a
+// load that dropped nothing, so a caller can treat a non-empty result as
+// something worth telling the user about.
+func (sp *streamProcessor) recordSkippedRows(table string, count, total int) {
+	if count == 0 {
+		return
+	}
+	sp.skippedMu.Lock()
+	defer sp.skippedMu.Unlock()
+	sp.skipped = append(sp.skipped, SkippedRows{Table: table, Count: count, Total: total})
+}
+
+// skippedRows returns what the loads so far discarded.
+func (sp *streamProcessor) skippedRows() []SkippedRows {
+	sp.skippedMu.Lock()
+	defer sp.skippedMu.Unlock()
+	return append([]SkippedRows(nil), sp.skipped...)
 }
 
 // dropIfReplacing drops a same-named table when replaceExisting is set, so the
@@ -284,6 +321,9 @@ func (sp *streamProcessor) streamReaderToDatabase(ctx context.Context, db DBTX, 
 	parser := newStreamingParser(input.fileType, input.compression, input.tableName, sp.chunkSize)
 	parser.malformedRowPolicy = sp.malformedRowPolicy
 	parser.excelSheetPolicy = sp.excelSheetPolicy
+	// What the malformed-row policy dropped is worth saying even when the load
+	// itself succeeded, so it is collected however this function returns.
+	defer func() { sp.recordSkippedRows(input.tableName, parser.skippedRows, parser.totalRows) }()
 
 	// Initialize the table schema (we need to peek at the first chunk to get headers)
 	var tableCreated bool


### PR DESCRIPTION
`MalformedRowSkip` is something a caller asks for, so dropping a ragged row is not a failure. Saying nothing about it is. An import that dropped one row and one that dropped ninety percent of the file produced exactly the same output, and the row count that comes out the other end only means something to someone who already knew what went in. Whatever the caller does next — and for sqly that is a write-back over the source file — makes the loss permanent without either side having had a number to look at.

`DBBuilder.SkippedRows` returns one entry per table that lost rows:

```go
type SkippedRows struct {
	Table string // the table the rows would have gone into
	Count int    // how many data rows were dropped
	Total int    // how many the input held, dropped ones included
}
```

`Total` is there so a caller can say "skipped 2 of 4 data rows" rather than a bare number, which is the difference between a note and a warning. A load that dropped nothing is not listed at all, so a non-empty result is always something worth putting in front of a user, and a caller needs no threshold logic of its own.

The counting sits at the two places `reconcileFieldCount` already decides, so no extra pass over the data happens and the cost is two increments per row. The processor collects per table behind a mutex — loads run one file at a time today, but a builder holds several inputs and that is not a property worth depending on.

Valid after `Open`, `OpenContext`, `LoadInto`, or `LoadIntoTx`. Filed for nao1215/sqly#886, where `--row-mismatch skip` needs to tell the user what it dropped before `.save --in-place` writes the smaller file back over the source.