### PR TITLE
chore: release v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.39.0] - 2026-08-08
 
 ### Added
 


### PR DESCRIPTION
Stamps the four changes merged since v0.38.0 as v0.39.0.

The minor component moves because of the added API: `DBBuilder.SkippedRows`, which reports what `MalformedRowSkip` discarded so a caller can say how much of the file it is holding.

The rest are fixes. Type inference no longer lets a sampled decision damage a value it never saw — a zero-padded code or an int64-overflowing literal past the first chunk was rewritten by SQLite affinity (#255). ACH and Fedwire write-back refuses a value too wide for its fixed-width record instead of cutting it to fit (#257). The duplicate-header guard folds case, so `ID,id` fails as `ErrDuplicateColumn` rather than as SQLite refusal three wraps deep (#258). And the README now states what column-type inference does not preserve, decimal spelling above all (#256).