### PR TITLE
docs(changelog): stamp v0.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.40.1] - 2026-08-09
 
 ### Fixed
 


### PR DESCRIPTION
Stamps the Unreleased section as v0.40.1. It carries one fix: a Parquet double holding an infinity now imports as a REAL instead of as text, and a NaN imports as NULL, which is what SQLite has for it.