### PR TITLE
fix: read a CR-terminated CSV, TSV, or LTSV as lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A CSV, TSV, or LTSV whose lines end with a lone carriage return now imports its rows instead of loading empty ([#279](https://github.com/nao1215/filesql/issues/279)). The CSV and LTSV readers understand LF and CRLF, so a file written with the classic Mac OS 9 convention was one very long line: the data was folded into the column names and the table came out with zero rows, at no error. The line ending is now decided from the first 64 KiB of the file: only a file whose window holds a carriage return outside quotes and no line feed at all has its carriage returns read as line breaks, and only carriage returns outside quotes are translated, so a quoted one stays data in either kind of file. A first record longer than that window is left as it is rather than guessed at.
+- A CSV, TSV, or LTSV whose lines end with a lone carriage return now imports its rows instead of loading empty ([#279](https://github.com/nao1215/filesql/issues/279)). The CSV and LTSV readers understand LF and CRLF, so a file written with the classic Mac OS 9 convention was one very long line: the data was folded into the column names and the table came out with zero rows, at no error. The line ending is now decided from the first 64 KiB of the file, counting only what sits outside quotes: a file is read this way when that window holds a carriage return outside quotes and no line feed outside them, and only carriage returns outside quotes are translated, so a quoted one stays data in either kind of file. A first record longer than that window is left as it is rather than guessed at.
 
 ## [0.39.1] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A CSV, TSV, or LTSV whose lines end with a lone carriage return now imports its rows instead of loading empty ([#279](https://github.com/nao1215/filesql/issues/279)). The CSV and LTSV readers understand LF and CRLF, so a file written with the classic Mac OS 9 convention was one very long line: the data was folded into the column names and the table came out with zero rows, at no error. The line ending is now decided from the start of the file, and only a file that holds a carriage return and no line feed at all has its carriage returns read as line breaks — a carriage return inside a quoted field stays data, because a file that uses LF shows a line feed within that first 64 KiB.
+- A CSV, TSV, or LTSV whose lines end with a lone carriage return now imports its rows instead of loading empty ([#279](https://github.com/nao1215/filesql/issues/279)). The CSV and LTSV readers understand LF and CRLF, so a file written with the classic Mac OS 9 convention was one very long line: the data was folded into the column names and the table came out with zero rows, at no error. The line ending is now decided from the first 64 KiB of the file: only a file whose window holds a carriage return outside quotes and no line feed at all has its carriage returns read as line breaks, and only carriage returns outside quotes are translated, so a quoted one stays data in either kind of file. A first record longer than that window is left as it is rather than guessed at.
 
 ## [0.39.1] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- A CSV, TSV, or LTSV whose lines end with a lone carriage return now imports its rows instead of loading empty ([#279](https://github.com/nao1215/filesql/issues/279)). The CSV and LTSV readers understand LF and CRLF, so a file written with the classic Mac OS 9 convention was one very long line: the data was folded into the column names and the table came out with zero rows, at no error. The line ending is now decided from the start of the file, and only a file that holds a carriage return and no line feed at all has its carriage returns read as line breaks — a carriage return inside a quoted field stays data, because a file that uses LF shows a line feed within that first 64 KiB.
+
 ## [0.39.1] - 2026-08-08
 
 ### Fixed

--- a/parser/line_ending.go
+++ b/parser/line_ending.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"bufio"
-	"bytes"
 	"errors"
 	"io"
 )
@@ -23,12 +22,12 @@ const lineEndingSniffLimit = 64 * 1024
 //
 // The convention is decided from the start of the file rather than by
 // translating every carriage return that appears, because a carriage return
-// inside a quoted field is data. Translation happens only for a file whose first
-// 64 KiB hold a carriage return outside quotes and no line feed at all, and only
-// carriage returns outside quotes are translated, so a quoted one survives in
-// either kind of file. A first record longer than that window is left alone
-// rather than guessed at: reading it as one line is what happens today, while a
-// wrong guess would rewrite data.
+// inside a quoted field is data. Only what sits outside quotes counts, on both
+// sides of the question: a file is read this way when its first 64 KiB hold a
+// carriage return outside quotes and no line feed outside them, and only
+// carriage returns outside quotes are translated. A first record longer than
+// that window is left alone rather than guessed at: reading it as one line is
+// what happens today, while a wrong guess would rewrite data.
 func NormalizeLineEndings(reader io.Reader) io.Reader {
 	return &lineEndingReader{buffered: bufio.NewReaderSize(reader, lineEndingSniffLimit)}
 }
@@ -95,26 +94,32 @@ func (l *lineEndingReader) sniff() {
 // usesCarriageReturnTerminator reports whether window comes from a file that
 // ends its lines with a lone carriage return.
 //
-// Two conditions, because either alone accepts a file it should not. A line feed
-// anywhere says the file already has a terminator this stack understands, so its
-// carriage returns are data. A carriage return inside quotes is data as well,
-// and a record long enough to fill the window can hold one, so the carriage
-// return that decides has to be outside them.
+// Only what sits outside quotes is a terminator; inside them both bytes are
+// data, and a record long enough to fill the window can hold either one. So a
+// quoted line feed does not disqualify a carriage-return file, and a quoted
+// carriage return does not qualify one.
+//
+// Two conditions, because either alone accepts a file it should not. An
+// unquoted line feed says the file already has a terminator this stack
+// understands, which leaves an unquoted carriage return beside it as the stray
+// byte of a malformed row rather than a row boundary. An unquoted carriage
+// return is what says the file has no other terminator to be read by.
 func usesCarriageReturnTerminator(window []byte) bool {
-	if bytes.ContainsRune(window, '\n') {
-		return false
-	}
-
 	inQuotes := false
+	sawCarriageReturn := false
 	for _, c := range window {
 		switch c {
 		case '"':
 			inQuotes = !inQuotes
+		case '\n':
+			if !inQuotes {
+				return false
+			}
 		case '\r':
 			if !inQuotes {
-				return true
+				sawCarriageReturn = true
 			}
 		}
 	}
-	return false
+	return sawCarriageReturn
 }

--- a/parser/line_ending.go
+++ b/parser/line_ending.go
@@ -1,0 +1,81 @@
+package parser
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+)
+
+// lineEndingSniffLimit is how much of a file is inspected to decide whether it
+// ends its lines with a lone carriage return. A file that uses LF has a line
+// feed in its first row, so a window this size always holds the answer; it costs
+// one 64 KiB buffer, which then serves as this reader's read buffer.
+const lineEndingSniffLimit = 64 * 1024
+
+// NormalizeLineEndings wraps reader so a file whose lines end with a lone
+// carriage return is read as lines rather than as one very long line.
+//
+// CSV readers, and everything here that splits on "\n", understand LF and CRLF.
+// A file written with the classic Mac OS 9 convention has neither, so without
+// this the whole file parses as a single line: the data folds into the column
+// names and the table comes out with zero rows, at no error.
+//
+// The convention is decided from the start of the file rather than by
+// translating every carriage return that appears. A carriage return inside a
+// quoted field is data, and a file that uses LF shows a line feed within the
+// first 64 KiB, so translation happens only when that window holds a carriage
+// return and no line feed at all.
+func NormalizeLineEndings(reader io.Reader) io.Reader {
+	return &lineEndingReader{buffered: bufio.NewReaderSize(reader, lineEndingSniffLimit)}
+}
+
+// lineEndingReader translates lone carriage returns to line feeds for a source
+// that uses them as its line terminator.
+type lineEndingReader struct {
+	buffered  *bufio.Reader
+	sniffed   bool
+	translate bool
+	// The error the sniff took, held until the bytes read before it have been
+	// handed on. bufio.Reader.Peek consumes the source's error, so dropping the
+	// peeked result would drop the error too — and a source that rejects its own
+	// input, such as the UTF-8 validator, has no other way to report it.
+	sniffErr error
+}
+
+// Read implements io.Reader, translating carriage returns when the sniff said to
+// and replaying the source's error once the bytes read before it are handed on.
+func (l *lineEndingReader) Read(p []byte) (int, error) {
+	if !l.sniffed {
+		l.sniff()
+	}
+
+	n, err := l.buffered.Read(p)
+	if l.translate {
+		for i := range n {
+			if p[i] == '\r' {
+				p[i] = '\n'
+			}
+		}
+	}
+	if err == nil && l.sniffErr != nil && l.buffered.Buffered() == 0 {
+		err = l.sniffErr
+		l.sniffErr = nil
+	}
+	return n, err
+}
+
+// sniff decides, once, whether this source uses carriage returns as its line
+// terminator, and keeps whatever error the peek took from the source.
+func (l *lineEndingReader) sniff() {
+	l.sniffed = true
+
+	window, err := l.buffered.Peek(lineEndingSniffLimit)
+	// A window shorter than the limit means a file shorter than the limit, which
+	// is an answer rather than a failure: the bytes peeked are the whole file.
+	// Any other error belongs to the source and is replayed by Read.
+	if err != nil && !errors.Is(err, io.EOF) {
+		l.sniffErr = err
+	}
+	l.translate = !bytes.ContainsRune(window, '\n') && bytes.ContainsRune(window, '\r')
+}

--- a/parser/line_ending.go
+++ b/parser/line_ending.go
@@ -22,10 +22,13 @@ const lineEndingSniffLimit = 64 * 1024
 // names and the table comes out with zero rows, at no error.
 //
 // The convention is decided from the start of the file rather than by
-// translating every carriage return that appears. A carriage return inside a
-// quoted field is data, and a file that uses LF shows a line feed within the
-// first 64 KiB, so translation happens only when that window holds a carriage
-// return and no line feed at all.
+// translating every carriage return that appears, because a carriage return
+// inside a quoted field is data. Translation happens only for a file whose first
+// 64 KiB hold a carriage return outside quotes and no line feed at all, and only
+// carriage returns outside quotes are translated, so a quoted one survives in
+// either kind of file. A first record longer than that window is left alone
+// rather than guessed at: reading it as one line is what happens today, while a
+// wrong guess would rewrite data.
 func NormalizeLineEndings(reader io.Reader) io.Reader {
 	return &lineEndingReader{buffered: bufio.NewReaderSize(reader, lineEndingSniffLimit)}
 }
@@ -36,6 +39,10 @@ type lineEndingReader struct {
 	buffered  *bufio.Reader
 	sniffed   bool
 	translate bool
+	// inQuotes tracks whether the byte about to be read sits inside a quoted
+	// field, carried across reads because a field can span them. A doubled quote
+	// leaves and re-enters the field, which lands on the same answer.
+	inQuotes bool
 	// The error the sniff took, held until the bytes read before it have been
 	// handed on. bufio.Reader.Peek consumes the source's error, so dropping the
 	// peeked result would drop the error too — and a source that rejects its own
@@ -53,8 +60,13 @@ func (l *lineEndingReader) Read(p []byte) (int, error) {
 	n, err := l.buffered.Read(p)
 	if l.translate {
 		for i := range n {
-			if p[i] == '\r' {
-				p[i] = '\n'
+			switch p[i] {
+			case '"':
+				l.inQuotes = !l.inQuotes
+			case '\r':
+				if !l.inQuotes {
+					p[i] = '\n'
+				}
 			}
 		}
 	}
@@ -77,5 +89,32 @@ func (l *lineEndingReader) sniff() {
 	if err != nil && !errors.Is(err, io.EOF) {
 		l.sniffErr = err
 	}
-	l.translate = !bytes.ContainsRune(window, '\n') && bytes.ContainsRune(window, '\r')
+	l.translate = usesCarriageReturnTerminator(window)
+}
+
+// usesCarriageReturnTerminator reports whether window comes from a file that
+// ends its lines with a lone carriage return.
+//
+// Two conditions, because either alone accepts a file it should not. A line feed
+// anywhere says the file already has a terminator this stack understands, so its
+// carriage returns are data. A carriage return inside quotes is data as well,
+// and a record long enough to fill the window can hold one, so the carriage
+// return that decides has to be outside them.
+func usesCarriageReturnTerminator(window []byte) bool {
+	if bytes.ContainsRune(window, '\n') {
+		return false
+	}
+
+	inQuotes := false
+	for _, c := range window {
+		switch c {
+		case '"':
+			inQuotes = !inQuotes
+		case '\r':
+			if !inQuotes {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/parser/line_ending_test.go
+++ b/parser/line_ending_test.go
@@ -53,6 +53,16 @@ func TestNormalizeLineEndings(t *testing.T) {
 			input: "a,b\rx,\"y\rz\"\r",
 			want:  "a,b\nx,\"y\rz\"\n",
 		},
+		{
+			name:  "a quoted line feed does not disqualify a CR-terminated file",
+			input: "a,b\rx,\"y\nz\"\r",
+			want:  "a,b\nx,\"y\nz\"\n",
+		},
+		{
+			name:  "a stray carriage return beside a line feed stays data",
+			input: "a,b\nx\r,y\n",
+			want:  "a,b\nx\r,y\n",
+		},
 	}
 
 	for _, tt := range tests {

--- a/parser/line_ending_test.go
+++ b/parser/line_ending_test.go
@@ -48,6 +48,11 @@ func TestNormalizeLineEndings(t *testing.T) {
 			input: "",
 			want:  "",
 		},
+		{
+			name:  "a quoted carriage return survives a CR-terminated file",
+			input: "a,b\rx,\"y\rz\"\r",
+			want:  "a,b\nx,\"y\rz\"\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -90,4 +95,38 @@ func (f *failingReader) Read(p []byte) (int, error) {
 	f.done = true
 	n := copy(p, f.data)
 	return n, f.err
+}
+
+// TestNormalizeLineEndings_OversizedFirstRecord covers the two ways a record
+// longer than the sniff window could be misread. Neither may corrupt data: the
+// window is a heuristic, so it decides only what it can see, and what it cannot
+// see is left as it was.
+func TestNormalizeLineEndings_OversizedFirstRecord(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a quoted carriage return in a huge LF record is not a terminator", func(t *testing.T) {
+		t.Parallel()
+
+		// The first line feed sits past the window, and the record holds a quoted
+		// carriage return before it. Translating that one would rewrite the value.
+		input := "name,note\nbig,\"a\rb" + strings.Repeat("x", lineEndingSniffLimit) + "\"\nlast,1\n"
+
+		got, err := io.ReadAll(NormalizeLineEndings(strings.NewReader(input)))
+
+		require.NoError(t, err)
+		assert.Equal(t, input, string(got))
+	})
+
+	t.Run("a record filling the window with no terminator is left alone", func(t *testing.T) {
+		t.Parallel()
+
+		// A quoted carriage return is all the window holds, so there is nothing
+		// that says this file ends its lines with one.
+		input := "\"a\rb" + strings.Repeat("x", lineEndingSniffLimit) + "\"\n"
+
+		got, err := io.ReadAll(NormalizeLineEndings(strings.NewReader(input)))
+
+		require.NoError(t, err)
+		assert.Equal(t, input, string(got))
+	})
 }

--- a/parser/line_ending_test.go
+++ b/parser/line_ending_test.go
@@ -1,0 +1,93 @@
+package parser
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeLineEndings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "a CR-terminated file becomes LF-terminated",
+			input: "a\rb\rc\r",
+			want:  "a\nb\nc\n",
+		},
+		{
+			name:  "an LF-terminated file is untouched",
+			input: "a\nb\nc\n",
+			want:  "a\nb\nc\n",
+		},
+		{
+			name:  "a CRLF-terminated file is untouched",
+			input: "a\r\nb\r\n",
+			want:  "a\r\nb\r\n",
+		},
+		{
+			name:  "a CR is data in a file that has line feeds",
+			input: "a\rb\nc\n",
+			want:  "a\rb\nc\n",
+		},
+		{
+			name:  "a file with no line ending at all is untouched",
+			input: "a,b,c",
+			want:  "a,b,c",
+		},
+		{
+			name:  "an empty file is untouched",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := io.ReadAll(NormalizeLineEndings(strings.NewReader(tt.input)))
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+// The sniff peeks, and Peek consumes the source's error. Losing it would turn a
+// file the UTF-8 validator refused into a successful load.
+func TestNormalizeLineEndings_KeepsSourceError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("source rejected its input")
+	reader := NormalizeLineEndings(&failingReader{data: "name,age\n", err: sentinel})
+
+	_, err := io.ReadAll(reader)
+
+	require.ErrorIs(t, err, sentinel)
+}
+
+// failingReader returns its data together with err, the way a validating reader
+// refuses the chunk it just read.
+type failingReader struct {
+	data string
+	err  error
+	done bool
+}
+
+func (f *failingReader) Read(p []byte) (int, error) {
+	if f.done {
+		return 0, f.err
+	}
+	f.done = true
+	n := copy(p, f.data)
+	return n, f.err
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -729,7 +729,7 @@ func createDecompressedReader(reader io.Reader, fileType FileType) (io.Reader, f
 
 // parseDelimited parses CSV or TSV data.
 func parseDelimited(reader io.Reader, delimiter rune, fileTypeName string) (*TableData, error) {
-	csvReader := csv.NewReader(reader)
+	csvReader := csv.NewReader(NormalizeLineEndings(reader))
 	csvReader.Comma = delimiter
 
 	records, err := csvReader.ReadAll()
@@ -764,7 +764,7 @@ func parseDelimited(reader io.Reader, delimiter rune, fileTypeName string) (*Tab
 // parseLTSV parses LTSV (Labeled Tab-Separated Values) data.
 // Column order is preserved as first-seen order for deterministic output.
 func parseLTSV(reader io.Reader) (*TableData, error) {
-	content, err := io.ReadAll(reader)
+	content, err := io.ReadAll(NormalizeLineEndings(reader))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read LTSV: %w", err)
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -108,6 +108,69 @@ func TestParse_CSV(t *testing.T) {
 	})
 }
 
+func TestParse_CROnlyLineEndings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a CR-terminated CSV keeps its rows", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := Parse(strings.NewReader("name,age\rAlice,30\rBob,40\r"), CSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"name", "age"}, result.Headers)
+		assert.Equal(t, [][]string{{"Alice", "30"}, {"Bob", "40"}}, result.Records)
+	})
+
+	t.Run("a CR-terminated TSV keeps its rows", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := Parse(strings.NewReader("name\tage\rAlice\t30\rBob\t40\r"), TSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"name", "age"}, result.Headers)
+		assert.Equal(t, [][]string{{"Alice", "30"}, {"Bob", "40"}}, result.Records)
+	})
+
+	t.Run("a CR-terminated LTSV keeps its rows", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := Parse(strings.NewReader("name:Alice\tage:30\rname:Bob\tage:40\r"), LTSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"name", "age"}, result.Headers)
+		assert.Equal(t, [][]string{{"Alice", "30"}, {"Bob", "40"}}, result.Records)
+	})
+
+	t.Run("a CR inside a quoted field of an LF file is data, not a row boundary", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := Parse(strings.NewReader("name,note\nAlice,\"a\rb\"\nBob,plain\n"), CSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, [][]string{{"Alice", "a\rb"}, {"Bob", "plain"}}, result.Records)
+	})
+
+	t.Run("a CRLF-terminated CSV keeps its rows", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := Parse(strings.NewReader("name,age\r\nAlice,30\r\nBob,40\r\n"), CSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"name", "age"}, result.Headers)
+		assert.Equal(t, [][]string{{"Alice", "30"}, {"Bob", "40"}}, result.Records)
+	})
+
+	t.Run("a single CR-terminated line is a header with no rows", func(t *testing.T) {
+		t.Parallel()
+
+		result, err := Parse(strings.NewReader("name,age\r"), CSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"name", "age"}, result.Headers)
+		assert.Empty(t, result.Records)
+	})
+}
+
 func TestParse_TSV(t *testing.T) {
 	t.Parallel()
 

--- a/stream.go
+++ b/stream.go
@@ -15,6 +15,7 @@ import (
 	"github.com/apache/arrow/go/v18/arrow/array"
 	pqfile "github.com/apache/arrow/go/v18/parquet/file"
 	"github.com/apache/arrow/go/v18/parquet/pqarrow"
+	"github.com/nao1215/filesql/parser"
 	"github.com/xuri/excelize/v2"
 )
 
@@ -94,7 +95,7 @@ func (p *streamingParser) createDecompressedReader(reader io.Reader) (io.Reader,
 
 // parseDelimitedStream parses CSV or TSV data from reader using streaming approach
 func (p *streamingParser) parseDelimitedStream(reader io.Reader, delimiter rune, fileTypeName string) (*table, error) {
-	csvReader := csv.NewReader(reader)
+	csvReader := csv.NewReader(parser.NormalizeLineEndings(reader))
 	csvReader.Comma = delimiter
 	// Accept a variable field count so a ragged row is handled by the configured
 	// malformed-row policy instead of aborting the whole read.
@@ -175,7 +176,7 @@ func (l *labelOrder) len() int {
 }
 
 func (p *streamingParser) parseLTSVStream(reader io.Reader) (*table, error) {
-	content, err := io.ReadAll(reader)
+	content, err := io.ReadAll(parser.NormalizeLineEndings(reader))
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to read LTSV: %w", ErrParsing, err)
 	}
@@ -290,7 +291,7 @@ func (p *streamingParser) ProcessInChunks(reader io.Reader, processor chunkProce
 
 // processDelimitedInChunks processes CSV or TSV data in chunks based on delimiter
 func (p *streamingParser) processDelimitedInChunks(reader io.Reader, processor chunkProcessor, delimiter rune, fileTypeName string) error {
-	csvReader := csv.NewReader(reader)
+	csvReader := csv.NewReader(parser.NormalizeLineEndings(reader))
 	if delimiter != csvDelimiter {
 		csvReader.Comma = delimiter
 	}
@@ -438,7 +439,7 @@ func (p *streamingParser) processTSVInChunks(reader io.Reader, processor chunkPr
 // processLTSVInChunks processes LTSV data in chunks
 func (p *streamingParser) processLTSVInChunks(reader io.Reader, processor chunkProcessor) error {
 	// For LTSV, we need to read line by line
-	content, err := io.ReadAll(reader)
+	content, err := io.ReadAll(parser.NormalizeLineEndings(reader))
 	if err != nil {
 		return fmt.Errorf("%w: failed to read LTSV: %w", ErrParsing, err)
 	}

--- a/stream_test.go
+++ b/stream_test.go
@@ -117,6 +117,58 @@ func TestStreamingParser_ParseFromReader_LTSV(t *testing.T) {
 	})
 }
 
+func TestStreamingParser_CROnlyLineEndings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a CR-terminated CSV keeps its rows", func(t *testing.T) {
+		t.Parallel()
+
+		p := newStreamingParser(FileTypeCSV, CompressionNone, "users", 1024)
+		table, err := p.parseFromReader(strings.NewReader("name,age\rAlice,30\rBob,40\r"))
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"name", "age"}, []string(table.getHeader()))
+		assert.Len(t, table.getRecords(), 2)
+	})
+
+	t.Run("a CR-terminated LTSV keeps its rows", func(t *testing.T) {
+		t.Parallel()
+
+		p := newStreamingParser(FileTypeLTSV, CompressionNone, "users", 1024)
+		table, err := p.parseFromReader(strings.NewReader("name:Alice\tage:30\rname:Bob\tage:40\r"))
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"name", "age"}, []string(table.getHeader()))
+		assert.Len(t, table.getRecords(), 2)
+	})
+
+	t.Run("a CR-terminated CSV keeps its rows when read in chunks", func(t *testing.T) {
+		t.Parallel()
+
+		p := newStreamingParser(FileTypeCSV, CompressionNone, "users", 1)
+		rows := 0
+		err := p.ProcessInChunks(strings.NewReader("name,age\rAlice,30\rBob,40\r"), func(chunk *tableChunk) error {
+			rows += len(chunk.records)
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 2, rows)
+	})
+
+	t.Run("a CR inside a quoted field of an LF file is data, not a row boundary", func(t *testing.T) {
+		t.Parallel()
+
+		p := newStreamingParser(FileTypeCSV, CompressionNone, "notes", 1024)
+		table, err := p.parseFromReader(strings.NewReader("name,note\nAlice,\"a\rb\"\nBob,plain\n"))
+
+		require.NoError(t, err)
+		records := table.getRecords()
+		require.Len(t, records, 2)
+		assert.Equal(t, "a\rb", records[0][1])
+	})
+}
+
 func TestStreamingParser_ParseFromReader_Compressed(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
A file whose lines end with a lone carriage return, the classic Mac OS 9 convention, imported as zero data rows with no error. `encoding/csv` and the LTSV readers recognize LF and CRLF but not a bare CR, so the whole file was one logical line: the first "line" became a header whose column names carried the raw carriage returns and the rest of the data, and no data rows were produced. `sqly --inspect cr.csv` reported `cols: ['name', 'age\r alice', '30\r bob', '40'], rows: 0` at exit 0.

`parser.NormalizeLineEndings` wraps the reader and decides the convention from the start of the file rather than translating every carriage return it sees. A carriage return inside a quoted field is data, and a file that uses LF shows a line feed within the first 64 KiB, so translation happens only when that window holds a carriage return and no line feed at all. Translating a CR to LF also handles a hybrid file safely, since `encoding/csv` skips blank lines.

It is applied at all six places a delimited or LTSV source is read: the parser package's `parseDelimited` and `parseLTSV`, and the root package's `parseDelimitedStream`, `processDelimitedInChunks`, `parseLTSVStream` and `processLTSVInChunks`, so both the whole-file and the chunked paths are covered.

One subtlety the tests pin: `bufio.Reader.Peek` consumes the source's error, so the reader holds the error the sniff took and replays it once the bytes read before it have been handed on. Discarding it silently disabled the UTF-8 validator, turning a Shift-JIS file that must be refused into a successful load.

Tests cover CR-terminated CSV, TSV and LTSV through both the parser and the streaming paths, the chunked reader, a CR inside a quoted field of an LF file, CRLF and LF files being unaffected, a header-only CR file, and the preserved source error.

Closes #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - CSV, TSV, and LTSV files using carriage-return-only line endings now import correctly.
  - Streaming and chunked parsing now support these line endings as well.
  - Carriage returns inside quoted CSV fields remain preserved as data.
  - Handling remains correct for LF, CRLF, mixed line endings, empty files, and files without final terminators.
- **Documentation**
  - Added an unreleased changelog entry describing the line-ending compatibility fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->