### PR TITLE
docs(changelog): stamp v0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.40.0] - 2026-08-09
 
 ### Added
 


### PR DESCRIPTION
Stamps the Unreleased section as v0.40.0. It carries two import fixes — a CR-terminated CSV, TSV, or LTSV now imports its rows instead of loading empty (#279), and TSV is read and written literally so a value containing a double quote loads and round trips (#268) — plus the parser package's new TSV reader and writer, which is why the bump is a minor rather than a patch.