### PR TITLE
fix: fold ASCII case only, and keep the two header comparisons apart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The duplicate-header check folds ASCII case only, and keeps its two comparisons apart. v0.39.0 folded with `strings.ToLower` over a trimmed name, which refused two headers SQLite accepts: `ä` beside `Ä`, whose case SQLite does not fold, and `" A"` beside `"a"`, which differ by whitespace and by case at once so that neither rule matches on its own. A name is now compared with surrounding whitespace removed, and again with ASCII case ignored, as two separate questions — the rule the export side of nao1215/sqly was written against, and the one SQLite itself applies.
+
 ## [0.39.0] - 2026-08-08
 
 ### Added

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -456,18 +456,62 @@ func TestDuplicateColumnCheckIsTheSameEverywhere(t *testing.T) {
 		requireDuplicateColumnRefusal(t, err, `"nAmE"`, "column 2")
 	})
 
-	// Case and whitespace are one rule, not two applied in sequence by luck.
-	t.Run("csv rejects names that differ only by case and whitespace", func(t *testing.T) {
+	// Whitespace and case are two rules, and a name that differs by both
+	// satisfies neither: SQLite does not trim, so " NAME " and "name" are two
+	// columns to it, and an import that refused them would refuse a header the
+	// engine accepts.
+	t.Run("csv keeps names that differ by case and whitespace at once", func(t *testing.T) {
 		t.Parallel()
 
-		path := filepath.Join(t.TempDir(), "both.csv")
+		path := filepath.Join(t.TempDir(), "cased_spaced.csv")
 		require.NoError(t, os.WriteFile(path, []byte("name, NAME \n1,2\n"), 0o600))
 
 		db, err := OpenContext(context.Background(), path)
-		if db != nil {
-			defer db.Close()
-		}
-		requireDuplicateColumnRefusal(t, err, `" NAME "`, "column 2")
+		require.NoError(t, err)
+		defer db.Close()
+
+		var got string
+		require.NoError(t, db.QueryRowContext(context.Background(),
+			`SELECT "name" FROM cased_spaced`).Scan(&got))
+		assert.Equal(t, "1", got)
+	})
+
+	// The case rule is SQLite's, and SQLite's folding stops at ASCII: "ä" and
+	// "Ä" are two columns to it. Folding with strings.ToLower made them one and
+	// refused a header the engine accepts.
+	t.Run("csv keeps names that differ by non-ASCII case", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "accents.csv")
+		require.NoError(t, os.WriteFile(path, []byte("ä,Ä\n1,2\n"), 0o600))
+
+		db, err := OpenContext(context.Background(), path)
+		require.NoError(t, err, "SQLite tells these two apart, so the import must too")
+		defer db.Close()
+
+		var got string
+		require.NoError(t, db.QueryRowContext(context.Background(),
+			`SELECT "Ä" FROM accents`).Scan(&got))
+		assert.Equal(t, "2", got)
+	})
+
+	// The two comparisons are separate, not one folded-and-trimmed key. " A"
+	// and "a" differ by whitespace and by case, so neither rule matches on its
+	// own — and SQLite, which does not trim, keeps them as two columns.
+	t.Run("csv keeps names that differ by whitespace and case together", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "both.csv")
+		require.NoError(t, os.WriteFile(path, []byte(" A,a\n1,2\n"), 0o600))
+
+		db, err := OpenContext(context.Background(), path)
+		require.NoError(t, err, "neither the whitespace rule nor the case rule matches this pair")
+		defer db.Close()
+
+		var got string
+		require.NoError(t, db.QueryRowContext(context.Background(),
+			`SELECT "a" FROM both`).Scan(&got))
+		assert.Equal(t, "2", got)
 	})
 
 	// Names that are distinct after trimming stay distinct, so the rule refuses

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -857,13 +857,36 @@ func parseLTSV(reader io.Reader) (*TableData, error) {
 // same errors and only the comparison is meant to differ; the quoting and
 // position filesql adds are added where filesql builds its own message.
 func validateColumnNames(columns []string) error {
-	seen := make(map[string]bool, len(columns))
+	trimmed := make(map[string]bool, len(columns))
+	folded := make(map[string]bool, len(columns))
 	for _, col := range columns {
-		key := strings.ToLower(strings.TrimSpace(col))
-		if seen[key] {
+		trimmedName := strings.TrimSpace(col)
+		foldedName := asciiFold(col)
+		if trimmed[trimmedName] || folded[foldedName] {
 			return fmt.Errorf("duplicate column name: %s", col)
 		}
-		seen[key] = true
+		trimmed[trimmedName] = true
+		folded[foldedName] = true
 	}
 	return nil
+}
+
+// asciiFold lowercases the ASCII letters in s, which is how SQLite compares two
+// column names: its folding stops at ASCII, so "ä" and "Ä" stay two names.
+func asciiFold(s string) string {
+	var folded []byte
+	for i := range len(s) {
+		c := s[i]
+		if c < 'A' || c > 'Z' {
+			continue
+		}
+		if folded == nil {
+			folded = []byte(s)
+		}
+		folded[i] = c + ('a' - 'A')
+	}
+	if folded == nil {
+		return s
+	}
+	return string(folded)
 }

--- a/types.go
+++ b/types.go
@@ -176,30 +176,53 @@ func (ct columnType) String() string {
 // The message quotes the name and gives its 1-based position, because a header
 // can duplicate the empty name — two unnamed columns — and an unquoted empty
 // name printed nothing at all after the colon.
+// Two names are the same column if either comparison says so, and the two are
+// kept apart rather than combined into one key. Whitespace is filesql's own
+// rule — " name " and "name" are one name typed twice — while case is SQLite's,
+// because SQLite is what ends up holding the columns. Folding a trimmed name
+// would apply both at once and refuse " A" beside "a", which neither rule
+// refuses on its own and which SQLite keeps as two columns.
 func validateColumnNames(columns []string) error {
-	columnsSeen := make(map[string]bool)
+	trimmed := make(map[string]bool, len(columns))
+	folded := make(map[string]bool, len(columns))
 	for i, col := range columns {
-		key := columnNameKey(col)
-		if columnsSeen[key] {
+		trimmedName := strings.TrimSpace(col)
+		foldedName := asciiFold(col)
+		if trimmed[trimmedName] || folded[foldedName] {
 			return fmt.Errorf("%w: %q (column %d)", errDuplicateColumnName, col, i+1)
 		}
-		columnsSeen[key] = true
+		trimmed[trimmedName] = true
+		folded[foldedName] = true
 	}
 	return nil
 }
 
-// columnNameKey reduces a header cell to what decides whether two of them are
-// the same column: surrounding whitespace is not part of the name, and neither
-// is case.
+// asciiFold lowercases the ASCII letters in s and leaves every other byte as it
+// is, which is how SQLite compares two column names: its default case folding
+// stops at ASCII, so "ä" and "Ä" stay two names. Folding with strings.ToLower
+// would make them one and refuse a header SQLite accepts.
 //
-// Case is folded because SQLite is what ends up holding these columns and it
-// compares their names without regard to it. Keeping the comparison
-// case-sensitive here did not make "ID" and "id" two columns; it only moved the
-// refusal to SQLite, which reported it as a failed CREATE TABLE wrapped in a
-// database-operation error — no ErrDuplicateColumn to match, and no column
-// position — which is the outcome this check exists to replace.
-func columnNameKey(column string) string {
-	return strings.ToLower(strings.TrimSpace(column))
+// Case has to be folded somewhere, because leaving it out did not make "ID" and
+// "id" two columns: it moved the refusal to SQLite, which reported it as a
+// failed CREATE TABLE wrapped in a database-operation error — no
+// ErrDuplicateColumn to match and no column position, which is the outcome this
+// check exists to replace.
+func asciiFold(s string) string {
+	var folded []byte
+	for i := range len(s) {
+		c := s[i]
+		if c < 'A' || c > 'Z' {
+			continue
+		}
+		if folded == nil {
+			folded = []byte(s)
+		}
+		folded[i] = c + ('a' - 'A')
+	}
+	if folded == nil {
+		return s
+	}
+	return string(folded)
 }
 
 // chunkSizeValue represents a chunk size with validation. The name carries the


### PR DESCRIPTION
v0.39.0 gave the duplicate-header guard a single key — the name trimmed and then lowercased — and that refuses two headers SQLite accepts.

SQLite folds ASCII case only, so `ä` and `Ä` are two columns to it; `strings.ToLower` made them one. And trimming before folding asks both questions at once, so `" A"` beside `"a"` was refused even though neither rule catches it alone — SQLite does not trim, so it keeps those as two columns too.

The two comparisons are separate again: a name is compared with surrounding whitespace removed, and again with ASCII case ignored. That is the rule the export guard in nao1215/sqly was written against — it fails a header it could not read back — and the one the engine applies, so import and export agree on what a duplicate is.

Caught by sqly round-trip smoke test, which writes a header out and reads it back: the export permitted both pairs and the import refused them, on csv, tsv, and xlsx alike. The tests here now pin the two accepting cases beside the refusing ones.