### PR TITLE
chore: release v0.39.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.39.1] - 2026-08-08
 
 ### Fixed
 


### PR DESCRIPTION
Stamps the duplicate-header fold fix as v0.39.1. Patch only: v0.39.0 refused two headers SQLite accepts, and this restores the rule the export side of sqly is written against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to mark version 0.39.1 as released on August 8, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->