### PR TITLE
fix: keep a Parquet infinity a REAL on import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- A Parquet double holding an infinity imports as a REAL instead of as text. The column type comes from the Parquet schema, but the value reached SQLite as the text `%g` renders, and `+Inf` is not a number to SQLite's REAL affinity: the cell was stored as TEXT inside a column declared REAL, so `typeof()` answered `text` for a value the file held as a double, and comparisons on it ordered lexically. An infinity now renders as `9e999`, which SQLite parses back to one. A NaN renders as NULL, because SQLite has no NaN at all — a computed one is NULL there — and the word would leave the same text-in-a-REAL-column mismatch.
+
 ## [0.40.0] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A Parquet double holding an infinity imports as a REAL instead of as text. The column type comes from the Parquet schema, but the value reached SQLite as the text `%g` renders, and `+Inf` is not a number to SQLite's REAL affinity: the cell was stored as TEXT inside a column declared REAL, so `typeof()` answered `text` for a value the file held as a double, and comparisons on it ordered lexically. An infinity now renders as `9e999`, which SQLite parses back to one. A NaN renders as NULL, because SQLite has no NaN at all — a computed one is NULL there — and the word would leave the same text-in-a-REAL-column mismatch.
+- A Parquet double holding an infinity imports as a REAL instead of as text. The column type comes from the Parquet schema, but the value reached SQLite as the text `%g` renders, and `+Inf` is not a number to SQLite's REAL affinity: the cell was stored as TEXT inside a column declared REAL, so `typeof()` answered `text` for a value the file held as a double, and comparisons on it ordered lexically. An infinity now renders as `9e999`, which SQLite parses back to one. A NaN imports as NULL, because SQLite has no NaN at all — a computed one is NULL there — and the word would leave the same text-in-a-REAL-column mismatch.
 
 ## [0.40.0] - 2026-08-09
 

--- a/filesql.go
+++ b/filesql.go
@@ -805,6 +805,25 @@ func (b *bytesReaderAt) Read(p []byte) (int, error) {
 	return b.ReadAt(p, 0)
 }
 
+// arrowCellIsNull reports whether a cell has no value SQLite can store: a
+// Parquet null, or a NaN, which SQLite has no representation for at all — a
+// computed NaN is NULL there, so NULL is what the value already means in the
+// destination. Left as text it would sit in a column declared REAL as the word
+// "NaN".
+func arrowCellIsNull(arr arrow.Array, index int64) bool {
+	if arr.IsNull(int(index)) {
+		return true
+	}
+	switch a := arr.(type) {
+	case *array.Float32:
+		return math.IsNaN(float64(a.Value(int(index))))
+	case *array.Float64:
+		return math.IsNaN(a.Value(int(index)))
+	default:
+		return false
+	}
+}
+
 // sqliteFloatText renders a float at bitSize so SQLite's REAL affinity converts
 // it back to the same number, which "%g" does not for the three values that have
 // no decimal spelling.
@@ -820,11 +839,14 @@ func (b *bytesReaderAt) Read(p []byte) (int, error) {
 // the destination. Keeping the word would leave the same TEXT-in-a-REAL-column
 // mismatch this exists to remove.
 func sqliteFloatText(f float64, bitSize int) string {
+	// A literal SQLite overflows to an infinity while parsing it. There is no
+	// spelling of the value itself that its REAL affinity accepts.
+	const infinityLiteral = "9e999"
 	switch {
 	case math.IsInf(f, 1):
-		return "9e999"
+		return infinityLiteral
 	case math.IsInf(f, -1):
-		return "-9e999"
+		return "-" + infinityLiteral
 	case math.IsNaN(f):
 		return ""
 	}

--- a/filesql.go
+++ b/filesql.go
@@ -6,6 +6,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -804,6 +805,32 @@ func (b *bytesReaderAt) Read(p []byte) (int, error) {
 	return b.ReadAt(p, 0)
 }
 
+// sqliteFloatText renders a float at bitSize so SQLite's REAL affinity converts
+// it back to the same number, which "%g" does not for the three values that have
+// no decimal spelling.
+//
+// The column is declared REAL from the Parquet schema, and SQLite applies that
+// affinity to the text an import binds: "+Inf" is not a number to it, so the
+// cell was stored as TEXT inside a REAL column and typeof() answered "text" for
+// a value the file held as a double. "9e999" overflows to infinity when SQLite
+// parses it, which is the only spelling that survives.
+//
+// NaN renders as empty, the same as a null, because SQLite has no NaN at all: a
+// computed one becomes NULL there, so NULL is what the value already means in
+// the destination. Keeping the word would leave the same TEXT-in-a-REAL-column
+// mismatch this exists to remove.
+func sqliteFloatText(f float64, bitSize int) string {
+	switch {
+	case math.IsInf(f, 1):
+		return "9e999"
+	case math.IsInf(f, -1):
+		return "-9e999"
+	case math.IsNaN(f):
+		return ""
+	}
+	return strconv.FormatFloat(f, 'g', -1, bitSize)
+}
+
 // extractValueFromArrowArray extracts a value from an Arrow array at the given index
 func extractValueFromArrowArray(arr arrow.Array, index int64) string {
 	if arr.IsNull(int(index)) {
@@ -836,9 +863,9 @@ func extractValueFromArrowArray(arr arrow.Array, index int64) string {
 		return strconv.FormatUint(a.Value(int(index)), 10)
 
 	case *array.Float32:
-		return fmt.Sprintf("%g", a.Value(int(index)))
+		return sqliteFloatText(float64(a.Value(int(index))), 32)
 	case *array.Float64:
-		return fmt.Sprintf("%g", a.Value(int(index)))
+		return sqliteFloatText(a.Value(int(index)), 64)
 
 	case *array.String:
 		return a.Value(int(index))

--- a/parquet_types_test.go
+++ b/parquet_types_test.go
@@ -9,6 +9,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/apache/arrow/go/v18/arrow"
+	"github.com/apache/arrow/go/v18/arrow/array"
+	"github.com/apache/arrow/go/v18/arrow/memory"
+	"github.com/apache/arrow/go/v18/parquet"
 	pqfile "github.com/apache/arrow/go/v18/parquet/file"
 	"github.com/apache/arrow/go/v18/parquet/pqarrow"
 	_ "modernc.org/sqlite"
@@ -329,7 +333,7 @@ func TestParquetNonFiniteRealStaysReal(t *testing.T) {
 	}
 	defer func() { _ = reloaded.Close() }()
 
-	rows, err := reloaded.QueryContext(ctx, `SELECT v, typeof(v) FROM m;`)
+	rows, err := reloaded.QueryContext(ctx, `SELECT v, typeof(v) FROM m ORDER BY rowid;`)
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
@@ -366,40 +370,149 @@ func TestParquetNonFiniteRealStaysReal(t *testing.T) {
 // at all — a computed one is stored as NULL — so a NaN carried by a Parquet
 // double becomes NULL rather than the word "NaN" sitting in a REAL column as
 // text.
+//
+// The file is written directly rather than dumped from SQLite, because SQLite
+// turns a NaN into NULL on the way in: a dumped file holds a null, and the
+// renderer this covers would never see a NaN at all.
 func TestParquetNaNBecomesNull(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	dir := t.TempDir()
-	db, err := sql.Open("sqlite", filepath.Join(dir, "src.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = db.Close() }()
+	path := filepath.Join(t.TempDir(), "nan.parquet")
+	writeFloat64Parquet(t, path, "v", []float64{math.NaN(), 1.5})
 
-	if _, err := db.ExecContext(ctx, `CREATE TABLE m (v REAL);`); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := db.ExecContext(ctx, `INSERT INTO m VALUES (?);`, math.NaN()); err != nil {
-		t.Fatal(err)
-	}
-
-	out := filepath.Join(dir, "out")
-	if err := DumpDatabase(db, out, NewDumpOptions().WithFormat(OutputFormatParquet)); err != nil {
-		t.Fatalf("DumpDatabase: %v", err)
-	}
-
-	reloaded, err := OpenContext(ctx, filepath.Join(out, "m.parquet"))
+	db, err := OpenContext(ctx, path)
 	if err != nil {
 		t.Fatalf("OpenContext: %v", err)
 	}
-	defer func() { _ = reloaded.Close() }()
+	defer func() { _ = db.Close() }()
 
-	var ty string
-	if err := reloaded.QueryRowContext(ctx, `SELECT typeof(v) FROM m;`).Scan(&ty); err != nil {
+	rows, err := db.QueryContext(ctx, `SELECT typeof(v) FROM nan ORDER BY rowid;`)
+	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
-	if ty != "null" {
-		t.Errorf("typeof = %q, want \"null\": SQLite has no NaN to store", ty)
+	defer func() { _ = rows.Close() }()
+
+	var types []string
+	for rows.Next() {
+		var ty string
+		if err := rows.Scan(&ty); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		types = append(types, ty)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if want := []string{"null", "real"}; !reflect.DeepEqual(types, want) {
+		t.Errorf("typeof = %v, want %v: SQLite has no NaN to store, and the finite value beside it is untouched", types, want)
+	}
+}
+
+// TestParquetInfinityFromFileStaysReal reads an infinity written straight into a
+// Parquet double, which is what a file another tool produced looks like.
+func TestParquetInfinityFromFileStaysReal(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "inf.parquet")
+	writeFloat64Parquet(t, path, "v", []float64{math.Inf(1), math.Inf(-1)})
+
+	db, err := OpenContext(ctx, path)
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.QueryContext(ctx, `SELECT v, typeof(v) FROM inf ORDER BY rowid;`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var (
+		values []float64
+		types  []string
+	)
+	for rows.Next() {
+		var (
+			v  float64
+			ty string
+		)
+		if err := rows.Scan(&v, &ty); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		values = append(values, v)
+		types = append(types, ty)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if want := []string{"real", "real"}; !reflect.DeepEqual(types, want) {
+		t.Errorf("typeof = %v, want %v", types, want)
+	}
+	if len(values) != 2 || !math.IsInf(values[0], 1) || !math.IsInf(values[1], -1) {
+		t.Errorf("values = %v, want [+Inf -Inf]", values)
+	}
+}
+
+// TestSQLiteFloatText covers the renderer directly, including the float32 width
+// a Parquet FLOAT column is read at: rendering it as a float64 would hand SQLite
+// the expansion (3.141590118408203) instead of the number the file holds.
+func TestSQLiteFloatText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   float64
+		bitSize int
+		want    string
+	}{
+		{name: "positive infinity is a literal SQLite overflows to one", value: math.Inf(1), bitSize: 64, want: "9e999"},
+		{name: "negative infinity likewise", value: math.Inf(-1), bitSize: 64, want: "-9e999"},
+		{name: "NaN is empty, which is how a null is rendered", value: math.NaN(), bitSize: 64, want: ""},
+		{name: "a finite double is unchanged", value: 1.5, bitSize: 64, want: "1.5"},
+		{name: "a float32 renders at its own width", value: float64(float32(3.14159)), bitSize: 32, want: "3.14159"},
+		{name: "a float32 infinity is the same literal", value: float64(float32(math.Inf(1))), bitSize: 32, want: "9e999"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := sqliteFloatText(tt.value, tt.bitSize); got != tt.want {
+				t.Errorf("sqliteFloatText(%v, %d) = %q, want %q", tt.value, tt.bitSize, got, tt.want)
+			}
+		})
+	}
+}
+
+// writeFloat64Parquet writes a one-column Parquet file of doubles, so a test can
+// hand the reader a value SQLite would not have let through on the way in.
+func writeFloat64Parquet(t *testing.T, path, column string, values []float64) {
+	t.Helper()
+
+	schema := arrow.NewSchema([]arrow.Field{{Name: column, Type: arrow.PrimitiveTypes.Float64, Nullable: true}}, nil)
+	builder := array.NewFloat64Builder(memory.NewGoAllocator())
+	defer builder.Release()
+	builder.AppendValues(values, nil)
+
+	arr := builder.NewArray()
+	defer arr.Release()
+	rec := array.NewRecord(schema, []arrow.Array{arr}, int64(len(values)))
+	defer rec.Release()
+	tbl := array.NewTableFromRecords(schema, []arrow.Record{rec})
+	defer tbl.Release()
+
+	f, err := os.Create(path) //nolint:gosec // test-owned path
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := pqarrow.WriteTable(tbl, f, 1024, parquet.NewWriterProperties(), pqarrow.DefaultWriterProps()); err != nil {
+		t.Fatalf("write parquet: %v", err)
 	}
 }

--- a/parquet_types_test.go
+++ b/parquet_types_test.go
@@ -3,8 +3,10 @@ package filesql
 import (
 	"context"
 	"database/sql"
+	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	pqfile "github.com/apache/arrow/go/v18/parquet/file"
@@ -284,5 +286,120 @@ func assertParquetSchema(t *testing.T, path string, want map[string]string) {
 		if got := schema.Field(fields[0]).Type.Name(); got != wantType {
 			t.Errorf("column %q has parquet type %q, want %q", name, got, wantType)
 		}
+	}
+}
+
+// TestParquetNonFiniteRealStaysReal pins the invariant arrowColumnInfoList
+// states: the column type taken from the Parquet schema and the text
+// extractValueFromArrowArray renders have to agree, because SQLite applies the
+// column's affinity to that text.
+//
+// "%g" spells an infinity "+Inf", which SQLite's REAL affinity cannot convert,
+// so the cell was stored as TEXT inside a column declared REAL: a double in the
+// file came back as a string, and typeof() said so.
+func TestParquetNonFiniteRealStaysReal(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "src.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE m (v REAL);`); err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range []float64{math.Inf(1), math.Inf(-1), 1.5} {
+		if _, err := db.ExecContext(ctx, `INSERT INTO m VALUES (?);`, v); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out := filepath.Join(dir, "out")
+	if err := DumpDatabase(db, out, NewDumpOptions().WithFormat(OutputFormatParquet)); err != nil {
+		t.Fatalf("DumpDatabase: %v", err)
+	}
+	assertParquetSchema(t, filepath.Join(out, "m.parquet"), map[string]string{"v": "float64"})
+
+	reloaded, err := OpenContext(ctx, filepath.Join(out, "m.parquet"))
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	defer func() { _ = reloaded.Close() }()
+
+	rows, err := reloaded.QueryContext(ctx, `SELECT v, typeof(v) FROM m;`)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var (
+		values []float64
+		types  []string
+	)
+	for rows.Next() {
+		var (
+			v  float64
+			ty string
+		)
+		if err := rows.Scan(&v, &ty); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		values = append(values, v)
+		types = append(types, ty)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	if want := []string{"real", "real", "real"}; !reflect.DeepEqual(types, want) {
+		t.Errorf("typeof = %v, want %v: a double column stays REAL whatever it holds", types, want)
+	}
+	if len(values) != 3 || !math.IsInf(values[0], 1) || !math.IsInf(values[1], -1) || values[2] != 1.5 {
+		t.Errorf("values = %v, want [+Inf -Inf 1.5]", values)
+	}
+}
+
+// TestParquetNaNBecomesNull pins the one value SQLite cannot hold. It has no NaN
+// at all — a computed one is stored as NULL — so a NaN carried by a Parquet
+// double becomes NULL rather than the word "NaN" sitting in a REAL column as
+// text.
+func TestParquetNaNBecomesNull(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "src.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.ExecContext(ctx, `CREATE TABLE m (v REAL);`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO m VALUES (?);`, math.NaN()); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(dir, "out")
+	if err := DumpDatabase(db, out, NewDumpOptions().WithFormat(OutputFormatParquet)); err != nil {
+		t.Fatalf("DumpDatabase: %v", err)
+	}
+
+	reloaded, err := OpenContext(ctx, filepath.Join(out, "m.parquet"))
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	defer func() { _ = reloaded.Close() }()
+
+	var ty string
+	if err := reloaded.QueryRowContext(ctx, `SELECT typeof(v) FROM m;`).Scan(&ty); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if ty != "null" {
+		t.Errorf("typeof = %q, want \"null\": SQLite has no NaN to store", ty)
 	}
 }

--- a/parser/parquet.go
+++ b/parser/parquet.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 
 	"github.com/apache/arrow/go/v18/arrow"
@@ -188,6 +189,32 @@ func arrowColumnType(dt arrow.DataType) ColumnType {
 	}
 }
 
+// sqliteFloatText renders a float at bitSize so SQLite's REAL affinity converts
+// it back to the same number, which "%g" does not for the three values that have
+// no decimal spelling.
+//
+// The column is declared REAL from the Parquet schema, and SQLite applies that
+// affinity to the text an import binds: "+Inf" is not a number to it, so the
+// cell was stored as TEXT inside a REAL column and typeof() answered "text" for
+// a value the file held as a double. "9e999" overflows to infinity when SQLite
+// parses it, which is the only spelling that survives.
+//
+// NaN renders as empty, the same as a null, because SQLite has no NaN at all: a
+// computed one becomes NULL there, so NULL is what the value already means in
+// the destination. Keeping the word would leave the same TEXT-in-a-REAL-column
+// mismatch this exists to remove.
+func sqliteFloatText(f float64, bitSize int) string {
+	switch {
+	case math.IsInf(f, 1):
+		return "9e999"
+	case math.IsInf(f, -1):
+		return "-9e999"
+	case math.IsNaN(f):
+		return ""
+	}
+	return strconv.FormatFloat(f, 'g', -1, bitSize)
+}
+
 // extractValueFromArrowArray extracts a value from an Arrow array at the given index.
 func extractValueFromArrowArray(arr arrow.Array, index int64) string {
 	if arr.IsNull(int(index)) {
@@ -220,9 +247,9 @@ func extractValueFromArrowArray(arr arrow.Array, index int64) string {
 		return strconv.FormatUint(a.Value(int(index)), 10)
 
 	case *array.Float32:
-		return fmt.Sprintf("%g", a.Value(int(index)))
+		return sqliteFloatText(float64(a.Value(int(index))), 32)
 	case *array.Float64:
-		return fmt.Sprintf("%g", a.Value(int(index)))
+		return sqliteFloatText(a.Value(int(index)), 64)
 
 	case *array.String:
 		return a.Value(int(index))

--- a/parser/parquet.go
+++ b/parser/parquet.go
@@ -204,11 +204,14 @@ func arrowColumnType(dt arrow.DataType) ColumnType {
 // the destination. Keeping the word would leave the same TEXT-in-a-REAL-column
 // mismatch this exists to remove.
 func sqliteFloatText(f float64, bitSize int) string {
+	// A literal SQLite overflows to an infinity while parsing it. There is no
+	// spelling of the value itself that its REAL affinity accepts.
+	const infinityLiteral = "9e999"
 	switch {
 	case math.IsInf(f, 1):
-		return "9e999"
+		return infinityLiteral
 	case math.IsInf(f, -1):
-		return "-9e999"
+		return "-" + infinityLiteral
 	case math.IsNaN(f):
 		return ""
 	}

--- a/parser/parquet_test.go
+++ b/parser/parquet_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bytes"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -421,6 +422,41 @@ func TestExtractValueFromArrowArray(t *testing.T) {
 
 		assert.Equal(t, "1.5", extractValueFromArrowArray(arr, 0))
 		assert.Equal(t, "2.5", extractValueFromArrowArray(arr, 1))
+	})
+
+	// An infinity has no decimal spelling, and SQLite's REAL affinity cannot read
+	// "+Inf": rendered that way it lands in a column declared REAL as text. The
+	// literal below is one SQLite overflows to an infinity.
+	t.Run("renders a float32 infinity as a literal SQLite reads as one", func(t *testing.T) {
+		t.Parallel()
+
+		builder := array.NewFloat32Builder(pool)
+		defer builder.Release()
+		builder.AppendValues([]float32{float32(math.Inf(1)), float32(math.Inf(-1)), float32(math.NaN()), 3.14159}, nil)
+		arr := builder.NewArray()
+		defer arr.Release()
+
+		assert.Equal(t, "9e999", extractValueFromArrowArray(arr, 0))
+		assert.Equal(t, "-9e999", extractValueFromArrowArray(arr, 1))
+		assert.Equal(t, "", extractValueFromArrowArray(arr, 2))
+		// The width is the array's, not float64's: through a float64 this would be
+		// its expansion, 3.141590118408203.
+		assert.Equal(t, "3.14159", extractValueFromArrowArray(arr, 3))
+	})
+
+	t.Run("renders a float64 infinity the same way", func(t *testing.T) {
+		t.Parallel()
+
+		builder := array.NewFloat64Builder(pool)
+		defer builder.Release()
+		builder.AppendValues([]float64{math.Inf(1), math.Inf(-1), math.NaN(), 1.5}, nil)
+		arr := builder.NewArray()
+		defer arr.Release()
+
+		assert.Equal(t, "9e999", extractValueFromArrowArray(arr, 0))
+		assert.Equal(t, "-9e999", extractValueFromArrowArray(arr, 1))
+		assert.Equal(t, "", extractValueFromArrowArray(arr, 2))
+		assert.Equal(t, "1.5", extractValueFromArrowArray(arr, 3))
 	})
 
 	t.Run("extracts binary value", func(t *testing.T) {

--- a/stream.go
+++ b/stream.go
@@ -663,8 +663,7 @@ func (p *streamingParser) parseParquetStream(reader io.Reader) (*table, error) {
 		for i := range numRows {
 			row := make(record, batch.NumCols())
 			for j, col := range batch.Columns() {
-				value := extractValueFromArrowArray(col, i)
-				row[j] = value
+				row[j] = extractValueFromArrowArray(col, i)
 			}
 			allRecords = append(allRecords, row)
 		}
@@ -799,7 +798,7 @@ func (p *streamingParser) processParquetInChunks(reader io.Reader, processor chu
 			row := make(record, batch.NumCols())
 			nullRow := make([]bool, batch.NumCols())
 			for j, col := range batch.Columns() {
-				if col.IsNull(int(i)) {
+				if arrowCellIsNull(col, i) {
 					nullRow[j] = true
 					continue
 				}


### PR DESCRIPTION
A Parquet double holding an infinity came back as text. The file is written correctly — the column is a `float64` and the value is a real `+Inf` — but on import `typeof()` answers `text`:

```
sqly --output-format parquet --output inf.parquet --sql "SELECT 1e308*10 AS big" sample.csv
sqly --sql "SELECT big, typeof(big) FROM inf" inf.parquet
# +Inf | text
```

`arrowColumnInfoList` already states the rule this breaks: the type taken from the Parquet schema and the text `extractValueFromArrowArray` renders have to agree, because SQLite applies the column's affinity to that text. `%g` spells an infinity `+Inf`, which REAL affinity cannot convert, so SQLite stored the cell as TEXT inside a column declared REAL. A column that mixes one infinity with finite doubles then compares and orders lexically for that row.

An infinity now renders as `9e999`, which SQLite parses back to an infinity — the only spelling that survives the text hop. A NaN renders as empty, the same as a null: SQLite has no NaN at all, a computed one is NULL there, so NULL is what the value already means in the destination, and keeping the word would leave exactly the mismatch this removes.

The renderer takes a bit size so a float32 still renders at 32-bit precision instead of through its float64 expansion, which is what `%g` on a float32 did.

Both copies of the renderer are changed — the root package's, used by the streaming import, and the `parser` package's — so the two paths keep agreeing.

Found while investigating nao1215/sqly#891, which reports a non-finite float losing its type across sqly's output formats; this is the Parquet half of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Parquet floating-point handling when loading data into SQLite.
  * Positive and negative infinity values retain their signs and are stored as REAL values.
  * NaN values are represented as SQLite NULL.
  * Finite floating-point values continue to round-trip accurately across supported precisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->