### PR TITLE
fix: read and write TSV fields literally, without CSV quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `parser.TSVReader` and `parser.WriteTSVRecord` read and write tab-separated records literally, and `parser.ErrTSVUnrepresentable` reports a value the format cannot hold. They are what the TSV fix below is built on, and they are exported because the package is the one that defines what TSV means here.
+
 ### Fixed
 
+- A TSV value containing a double quote imports, and a TSV dump writes it back unchanged ([#268](https://github.com/nao1215/filesql/issues/268)). TSV was read with a CSV reader, which brought CSV's quote handling with it, so a value as ordinary as `5'9" tall` failed the whole import with `bare " in non-quoted-field`. IANA's text/tab-separated-values has no quoting: a field is the bytes between two tabs, and a double quote there is an ordinary character. Both halves now agree on that — the reader splits on tabs and keeps what is between them, and the writer joins with tabs and refuses a value holding a tab or a line break, which the format cannot represent, rather than quoting it into something the reader would hand back with the quotes attached. A blank line in a one-column TSV is that column's empty value, which is how a dump writes it; with more columns it is skipped, as a CSV reader skips it.
 - A CSV, TSV, or LTSV whose lines end with a lone carriage return now imports its rows instead of loading empty ([#279](https://github.com/nao1215/filesql/issues/279)). The CSV and LTSV readers understand LF and CRLF, so a file written with the classic Mac OS 9 convention was one very long line: the data was folded into the column names and the table came out with zero rows, at no error. The line ending is now decided from the first 64 KiB of the file, counting only what sits outside quotes: a file is read this way when that window holds a carriage return outside quotes and no line feed outside them, and only carriage returns outside quotes are translated, so a quoted one stays data in either kind of file. A first record longer than that window is left as it is rather than guessed at.
 
 ## [0.39.1] - 2026-08-08

--- a/dump_lone_empty_test.go
+++ b/dump_lone_empty_test.go
@@ -12,12 +12,16 @@ import (
 // TestDumpLoneEmptyField pins that a row whose only column is empty survives a
 // dump and a reload.
 //
-// In CSV and TSV a record of one empty field, written plainly, is a blank line,
-// and a blank line is not a record — a reader skips it. A one-column table of
-// five rows, two of them empty, came back with three: the rows were gone and the
-// dump reported success. Quoting the field says "one field, empty" and cannot be
-// read as anything else. A record of several columns is unaffected, because the
+// In CSV a record of one empty field, written plainly, is a blank line, and a
+// blank line is not a record — a reader skips it. A one-column table of five
+// rows, two of them empty, came back with three: the rows were gone and the dump
+// reported success. Quoting the field says "one field, empty" and cannot be read
+// as anything else. A record of several columns is unaffected, because the
 // delimiters already say how many fields there are.
+//
+// TSV has no quoting to say that with, so the two halves agree the other way:
+// the blank line is the value, and the reader takes it back as that column's
+// empty field.
 func TestDumpLoneEmptyField(t *testing.T) {
 	t.Parallel()
 
@@ -27,7 +31,7 @@ func TestDumpLoneEmptyField(t *testing.T) {
 		want   string
 	}{
 		{name: "csv", format: OutputFormatCSV, want: "v\nalice\n\"\"\nbob\n"},
-		{name: "tsv", format: OutputFormatTSV, want: "v\nalice\n\"\"\nbob\n"},
+		{name: "tsv", format: OutputFormatTSV, want: "v\nalice\n\nbob\n"},
 	}
 
 	for _, tt := range tests {

--- a/dump_roundtrip_test.go
+++ b/dump_roundtrip_test.go
@@ -81,3 +81,48 @@ func TestDumpDatabase_RoundTripPerFormat(t *testing.T) {
 		})
 	}
 }
+
+// TestDumpDatabase_TSVQuoteRoundTrip is the metamorphic half of TSV taking its
+// fields literally: what a dump writes is what a load reads back. A CSV writer
+// would quote a value holding a quote, and the literal reader would hand those
+// quotes back as part of the value.
+func TestDumpDatabase_TSVQuoteRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	stored := []string{`5'9" tall`, `said "hi" loudly`, `"quoted"`, `a""b`, "plain"}
+
+	ctx := t.Context()
+	src := filepath.Join(t.TempDir(), "seed.csv")
+	require.NoError(t, os.WriteFile(src, []byte("a\n1\n"), 0o600))
+
+	db, err := OpenContext(ctx, src)
+	require.NoError(t, err)
+	defer db.Close()
+
+	_, err = db.ExecContext(ctx, "CREATE TABLE notes (v TEXT)")
+	require.NoError(t, err)
+	for _, v := range stored {
+		_, err = db.ExecContext(ctx, "INSERT INTO notes VALUES (?)", v)
+		require.NoError(t, err)
+	}
+
+	outDir := t.TempDir()
+	require.NoError(t, DumpDatabase(db, outDir, NewDumpOptions().WithFormat(OutputFormatTSV)))
+
+	reloaded, err := OpenContext(ctx, filepath.Join(outDir, "notes.tsv"))
+	require.NoError(t, err)
+	defer reloaded.Close()
+
+	rows, err := reloaded.QueryContext(ctx, "SELECT v FROM notes")
+	require.NoError(t, err)
+	defer rows.Close()
+	got := make([]string, 0, len(stored))
+	for rows.Next() {
+		var v string
+		require.NoError(t, rows.Scan(&v))
+		got = append(got, v)
+	}
+	require.NoError(t, rows.Err())
+
+	assert.Equal(t, stored, got)
+}

--- a/filesql.go
+++ b/filesql.go
@@ -16,6 +16,7 @@ import (
 	"github.com/apache/arrow/go/v18/arrow/array"
 	"github.com/apache/arrow/go/v18/arrow/memory"
 	"github.com/apache/arrow/go/v18/parquet/pqarrow"
+	"github.com/nao1215/filesql/parser"
 	"github.com/xuri/excelize/v2"
 )
 
@@ -553,9 +554,9 @@ func createCompressedWriter(w io.Writer, compression CompressionType) (io.Writer
 	return handler.CreateWriter(w)
 }
 
-// loneEmptyField is what a record of one empty field is written as.
+// loneEmptyField is what a CSV record of one empty field is written as.
 //
-// Written plainly it is a blank line, and a blank line is not a record: a reader
+// Written plainly it is a blank line, and a blank line is not a CSV record: a reader
 // skips it, so a one-column table's empty rows disappeared and the dump reported
 // success. The quotes say "one field, and it is empty", which cannot be read as
 // anything else. encoding/csv's writer does not quote an empty field — it has no
@@ -573,6 +574,11 @@ func writeDelimitedData(writer io.Writer, columns []string, rows *sql.Rows, deli
 	// writeRecord writes one record, taking the lone empty field around the csv
 	// writer. Flushing first keeps the two writers' output in order.
 	writeRecord := func(record []string) error {
+		// TSV is written literally; see parser.WriteTSVRecord. A blank line is
+		// already the one-column empty value there, so it needs no form of its own.
+		if delimiter == tsvDelimiter {
+			return parser.WriteTSVRecord(writer, record)
+		}
 		if len(record) != 1 || record[0] != "" {
 			return csvWriter.Write(record)
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -727,12 +727,19 @@ func createDecompressedReader(reader io.Reader, fileType FileType) (io.Reader, f
 	}
 }
 
-// parseDelimited parses CSV or TSV data.
+// parseDelimited parses CSV or TSV data. TSV is read literally; see TSVReader.
 func parseDelimited(reader io.Reader, delimiter rune, fileTypeName string) (*TableData, error) {
-	csvReader := csv.NewReader(NormalizeLineEndings(reader))
-	csvReader.Comma = delimiter
+	normalized := NormalizeLineEndings(reader)
 
-	records, err := csvReader.ReadAll()
+	var records [][]string
+	var err error
+	if delimiter == '\t' {
+		records, err = NewTSVReader(normalized).ReadAll()
+	} else {
+		csvReader := csv.NewReader(normalized)
+		csvReader.Comma = delimiter
+		records, err = csvReader.ReadAll()
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to read %s: %w", fileTypeName, err)
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -189,6 +189,129 @@ func TestParse_TSV(t *testing.T) {
 	})
 }
 
+func TestParse_TSVTakesFieldsLiterally(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a quote is data, not a quote character", func(t *testing.T) {
+		t.Parallel()
+
+		input := "name\tnote\nalice\t5'9\" tall\nbob\tsaid \"hi\" loudly\n"
+
+		result, err := Parse(strings.NewReader(input), TSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"name", "note"}, result.Headers)
+		assert.Equal(t, [][]string{
+			{"alice", `5'9" tall`},
+			{"bob", `said "hi" loudly`},
+		}, result.Records)
+	})
+
+	t.Run("a field that begins and ends with a quote keeps both", func(t *testing.T) {
+		t.Parallel()
+
+		input := "name\tnote\nalice\t\"quoted\"\n"
+
+		result, err := Parse(strings.NewReader(input), TSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, [][]string{{"alice", `"quoted"`}}, result.Records)
+	})
+
+	t.Run("a doubled quote is two characters", func(t *testing.T) {
+		t.Parallel()
+
+		input := "v\na\"\"b\n"
+
+		result, err := Parse(strings.NewReader(input), TSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, [][]string{{`a""b`}}, result.Records)
+	})
+
+	t.Run("a blank line is the empty value of a one-column file", func(t *testing.T) {
+		t.Parallel()
+
+		input := "v\nalice\n\nbob\n"
+
+		result, err := Parse(strings.NewReader(input), TSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, [][]string{{"alice"}, {""}, {"bob"}}, result.Records)
+	})
+
+	t.Run("a blank line between multi-column records is skipped", func(t *testing.T) {
+		t.Parallel()
+
+		input := "a\tb\n1\t2\n\n3\t4\n"
+
+		result, err := Parse(strings.NewReader(input), TSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, [][]string{{"1", "2"}, {"3", "4"}}, result.Records)
+	})
+
+	t.Run("CRLF line endings are stripped, not kept as data", func(t *testing.T) {
+		t.Parallel()
+
+		input := "a\tb\r\n1\t2\r\n"
+
+		result, err := Parse(strings.NewReader(input), TSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a", "b"}, result.Headers)
+		assert.Equal(t, [][]string{{"1", "2"}}, result.Records)
+	})
+
+	t.Run("CSV still reads a quoted field as one field", func(t *testing.T) {
+		t.Parallel()
+
+		input := "name,note\nalice,\"a,b\"\n"
+
+		result, err := Parse(strings.NewReader(input), CSV)
+
+		require.NoError(t, err)
+		assert.Equal(t, [][]string{{"alice", "a,b"}}, result.Records)
+	})
+}
+
+func TestWriteTSVRecord(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a quote is written as is", func(t *testing.T) {
+		t.Parallel()
+
+		var out strings.Builder
+		require.NoError(t, WriteTSVRecord(&out, []string{"alice", `5'9" tall`}))
+		assert.Equal(t, "alice\t5'9\" tall\n", out.String())
+	})
+
+	t.Run("a value round trips through the reader", func(t *testing.T) {
+		t.Parallel()
+
+		record := []string{`said "hi"`, `a""b`, "", "plain"}
+
+		var out strings.Builder
+		require.NoError(t, WriteTSVRecord(&out, record))
+		got, err := NewTSVReader(strings.NewReader(out.String())).ReadAll()
+
+		require.NoError(t, err)
+		assert.Equal(t, [][]string{record}, got)
+	})
+
+	t.Run("a value the format cannot hold is refused", func(t *testing.T) {
+		t.Parallel()
+
+		for _, field := range []string{"a\tb", "a\nb", "a\rb"} {
+			var out strings.Builder
+			err := WriteTSVRecord(&out, []string{field})
+
+			require.ErrorIs(t, err, ErrTSVUnrepresentable, "field %q", field)
+			assert.Empty(t, out.String(), "nothing is written for a refused record")
+		}
+	})
+}
+
 func TestParse_LTSV(t *testing.T) {
 	t.Parallel()
 

--- a/parser/tsv.go
+++ b/parser/tsv.go
@@ -1,0 +1,101 @@
+package parser
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ErrTSVUnrepresentable reports a value that tab-separated values cannot hold:
+// one containing a tab, which is the delimiter, or a line break, which ends the
+// record. There is no escape for either.
+var ErrTSVUnrepresentable = errors.New("value cannot be represented in TSV")
+
+// TSVReader reads tab-separated records, taking every field literally.
+//
+// TSV has no quoting. IANA's text/tab-separated-values says a field is the bytes
+// between two tabs, so a double quote in one is an ordinary character. Reading
+// TSV with a CSV reader brings CSV's quote handling with it: a value as plain as
+// 5'9" tall fails the whole import with `bare " in non-quoted-field`.
+type TSVReader struct {
+	scanner *bufio.Scanner
+	// fields is the field count of the first record, which decides what a blank
+	// line means. See Read.
+	fields int
+	read   bool
+}
+
+// maxTSVRecordSize caps one record, so a file that is not TSV at all cannot ask
+// for unbounded memory one line at a time.
+const maxTSVRecordSize = 64 * 1024 * 1024
+
+// NewTSVReader returns a reader over the tab-separated records in r.
+func NewTSVReader(r io.Reader) *TSVReader {
+	scanner := bufio.NewScanner(r)
+	// A record is a line, and a line can be as long as the data in it. The
+	// default 64 KiB limit would fail the whole read on a file whose rows are
+	// wider than that.
+	scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), maxTSVRecordSize)
+	return &TSVReader{scanner: scanner}
+}
+
+// Read returns the next record, or io.EOF when there are none left.
+//
+// A blank line is a record only in a one-column file, where it is that column's
+// empty value. With more columns it cannot be a record of that shape, so it is
+// skipped, as a CSV reader skips it.
+func (t *TSVReader) Read() ([]string, error) {
+	for t.scanner.Scan() {
+		line := strings.TrimSuffix(t.scanner.Text(), "\r")
+		if line == "" && t.read && t.fields > 1 {
+			continue
+		}
+
+		record := strings.Split(line, "\t")
+		if !t.read {
+			t.fields = len(record)
+			t.read = true
+		}
+		return record, nil
+	}
+
+	if err := t.scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read TSV record: %w", err)
+	}
+	return nil, io.EOF
+}
+
+// ReadAll returns every remaining record.
+func (t *TSVReader) ReadAll() ([][]string, error) {
+	var records [][]string
+	for {
+		record, err := t.Read()
+		if errors.Is(err, io.EOF) {
+			return records, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+}
+
+// WriteTSVRecord writes one record as a line of tab-separated fields, and
+// reports a field the format cannot hold rather than writing something else.
+//
+// A CSV writer would quote such a field instead, and to this reader a quote is
+// data, so what came back would carry the quotes the writer added.
+func WriteTSVRecord(w io.Writer, record []string) error {
+	for _, field := range record {
+		if i := strings.IndexAny(field, "\t\n\r"); i >= 0 {
+			return fmt.Errorf("%w: field %q contains %q", ErrTSVUnrepresentable, field, field[i:i+1])
+		}
+	}
+
+	if _, err := io.WriteString(w, strings.Join(record, "\t")+"\n"); err != nil {
+		return fmt.Errorf("failed to write TSV record: %w", err)
+	}
+	return nil
+}

--- a/prep/processor.go
+++ b/prep/processor.go
@@ -549,23 +549,18 @@ func (p *Processor) writeCSV(w io.Writer, headers []string, records [][]string) 
 	return csvWriter.Error()
 }
 
-// writeTSV writes data in TSV format
+// writeTSV writes data in TSV format, literally; see parser.WriteTSVRecord.
 func (p *Processor) writeTSV(w io.Writer, headers []string, records [][]string) error {
-	csvWriter := csv.NewWriter(w)
-	csvWriter.Comma = '\t'
-
-	if err := csvWriter.Write(headers); err != nil {
+	if err := parser.WriteTSVRecord(w, headers); err != nil {
 		return err
 	}
 
 	for _, record := range records {
-		if err := csvWriter.Write(record); err != nil {
+		if err := parser.WriteTSVRecord(w, record); err != nil {
 			return err
 		}
 	}
-
-	csvWriter.Flush()
-	return csvWriter.Error()
+	return nil
 }
 
 // writeLTSV writes data in LTSV format

--- a/stream.go
+++ b/stream.go
@@ -93,14 +93,33 @@ func (p *streamingParser) createDecompressedReader(reader io.Reader) (io.Reader,
 	return NewCompressionHandler(p.compression).CreateReader(reader)
 }
 
-// parseDelimitedStream parses CSV or TSV data from reader using streaming approach
-func (p *streamingParser) parseDelimitedStream(reader io.Reader, delimiter rune, fileTypeName string) (*table, error) {
-	csvReader := csv.NewReader(parser.NormalizeLineEndings(reader))
+// delimitedReader reads the records of a delimited file. CSV and TSV need
+// different readers because the formats differ on what a quote means: CSV
+// escapes with it, TSV has no escape at all.
+type delimitedReader interface {
+	Read() ([]string, error)
+	ReadAll() ([][]string, error)
+}
+
+// newDelimitedReader picks the reader delimiter names, over normalized line
+// endings so a carriage-return terminated file is read as lines.
+func newDelimitedReader(reader io.Reader, delimiter rune) delimitedReader {
+	normalized := parser.NormalizeLineEndings(reader)
+	if delimiter == tsvDelimiter {
+		return parser.NewTSVReader(normalized)
+	}
+
+	csvReader := csv.NewReader(normalized)
 	csvReader.Comma = delimiter
 	// Accept a variable field count so a ragged row is handled by the configured
 	// malformed-row policy instead of aborting the whole read.
 	csvReader.FieldsPerRecord = -1
-	records, err := csvReader.ReadAll()
+	return csvReader
+}
+
+// parseDelimitedStream parses CSV or TSV data from reader using streaming approach
+func (p *streamingParser) parseDelimitedStream(reader io.Reader, delimiter rune, fileTypeName string) (*table, error) {
+	records, err := newDelimitedReader(reader, delimiter).ReadAll()
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to read %s: %w", ErrParsing, fileTypeName, err)
 	}
@@ -291,16 +310,10 @@ func (p *streamingParser) ProcessInChunks(reader io.Reader, processor chunkProce
 
 // processDelimitedInChunks processes CSV or TSV data in chunks based on delimiter
 func (p *streamingParser) processDelimitedInChunks(reader io.Reader, processor chunkProcessor, delimiter rune, fileTypeName string) error {
-	csvReader := csv.NewReader(parser.NormalizeLineEndings(reader))
-	if delimiter != csvDelimiter {
-		csvReader.Comma = delimiter
-	}
-	// Accept a variable field count from the reader so a ragged row is handled by
-	// the configured malformed-row policy instead of aborting the whole read.
-	csvReader.FieldsPerRecord = -1
+	recordReader := newDelimitedReader(reader, delimiter)
 
 	// Read header first
-	headerrecord, err := csvReader.Read()
+	headerrecord, err := recordReader.Read()
 	if err != nil {
 		if errors.Is(err, io.EOF) {
 			return fmt.Errorf("%w: empty %s data", ErrEmptyData, fileTypeName)
@@ -326,7 +339,7 @@ func (p *streamingParser) processDelimitedInChunks(reader io.Reader, processor c
 
 	rowNum := 0
 	for {
-		record, err := csvReader.Read()
+		record, err := recordReader.Read()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				break

--- a/stream_test.go
+++ b/stream_test.go
@@ -117,6 +117,41 @@ func TestStreamingParser_ParseFromReader_LTSV(t *testing.T) {
 	})
 }
 
+func TestStreamingParser_TSVTakesFieldsLiterally(t *testing.T) {
+	t.Parallel()
+
+	const input = "name\tnote\nalice\t5'9\" tall\nbob\tsaid \"hi\" loudly\n"
+
+	t.Run("a quote in a value does not fail the read", func(t *testing.T) {
+		t.Parallel()
+
+		p := newStreamingParser(FileTypeTSV, CompressionNone, "notes", 1024)
+		table, err := p.parseFromReader(strings.NewReader(input))
+
+		require.NoError(t, err)
+		records := table.getRecords()
+		require.Len(t, records, 2)
+		assert.Equal(t, `5'9" tall`, records[0][1])
+		assert.Equal(t, `said "hi" loudly`, records[1][1])
+	})
+
+	t.Run("the chunked reader agrees", func(t *testing.T) {
+		t.Parallel()
+
+		p := newStreamingParser(FileTypeTSV, CompressionNone, "notes", 1)
+		var values []string
+		err := p.ProcessInChunks(strings.NewReader(input), func(chunk *tableChunk) error {
+			for _, r := range chunk.records {
+				values = append(values, r[1])
+			}
+			return nil
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{`5'9" tall`, `said "hi" loudly`}, values)
+	})
+}
+
 func TestStreamingParser_CROnlyLineEndings(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
A TSV whose value contains a double quote could not be loaded. TSV was read with `encoding/csv` and the delimiter set to tab, which brought CSV's quote handling with it, so `5'9" tall` failed the whole import with `bare " in non-quoted-field`. IANA's text/tab-separated-values defines no quoting at all: a field is the bytes between two tabs, and a double quote there is an ordinary character.

The reader is the fix the issue asks for, but it cannot land alone. `writeDelimitedData` writes TSV with a CSV writer, which quotes any field holding a quote, and a quoted field read literally is not the value that was written. So both halves move together: `parser.TSVReader` splits on tabs and keeps what is between them, and `parser.WriteTSVRecord` joins with tabs and refuses a value holding a tab or a line break, which the format cannot represent, instead of quoting it. The dump path and `prep`'s TSV output both write through it, so a TSV round trip returns the value that was stored.

One consequence worth naming: a record of one empty field. In CSV it is written `""`, because a blank line is not a CSV record. TSV has no quoting to say that with, so the blank line is the value, and the reader takes a blank line in a one-column file as that column's empty field. With more columns a blank line cannot be a record of that shape and is skipped, as a CSV reader skips it. `TestDumpLoneEmptyField` is updated to that, and its round-trip half is unchanged.

CSV is untouched: `newDelimitedReader` picks the reader the delimiter names, and a CSV quoted field still reads as one field.

Tests cover a quote inside a value, a field that begins and ends with a quote, a doubled quote as two characters, blank lines in one-column and multi-column files, CRLF endings, the writer refusing a tab, a newline and a carriage return, the streaming and chunked paths, and a dump-then-load round trip of five quote-bearing values.

Closes #268