### PR TITLE
feat: translate MySQL's operator family, BigQuery's SAFE. prefix, and refuse what SQLite cannot represent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- MySQL's logical and bitwise operators that SQLite does not share are translated ([nao1215/sqly#893](https://github.com/nao1215/sqly/issues/893)). `&&` becomes `AND`. `!` becomes a parenthesized `NOT`: MySQL's `!` binds tighter than a comparison while SQLite's `NOT` binds looser, so a bare `NOT` would turn `!a = b` into a negation of the comparison. `^` has no SQLite operator at all and becomes a `mysql_bit_xor` helper call rather than the `(a|b)&~(a&b)` expansion, which would evaluate each operand twice.
+- BigQuery's `SAFE.` call prefix is translated ([nao1215/sqly#894](https://github.com/nao1215/sqly/issues/894)). `SAFE.DIVIDE(1, 0)` is now the same query as `SAFE_DIVIDE(1, 0)`; BigQuery's own documentation writes these functions with the prefix. A `SAFE.` prefix on any other function is refused rather than dropped.
+
+### Fixed
+
+- Constructs SQLite cannot represent are refused by name instead of reaching its parser ([nao1215/sqly#895](https://github.com/nao1215/sqly/issues/895)). A GoogleSQL array literal came back as `no such column: 1,2,3`, because SQLite reads `[...]` as identifier quoting, and a PostgreSQL `generate_series` as `no such table`, which reads as a missing input file. Both now say which construct is unsupported. MySQL's `XOR` is refused for the same reason: its precedence sits between `OR` and `AND`, which SQLite has no operator for, so its operands are not the primaries a rewrite can pick out and translating it would reassociate the expression. A `SAFE.` prefix on a function with no safe form is refused rather than dropped, since dropping it would answer with the plain function, which raises where the caller asked for a NULL.
+
 ## [0.40.1] - 2026-08-09
 
 ### Fixed
@@ -1161,7 +1172,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.30.1...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.40.1...HEAD
 [0.30.1]: https://github.com/nao1215/filesql/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/nao1215/filesql/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/nao1215/filesql/compare/v0.28.0...v0.29.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- MySQL's logical and bitwise operators that SQLite does not share are translated ([nao1215/sqly#893](https://github.com/nao1215/sqly/issues/893)). `&&` becomes `AND`. `!` becomes a parenthesized `NOT`: MySQL's `!` binds tighter than a comparison while SQLite's `NOT` binds looser, so a bare `NOT` would turn `!a = b` into a negation of the comparison. `^` has no SQLite operator at all and becomes a `mysql_bit_xor` helper call rather than the `(a|b)&~(a&b)` expansion, which would evaluate each operand twice.
+- MySQL's logical and bitwise operators that SQLite does not share are translated ([nao1215/sqly#893](https://github.com/nao1215/sqly/issues/893)). `&&` becomes `AND`. `!` becomes a parenthesized `NOT`: MySQL's `!` binds tighter than a comparison while SQLite's `NOT` binds looser, so a bare `NOT` would turn `!a = b` into a negation of the comparison. `^` has no SQLite operator at all and becomes a `mysql_bit_xor` helper call rather than the `(a|b)&~(a&b)` expansion, which would evaluate each operand twice; its arithmetic is unsigned, as MySQL's bitwise operators are, and the result comes back as the same 64 bits in SQLite's only integer, which is signed.
 - BigQuery's `SAFE.` call prefix is translated ([nao1215/sqly#894](https://github.com/nao1215/sqly/issues/894)). `SAFE.DIVIDE(1, 0)` is now the same query as `SAFE_DIVIDE(1, 0)`; BigQuery's own documentation writes these functions with the prefix. A `SAFE.` prefix on any other function is refused rather than dropped.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -196,8 +196,9 @@ func main() {
 Translation is best-effort compatibility, not a full emulator: common
 incompatibilities (identifier quoting, `DATE_ADD`, `SPLIT_PART`, `SAFE_DIVIDE`,
 `EXTRACT`, casts, …) are rewritten or backed by helper functions, constructs
-with no SQLite equivalent (for example `QUALIFY` or `DISTINCT ON`) return a
-clear error, and anything else is passed through to SQLite. A non-SQLite dialect
+with no SQLite equivalent (for example `QUALIFY`, `DISTINCT ON`, or MySQL's
+`XOR`) return a clear error, and anything else is passed through to SQLite.
+A non-SQLite dialect
 cannot be combined with auto-save. See the [`dialect`](./dialect) package for the
 full list of supported translations.
 

--- a/dialect/doc.go
+++ b/dialect/doc.go
@@ -9,9 +9,13 @@
 //   - Known incompatibilities that have a SQLite equivalent are rewritten (for
 //     example MySQL's backtick identifiers become double-quoted identifiers, and
 //     PostgreSQL's "expr::type" becomes "CAST(expr AS type)").
-//   - Known constructs with no SQLite equivalent (QUALIFY, ARRAY/STRUCT types,
-//     LATERAL, DISTINCT ON, ...) are rejected with ErrUnsupportedSyntax so the
-//     caller sees a clear error instead of a confusing engine message.
+//   - Known constructs with no SQLite equivalent (QUALIFY, arrays, STRUCT
+//     types, LATERAL, DISTINCT ON, PostgreSQL's set-returning functions,
+//     MySQL's XOR, ...) are rejected with ErrUnsupportedSyntax so the caller
+//     sees a clear error instead of a confusing engine message: an array
+//     literal reached SQLite as identifier quoting and came back as "no such
+//     column: 1,2,3", and generate_series as "no such table", each naming
+//     something the query never wrote.
 //   - Anything else is passed through unchanged and left to SQLite to accept or
 //     reject.
 //

--- a/dialect/functions.go
+++ b/dialect/functions.go
@@ -146,6 +146,7 @@ func registerAll() error {
 		// SQLite's affinity; see cast.go.
 		"mysql_cast":          {2, dialectCast(MySQL, false)},
 		"mysql_divide":        {2, divideFloat(false)},
+		"mysql_bit_xor":       {2, fnBitXor},
 		"interval_add":        {3, fnDateIntervalAdd},
 		"interval_text_add":   {3, fnIntervalTextAdd},
 		"date_trunc_part":     {2, fnDateTruncPart},

--- a/dialect/googlesql.go
+++ b/dialect/googlesql.go
@@ -27,8 +27,16 @@ import (
 //	G-16 UNION DISTINCT                       -> UNION
 //	G-17 JSON_VALUE / BYTE_LENGTH / CHAR_LENGTH
 //	G-18 STRING_AGG(DISTINCT x, ',')           -> group_concat(DISTINCT x)
+//	G-19 [1,2,3] / x[OFFSET(n)]               -> ErrUnsupportedSyntax
+//	G-20 SAFE.f(args)                         -> safe_f(args)
 func rewriteGoogleSQL(tokens []token) ([]token, error) {
 	if err := checkUnsupportedGoogleSQL(tokens); err != nil {
+		return nil, err
+	}
+	// G-20: fold BigQuery's "SAFE." call prefix into the underscore name the
+	// rest of the pass already knows, before any call is looked at.
+	tokens, err := safePrefixPass(tokens)
+	if err != nil {
 		return nil, err
 	}
 	out, err := googlesqlCallPass(tokens)
@@ -54,6 +62,77 @@ func rewriteGoogleSQL(tokens []token) ([]token, error) {
 	return aggregatePass(out, GoogleSQL)
 }
 
+// safeFunctions are the functions a "SAFE." prefix can be honored for: those
+// with a safe_ helper registered for them, named the same lowercased. The prefix
+// means "return NULL rather than raise", and only a helper written for that can
+// promise it. The order is the message's, so it does not change between runs.
+var safeFunctions = []string{"ADD", "DIVIDE", "MULTIPLY", "NEGATE", "SUBTRACT"}
+
+// safeHelperFor returns the helper a "SAFE." prefix on name maps to, and
+// whether there is one.
+func safeHelperFor(name string) (string, bool) {
+	upper := strings.ToUpper(name)
+	for _, fn := range safeFunctions {
+		if fn == upper {
+			return "safe_" + strings.ToLower(fn), true
+		}
+	}
+	return "", false
+}
+
+// safePrefixPass implements G-20: SAFE.f(args) -> safe_f(args).
+//
+// BigQuery's own documentation writes the safe functions this way, and only a
+// few of them have an underscore name at all, so the prefix is the general
+// form. Left alone it reaches SQLite as a qualified name, which reports on the
+// "(" that follows rather than on the prefix, and says nothing about the
+// dialect.
+//
+// A prefix on a function with no safe form is refused rather than dropped:
+// dropping it would answer the query with the plain function, which raises
+// where the caller asked for a NULL.
+func safePrefixPass(tokens []token) ([]token, error) {
+	out := make([]token, 0, len(tokens))
+	i := 0
+	for i < len(tokens) {
+		name, end, ok := matchSafePrefix(tokens, i)
+		if !ok {
+			out = append(out, tokens[i])
+			i++
+			continue
+		}
+		helper, supported := safeHelperFor(name)
+		if !supported {
+			return nil, fmt.Errorf("%w: SAFE.%s is not supported; the SAFE. prefix works with %s",
+				ErrUnsupportedSyntax, strings.ToUpper(name), strings.Join(safeFunctions, ", "))
+		}
+		out = append(out, wordToken(helper))
+		i = end + 1
+	}
+	return out, nil
+}
+
+// matchSafePrefix reports whether tokens[i] starts a "SAFE . name (" sequence,
+// returning the function name and the index of the name token.
+func matchSafePrefix(tokens []token, i int) (string, int, bool) {
+	if !isWordEq(tokens[i], "SAFE") {
+		return "", 0, false
+	}
+	dot := nextSig(tokens, i+1)
+	if dot < 0 || !isOpEq(tokens[dot], ".") {
+		return "", 0, false
+	}
+	name := nextSig(tokens, dot+1)
+	if name < 0 || tokens[name].kind != tokWord {
+		return "", 0, false
+	}
+	// The "(" is what makes this a call rather than a qualified column.
+	if open := nextSig(tokens, name+1); open < 0 || !isOpEq(tokens[open], "(") {
+		return "", 0, false
+	}
+	return tokens[name].text, name, true
+}
+
 // checkUnsupportedGoogleSQL rejects the G-9 constructs that have no SQLite
 // equivalent.
 func checkUnsupportedGoogleSQL(tokens []token) error {
@@ -71,6 +150,14 @@ func checkUnsupportedGoogleSQL(tokens []token) error {
 			if lt := nextSig(tokens, i+1); lt >= 0 && isOpEq(tokens[lt], "<") {
 				return fmt.Errorf("%w: %s type is not supported", ErrUnsupportedSyntax, strings.ToUpper(t.text))
 			}
+		}
+		// G-19: SQLite has no array type, and "[" is its identifier quoting, so an
+		// array literal or subscript reaches the planner as a name: the error was
+		// "no such column: 1,2,3", about a column the query never wrote. Under
+		// GoogleSQL a "[" is never quoting — backticks are — so every one of them
+		// is an array.
+		if isOpEq(t, "[") {
+			return fmt.Errorf("%w: arrays are not supported; SQLite has no array type", ErrUnsupportedSyntax)
 		}
 		// SELECT * EXCEPT(...) / SELECT * REPLACE(...)
 		if isOpEq(t, "*") {

--- a/dialect/googlesql_test.go
+++ b/dialect/googlesql_test.go
@@ -21,6 +21,20 @@ func TestGoogleSQLTranslate(t *testing.T) {
 		{"G-2_safe_cast", "SELECT SAFE_CAST(x AS INT64) FROM t", "SELECT googlesql_safe_cast(x, 'INT64') AS \"SAFE_CAST(x AS INT64)\" FROM t"},
 		{"G-2_safe_cast_unknown_type", "SELECT SAFE_CAST(x AS GEOGRAPHY)", "SELECT CAST(x AS GEOGRAPHY) AS \"SAFE_CAST(x AS GEOGRAPHY)\""},
 
+		// G-20: BigQuery writes the safe functions with a "SAFE." call prefix, and
+		// its own documentation uses that spelling. Only a few of them have an
+		// underscore name, so the prefix is the general form.
+		{"G-20_safe_divide", "SELECT SAFE.DIVIDE(1, 0)", `SELECT safe_divide(1, 0) AS "SAFE.DIVIDE(1, 0)"`},
+		{"G-20_safe_divide_lowercase", "SELECT safe.divide(a, b) FROM t", `SELECT safe_divide(a, b) AS "safe.divide(a, b)" FROM t`},
+		{"G-20_safe_add", "SELECT SAFE.ADD(a, b) FROM t", `SELECT safe_add(a, b) AS "SAFE.ADD(a, b)" FROM t`},
+		{"G-20_safe_negate", "SELECT SAFE.NEGATE(a) FROM t", `SELECT safe_negate(a) AS "SAFE.NEGATE(a)" FROM t`},
+		{"G-20_safe_multiply_nested", "SELECT SAFE.MULTIPLY(SAFE.ADD(a, b), c) FROM t", `SELECT safe_multiply(safe_add(a, b), c) AS "SAFE.MULTIPLY(SAFE.ADD(a, b), c)" FROM t`},
+		{"G-20_safe_divide_in_where", "SELECT a FROM t WHERE SAFE.DIVIDE(a, b) > 1", "SELECT a FROM t WHERE safe_divide(a, b) > 1"},
+		// A column named safe, and a qualified column on a table named safe, are
+		// not calls and keep their meaning.
+		{"G-20_safe_column_untouched", "SELECT safe FROM t", "SELECT safe FROM t"},
+		{"G-20_safe_qualified_column_untouched", "SELECT safe.divide FROM t", "SELECT safe.divide FROM t"},
+
 		{"G-3_date_literal", "SELECT DATE '2026-01-01'", "SELECT '2026-01-01' AS \"DATE '2026-01-01'\""},
 		{"G-3_timestamp_literal", "SELECT TIMESTAMP '2026-01-01 00:00:00'", "SELECT '2026-01-01 00:00:00' AS \"TIMESTAMP '2026-01-01 00:00:00'\""},
 		{"G-3_date_word_not_literal", "SELECT DATE FROM t", "SELECT DATE FROM t"},
@@ -84,6 +98,20 @@ func TestGoogleSQLTranslateUnsupported(t *testing.T) {
 		// comma-joined string would be a different answer, not a translation.
 		{"G-18_string_agg_distinct_other_separator", "SELECT STRING_AGG(DISTINCT name, '-') FROM t"},
 		{"G-18_string_agg_distinct_separator_expression", "SELECT STRING_AGG(DISTINCT name, sep) FROM t"},
+
+		// A SAFE. call whose function has no safe form here is refused by name.
+		// Passed through, SQLite reads "SAFE.SUBSTR" as schema.table and reports on
+		// the "(" instead.
+		{"G-20_safe_unknown_function", "SELECT SAFE.SUBSTR(s, 1, 2) FROM t"},
+		{"G-20_safe_cast_prefix", "SELECT SAFE.CAST(x AS INT64) FROM t"},
+
+		// G-19: SQLite reads "[...]" as an identifier, so an array literal came
+		// back as "no such column: 1,2,3", about a column the query never named.
+		{"G-19_array_literal", "SELECT ARRAY_LENGTH([1,2,3]) AS r"},
+		{"G-19_array_literal_bare", "SELECT [1, 2, 3]"},
+		{"G-19_array_subscript", "SELECT x[OFFSET(0)] AS r FROM t"},
+		{"G-19_array_subscript_ordinal", "SELECT x[ORDINAL(1)] FROM t"},
+		{"G-19_array_literal_in_where", "SELECT a FROM t WHERE b IN UNNEST([1, 2])"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -27,6 +27,10 @@ import (
 //	M-18 ANY_VALUE / STD / VARIANCE      -> SQLite aggregate expressions
 //	M-19 UNION DISTINCT                  -> UNION
 //	M-20 LENGTH / CHAR_LENGTH / ORD / TRIM(BOTH x FROM s)
+//	M-21 a && b                          -> a AND b
+//	M-21 !a                              -> (NOT a)
+//	M-21 a ^ b                           -> mysql_bit_xor(a, b)
+//	M-21 a XOR b                         -> ErrUnsupportedSyntax
 //
 // M-10 (LIMIT n, m) needs no rewrite: SQLite accepts it natively.
 func rewriteMySQL(tokens []token) ([]token, error) {
@@ -44,9 +48,32 @@ func rewriteMySQL(tokens []token) ([]token, error) {
 	if err != nil {
 		return nil, err
 	}
-	// M-12/M-13: MySQL reads "||" as a logical OR under its default sql_mode,
-	// and "<=>" as null-safe equality, which SQLite spells IS.
+	// M-21: "^" is a bitwise XOR in MySQL, which SQLite has no operator for. It
+	// binds tightly enough that both operands are primaries, so the rewrite is a
+	// helper call rather than the (a|b)&~(a&b) expansion, which would evaluate
+	// each operand twice.
+	out, err = binaryOperatorPass(out, "^", "mysql_bit_xor")
+	if err != nil {
+		return nil, err
+	}
+	// M-21: XOR has no SQLite spelling that keeps its precedence. It sits between
+	// OR and AND, so its operands are whole AND-expressions rather than the
+	// primaries a rewrite can pick out: translating it as if they were primaries
+	// would reassociate "a AND b XOR c" into something MySQL never meant.
+	if err := rejectWordPass(out, "XOR",
+		"SQLite has no operator with its precedence; write (a AND NOT b) OR (NOT a AND b)"); err != nil {
+		return nil, err
+	}
+	// M-21: "!" is MySQL's NOT, and it binds tighter than a comparison.
+	out, err = unaryNotPass(out)
+	if err != nil {
+		return nil, err
+	}
+	// M-12/M-13/M-21: MySQL reads "||" as a logical OR under its default
+	// sql_mode, "&&" as AND, and "<=>" as null-safe equality, which SQLite
+	// spells IS.
 	out = replaceOperatorWithWord(out, "||", "OR")
+	out = replaceOperatorWithWord(out, "&&", "AND")
 	out = replaceOperatorWithWord(out, "<=>", "IS")
 	// M-14/M-15: MySQL accepts typed date literals and the parenthesized
 	// CURRENT_DATE() spelling, neither of which SQLite parses.

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -42,6 +42,14 @@ func rewriteMySQL(tokens []token) ([]token, error) {
 	if err != nil {
 		return nil, err
 	}
+	// M-21: "!" is MySQL's NOT, and it binds tighter than every operator the
+	// passes below rewrite, so it is resolved before them: "!a ^ b" is
+	// "(!a) ^ b", and a "^" pass that ran first would take "a" for its left
+	// operand and leave the negation outside the call.
+	out, err = unaryNotPass(out)
+	if err != nil {
+		return nil, err
+	}
 	// M-11: MySQL's "/" is floating-point division, so 5/2 is 2.5 rather than
 	// the 2 SQLite gives for two integers.
 	out, err = binaryOperatorPass(out, "/", "mysql_divide")
@@ -62,11 +70,6 @@ func rewriteMySQL(tokens []token) ([]token, error) {
 	// would reassociate "a AND b XOR c" into something MySQL never meant.
 	if err := rejectWordPass(out, "XOR",
 		"SQLite has no operator with its precedence; write (a AND NOT b) OR (NOT a AND b)"); err != nil {
-		return nil, err
-	}
-	// M-21: "!" is MySQL's NOT, and it binds tighter than a comparison.
-	out, err = unaryNotPass(out)
-	if err != nil {
 		return nil, err
 	}
 	// M-12/M-13/M-21: MySQL reads "||" as a logical OR under its default

--- a/dialect/mysql_test.go
+++ b/dialect/mysql_test.go
@@ -57,6 +57,34 @@ func TestMySQLTranslate(t *testing.T) {
 		{"M-10_limit_offset", "SELECT * FROM t LIMIT 5, 10", "SELECT * FROM t LIMIT 5, 10"},
 
 		{"nested_date_add_in_extract", "SELECT EXTRACT(DAY FROM DATE_ADD(d, INTERVAL 1 DAY))", "SELECT DATE_PART('day', interval_add(d, 1, 'day')) AS \"EXTRACT(DAY FROM DATE_ADD(d, INTERVAL 1 DAY))\""},
+		// M-21: the logical and bitwise operators MySQL spells with punctuation.
+		// "||" was translated and its siblings were not, so they reached SQLite's
+		// tokenizer as unrecognized tokens.
+		{"M-21_andand", "SELECT a && b FROM t", `SELECT a AND b AS "a && b" FROM t`},
+		{"M-21_andand_no_spaces", "SELECT a&&b FROM t", `SELECT a AND b AS "a&&b" FROM t`},
+		{"M-21_bang", "SELECT !a FROM t", `SELECT (NOT a) AS "!a" FROM t`},
+		{"M-21_bang_paren", "SELECT !(a AND b) FROM t", `SELECT (NOT (a AND b)) AS "!(a AND b)" FROM t`},
+		{"M-21_bang_call", "SELECT !f(a) FROM t", `SELECT (NOT f(a)) AS "!f(a)" FROM t`},
+		// "!" binds tighter than a comparison in MySQL, so the negation is of the
+		// operand alone. Written as a bare NOT it would have swallowed the
+		// comparison, because SQLite's NOT binds looser than "=".
+		{"M-21_bang_before_comparison", "SELECT !a = b FROM t", `SELECT (NOT a) = b AS "!a = b" FROM t`},
+		{"M-21_not_equal_untouched", "SELECT a != b FROM t", `SELECT a != b FROM t`},
+		{"M-21_bitxor", "SELECT a ^ b FROM t", `SELECT mysql_bit_xor(a, b) AS "a ^ b" FROM t`},
+		{"M-21_bitxor_literals", "SELECT 5 ^ 3", `SELECT mysql_bit_xor(5, 3) AS "5 ^ 3"`},
+		{"M-21_bitand_untouched", "SELECT a & b FROM t", "SELECT a & b FROM t"},
+		{"M-21_bitor_untouched", "SELECT a | b FROM t", "SELECT a | b FROM t"},
+		{"M-21_shifts_untouched", "SELECT a << 1, b >> 2 FROM t", "SELECT a << 1, b >> 2 FROM t"},
+		// The positions a rewrite has to survive: a WHERE clause, a CASE, a
+		// window's PARTITION BY, and a GROUP BY, where an operand that stopped at
+		// the wrong token has shown up before.
+		{"M-21_andand_in_where", "SELECT a FROM t WHERE b && c", "SELECT a FROM t WHERE b AND c"},
+		{"M-21_bitxor_in_where", "SELECT a FROM t WHERE b ^ c = 0", "SELECT a FROM t WHERE mysql_bit_xor(b, c) = 0"},
+		{"M-21_bitxor_in_case", "SELECT CASE WHEN a ^ b THEN 1 ELSE 0 END FROM t", `SELECT CASE WHEN mysql_bit_xor(a, b) THEN 1 ELSE 0 END AS "CASE WHEN a ^ b THEN 1 ELSE 0 END" FROM t`},
+		{"M-21_bitxor_in_group_by", "SELECT a FROM t GROUP BY a ^ b", "SELECT a FROM t GROUP BY mysql_bit_xor(a, b)"},
+		{"M-21_bitxor_in_window", "SELECT SUM(a) OVER (PARTITION BY b ^ c) FROM t", `SELECT SUM(a) OVER (PARTITION BY mysql_bit_xor(b, c)) AS "SUM(a) OVER (PARTITION BY b ^ c)" FROM t`},
+		{"M-21_bang_in_where", "SELECT a FROM t WHERE !b", "SELECT a FROM t WHERE (NOT b)"},
+
 		{"unrelated_function_untouched", "SELECT COALESCE(a, b), SUM(c) FROM t", "SELECT COALESCE(a, b), SUM(c) FROM t"},
 		{"extract_without_from_passthrough", "SELECT EXTRACT(x) FROM t", "SELECT EXTRACT(x) FROM t"},
 		{"cast_without_as_passthrough", "SELECT CAST(x) FROM t", "SELECT CAST(x) FROM t"},
@@ -89,6 +117,14 @@ func TestMySQLTranslateUnsupported(t *testing.T) {
 		{"M-5_missing_unit", "SELECT DATE_ADD(d, INTERVAL 3)"},
 		{"M-7_div_left_not_primary", "SELECT a, DIV b"},
 		{"M-7_div_right_missing", "SELECT a DIV"},
+		// XOR sits between OR and AND in MySQL's precedence, so its operands are
+		// whole AND-expressions rather than the primaries a rewrite can pick out.
+		// It is refused by name instead of being translated wrongly.
+		{"M-21_xor", "SELECT a XOR b FROM t"},
+		{"M-21_xor_lowercase", "SELECT a xor b FROM t"},
+		{"M-21_xor_in_where", "SELECT a FROM t WHERE b XOR c"},
+		{"M-21_bitxor_left_not_primary", "SELECT a, ^ b"},
+		{"M-21_bitxor_right_missing", "SELECT a ^"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/dialect/mysql_test.go
+++ b/dialect/mysql_test.go
@@ -84,6 +84,17 @@ func TestMySQLTranslate(t *testing.T) {
 		{"M-21_bitxor_in_group_by", "SELECT a FROM t GROUP BY a ^ b", "SELECT a FROM t GROUP BY mysql_bit_xor(a, b)"},
 		{"M-21_bitxor_in_window", "SELECT SUM(a) OVER (PARTITION BY b ^ c) FROM t", `SELECT SUM(a) OVER (PARTITION BY mysql_bit_xor(b, c)) AS "SUM(a) OVER (PARTITION BY b ^ c)" FROM t`},
 		{"M-21_bang_in_where", "SELECT a FROM t WHERE !b", "SELECT a FROM t WHERE (NOT b)"},
+		// "!" binds tighter than every operator rewritten below it, so it has to be
+		// resolved first: taken the other way round, the negation would end up
+		// outside the call and apply to the whole thing.
+		{"M-21_bang_left_of_bitxor", "SELECT !a ^ b FROM t", `SELECT mysql_bit_xor((NOT a), b) AS "!a ^ b" FROM t`},
+		{"M-21_bang_right_of_bitxor", "SELECT a ^ !b FROM t", `SELECT mysql_bit_xor(a, (NOT b)) AS "a ^ !b" FROM t`},
+		{"M-21_bang_left_of_divide", "SELECT !a / b FROM t", `SELECT mysql_divide((NOT a), b) AS "!a / b" FROM t`},
+		// A run of them negates as many times, and one inside a parenthesized
+		// operand is rewritten too rather than left for SQLite.
+		{"M-21_bang_double", "SELECT !!a FROM t", `SELECT (NOT (NOT a)) AS "!!a" FROM t`},
+		{"M-21_bang_nested_paren", "SELECT !(!a) FROM t", `SELECT (NOT ((NOT a))) AS "!(!a)" FROM t`},
+		{"M-21_bang_inside_call", "SELECT f(!a) FROM t", `SELECT f((NOT a)) AS "f(!a)" FROM t`},
 
 		{"unrelated_function_untouched", "SELECT COALESCE(a, b), SUM(c) FROM t", "SELECT COALESCE(a, b), SUM(c) FROM t"},
 		{"extract_without_from_passthrough", "SELECT EXTRACT(x) FROM t", "SELECT EXTRACT(x) FROM t"},

--- a/dialect/operators.go
+++ b/dialect/operators.go
@@ -242,29 +242,61 @@ func callTokens(name string, a, b []token) []token {
 	return repl
 }
 
-// fnBitXor implements MySQL's "^", a bitwise exclusive OR over 64-bit integers.
-// SQLite has &, | and ~ but no XOR operator, and the expression built from them
-// would evaluate each operand twice.
+// fnBitXor implements MySQL's "^", a bitwise exclusive OR. SQLite has &, | and ~
+// but no XOR operator, and the expression built from them would evaluate each
+// operand twice.
+//
+// The arithmetic is unsigned, as MySQL's bitwise operators are: an operand with
+// the high bit set is 2^64-1 rather than -1 there, and an operand written past
+// int64 is an ordinary literal. The result comes back as the same 64 bits in
+// SQLite's only integer, which is signed, so a result with the high bit set
+// reads as a negative number where MySQL would print it unsigned.
 //
 // A NULL operand gives NULL, as every arithmetic operator in SQL does. An
 // operand that is not a number gives NULL rather than an error, as the other
 // operator helpers here do.
 func fnBitXor(args []driver.Value) (driver.Value, error) {
-	a, ok1 := toInt(args[0])
-	b, ok2 := toInt(args[1])
+	a, ok1 := toUint64Bits(args[0])
+	b, ok2 := toUint64Bits(args[1])
 	if !ok1 || !ok2 {
 		return nil, nil
 	}
-	return a ^ b, nil
+	return int64(a ^ b), nil //nolint:gosec // the bits are the value; SQLite has no unsigned integer
+}
+
+// toUint64Bits reads an operand as the 64 bits MySQL's bitwise operators work
+// on. A negative number is its two's complement, and a text operand past int64
+// is read as the unsigned literal MySQL would have taken it for.
+func toUint64Bits(v driver.Value) (uint64, bool) {
+	if s, ok := v.(string); ok {
+		if n, err := strconv.ParseUint(strings.TrimSpace(s), 10, 64); err == nil {
+			return n, true
+		}
+	}
+	if b, ok := v.([]byte); ok {
+		if n, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64); err == nil {
+			return n, true
+		}
+	}
+	n, ok := toInt(v)
+	if !ok {
+		return 0, false
+	}
+	return uint64(n), true //nolint:gosec // a negative operand is its two's complement, which is what MySQL uses
 }
 
 // unaryNotPass rewrites MySQL's "!" into a parenthesized NOT over the primary it
 // applies to.
 //
 // MySQL's "!" binds tighter than a comparison while SQLite's NOT binds looser
-// than one, so "!a = b" written as
-// "NOT a = b" changes from negating a to negating the comparison. Wrapping the
-// result keeps it a primary, which is what the operator was.
+// than one, so "!a = b" written as "NOT a = b" changes from negating a to
+// negating the comparison. Wrapping the result keeps it a primary, which is what
+// the operator was.
+//
+// A run of them is one operand each way round: "!!a" is a double negation in
+// MySQL, and the operand of the last one is what the primary rule applies to.
+// The operand is rewritten too, so a "!" inside a parenthesized one is not left
+// for SQLite.
 //
 // "!=" is one token to the tokenizer, so a not-equal comparison never reaches
 // here.
@@ -277,14 +309,35 @@ func unaryNotPass(tokens []token) ([]token, error) {
 			i++
 			continue
 		}
-		start := nextSig(tokens, i+1)
-		end, ok := primaryEndForward(tokens, i+1)
+
+		// Every "!" up to the operand, so "!!a" negates twice rather than failing
+		// on an operand that is another "!".
+		depth := 0
+		j := i
+		for j >= 0 && j < len(tokens) && isOpEq(tokens[j], "!") {
+			depth++
+			j = nextSig(tokens, j+1)
+		}
+		if j < 0 {
+			return nil, fmt.Errorf("%w: operand of ! is not a primary expression", ErrUnsupportedSyntax)
+		}
+		start := j
+		end, ok := primaryEndForward(tokens, j)
 		if !ok {
 			return nil, fmt.Errorf("%w: operand of ! is not a primary expression", ErrUnsupportedSyntax)
 		}
-		out = append(out, opToken("("), wordToken("NOT"), spaceToken())
-		out = append(out, tokens[start:end+1]...)
-		out = append(out, opToken(")"))
+		operand, err := unaryNotPass(tokens[start : end+1])
+		if err != nil {
+			return nil, err
+		}
+
+		for range depth {
+			out = append(out, opToken("("), wordToken("NOT"), spaceToken())
+		}
+		out = append(out, operand...)
+		for range depth {
+			out = append(out, opToken(")"))
+		}
 		i = end + 1
 	}
 	return out, nil

--- a/dialect/operators.go
+++ b/dialect/operators.go
@@ -242,6 +242,66 @@ func callTokens(name string, a, b []token) []token {
 	return repl
 }
 
+// fnBitXor implements MySQL's "^", a bitwise exclusive OR over 64-bit integers.
+// SQLite has &, | and ~ but no XOR operator, and the expression built from them
+// would evaluate each operand twice.
+//
+// A NULL operand gives NULL, as every arithmetic operator in SQL does. An
+// operand that is not a number gives NULL rather than an error, as the other
+// operator helpers here do.
+func fnBitXor(args []driver.Value) (driver.Value, error) {
+	a, ok1 := toInt(args[0])
+	b, ok2 := toInt(args[1])
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+	return a ^ b, nil
+}
+
+// unaryNotPass rewrites MySQL's "!" into a parenthesized NOT over the primary it
+// applies to.
+//
+// MySQL's "!" binds tighter than a comparison while SQLite's NOT binds looser
+// than one, so "!a = b" written as
+// "NOT a = b" changes from negating a to negating the comparison. Wrapping the
+// result keeps it a primary, which is what the operator was.
+//
+// "!=" is one token to the tokenizer, so a not-equal comparison never reaches
+// here.
+func unaryNotPass(tokens []token) ([]token, error) {
+	out := make([]token, 0, len(tokens))
+	i := 0
+	for i < len(tokens) {
+		if !isOpEq(tokens[i], "!") {
+			out = append(out, tokens[i])
+			i++
+			continue
+		}
+		start := nextSig(tokens, i+1)
+		end, ok := primaryEndForward(tokens, i+1)
+		if !ok {
+			return nil, fmt.Errorf("%w: operand of ! is not a primary expression", ErrUnsupportedSyntax)
+		}
+		out = append(out, opToken("("), wordToken("NOT"), spaceToken())
+		out = append(out, tokens[start:end+1]...)
+		out = append(out, opToken(")"))
+		i = end + 1
+	}
+	return out, nil
+}
+
+// rejectWordPass refuses a construct that has no faithful SQLite spelling,
+// naming the construct rather than letting SQLite answer with a syntax error
+// near a keyword it does not know.
+func rejectWordPass(tokens []token, keyword, because string) error {
+	for _, t := range tokens {
+		if isWordEq(t, keyword) {
+			return fmt.Errorf("%w: %s is not supported; %s", ErrUnsupportedSyntax, keyword, because)
+		}
+	}
+	return nil
+}
+
 // replaceOperatorWithWord swaps an operator token for a keyword, spacing it so
 // "a||b" renders as "a OR b" rather than "aORb".
 func replaceOperatorWithWord(tokens []token, op, keyword string) []token {

--- a/dialect/operators_test.go
+++ b/dialect/operators_test.go
@@ -44,7 +44,9 @@ func TestOperatorSemantics(t *testing.T) {
 		{"mysql && is true when both are", MySQL, `SELECT 1 && 2`, "1", false},
 		{"mysql ! negates", MySQL, `SELECT !0`, "1", false},
 		{"mysql ! negates a nonzero", MySQL, `SELECT !5`, "0", false},
-		{"mysql ! binds tighter than a comparison", MySQL, `SELECT !0 = 1`, "1", false},
+		// The case that tells the two readings apart: "(!1) = 2" is 0, while the
+		// bare "NOT 1 = 2" SQLite would have parsed is 1.
+		{"mysql ! binds tighter than a comparison", MySQL, `SELECT !1 = 2`, "0", false},
 		{"mysql ! twice is the value's truth", MySQL, `SELECT !!5`, "1", false},
 		{"mysql ^ is a bitwise xor", MySQL, `SELECT 5 ^ 3`, "6", false},
 		{"mysql ^ of equal operands is zero", MySQL, `SELECT 7 ^ 7`, "0", false},

--- a/dialect/operators_test.go
+++ b/dialect/operators_test.go
@@ -38,6 +38,26 @@ func TestOperatorSemantics(t *testing.T) {
 		{"mysql DIV truncates toward zero", MySQL, `SELECT -7 DIV 2`, "-3", false},
 		{"postgresql keeps integer division", PostgreSQL, `SELECT 5/2`, "2", false},
 
+		// The operators MySQL spells with punctuation, executed rather than only
+		// rewritten: the rewrite is only right if the answer is.
+		{"mysql && is AND", MySQL, `SELECT 1 && 0`, "0", false},
+		{"mysql && is true when both are", MySQL, `SELECT 1 && 2`, "1", false},
+		{"mysql ! negates", MySQL, `SELECT !0`, "1", false},
+		{"mysql ! negates a nonzero", MySQL, `SELECT !5`, "0", false},
+		{"mysql ! binds tighter than a comparison", MySQL, `SELECT !0 = 1`, "1", false},
+		{"mysql ! twice is the value's truth", MySQL, `SELECT !!5`, "1", false},
+		{"mysql ^ is a bitwise xor", MySQL, `SELECT 5 ^ 3`, "6", false},
+		{"mysql ^ of equal operands is zero", MySQL, `SELECT 7 ^ 7`, "0", false},
+		// The bits are what the operator works on, and SQLite's only integer is
+		// signed, so a result with the high bit set reads as a negative number
+		// where MySQL prints it unsigned.
+		{"mysql ^ works on the high bit", MySQL, `SELECT -1 ^ 0`, "-1", false},
+		// A text operand past int64 is read as the unsigned number it spells. As a
+		// literal it never reaches the helper unchanged: SQLite's own parser turns
+		// an integer past int64 into a float first.
+		{"mysql ^ of a high-bit text operand", MySQL, `SELECT '18446744073709551615' ^ 0`, "-1", false},
+		{"mysql ^ propagates null", MySQL, `SELECT 1 ^ NULL`, "", true},
+
 		// LIKE is case-sensitive outside MySQL; SQLite's folds ASCII case.
 		{"postgresql LIKE is case-sensitive", PostgreSQL, `SELECT 'ABC' LIKE 'abc'`, "0", false},
 		{"postgresql LIKE matches exactly", PostgreSQL, `SELECT 'abc' LIKE 'a%'`, "1", false},

--- a/dialect/postgresql.go
+++ b/dialect/postgresql.go
@@ -26,6 +26,7 @@ import (
 //	P-15 BOOL_AND / STDDEV / ...   -> SQLite aggregate expressions
 //	P-16 TRIM(BOTH x FROM s), OVERLAY, BTRIM, JSONB_ARRAY_LENGTH
 //	P-17 ARRAY[...]                -> ErrUnsupportedSyntax
+//	P-18 generate_series(...) etc. -> ErrUnsupportedSyntax
 func rewritePostgreSQL(tokens []token) ([]token, error) {
 	if err := checkUnsupportedPostgreSQL(tokens); err != nil {
 		return nil, err
@@ -98,8 +99,46 @@ func checkUnsupportedPostgreSQL(tokens []token) error {
 				return fmt.Errorf("%w: DISTINCT ON is not supported", ErrUnsupportedSyntax)
 			}
 		}
+		// P-18: a set-returning function is a row source, and SQLite has no form
+		// for one. Passed through, the error was "no such table: generate_series",
+		// which reads as a missing input file rather than as a construct the
+		// translation cannot express.
+		if name, ok := setReturningFunction(t); ok {
+			if open := nextSig(tokens, i+1); open >= 0 && isOpEq(tokens[open], "(") {
+				return fmt.Errorf("%w: %s is not supported; SQLite has no set-returning functions", ErrUnsupportedSyntax, name)
+			}
+		}
 	}
 	return nil
+}
+
+// pgSetReturningFunctions are the PostgreSQL functions that return a set of
+// rows. They are named rather than detected, because nothing in the syntax says
+// a call returns a set.
+//
+// It lists only the functions with no SQLite counterpart. The json ones are left
+// out on purpose: SQLite's json1 extension has json_each and json_tree, so a
+// query using them runs, and refusing it would take away something that works.
+var pgSetReturningFunctions = map[string]struct{}{
+	"generate_series":       {},
+	"generate_subscripts":   {},
+	"unnest":                {},
+	"regexp_split_to_table": {},
+	"string_to_table":       {},
+	"regexp_matches":        {},
+}
+
+// setReturningFunction reports whether t names a set-returning function,
+// returning the name PostgreSQL spells it with.
+func setReturningFunction(t token) (string, bool) {
+	if t.kind != tokWord {
+		return "", false
+	}
+	name := strings.ToLower(t.text)
+	if _, ok := pgSetReturningFunctions[name]; !ok {
+		return "", false
+	}
+	return name, true
 }
 
 // pgCallPass rewrites the PostgreSQL function-call rules (C-1, P-4, P-5, P-8),

--- a/dialect/postgresql_test.go
+++ b/dialect/postgresql_test.go
@@ -76,6 +76,30 @@ func TestPostgreSQLTranslate(t *testing.T) {
 	}
 }
 
+// TestPostgreSQLSetReturningNameIsNotACall checks that a name which merely looks
+// like a set-returning function is not one: only a call is refused, so a column
+// or a table of that name still translates.
+func TestPostgreSQLSetReturningNameIsNotACall(t *testing.T) {
+	t.Parallel()
+	tests := []string{
+		"SELECT generate_series FROM t",
+		"SELECT a FROM generate_series",
+		"SELECT t.unnest FROM t",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			got, err := Translate(PostgreSQL, input)
+			if err != nil {
+				t.Fatalf("Translate(PostgreSQL, %q) unexpected error: %v", input, err)
+			}
+			if got != input {
+				t.Fatalf("Translate(PostgreSQL, %q) = %q, want it unchanged", input, got)
+			}
+		})
+	}
+}
+
 func TestPostgreSQLTranslateUnsupported(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -83,6 +107,13 @@ func TestPostgreSQLTranslateUnsupported(t *testing.T) {
 		input string
 	}{
 		{"P-10_distinct_on", "SELECT DISTINCT ON (a) a, b FROM t"},
+		// P-18: passed through, this reported "no such table: generate_series",
+		// which reads as a missing input file rather than as a construct the
+		// translation cannot express.
+		{"P-18_generate_series", "SELECT n FROM generate_series(1, 3) AS n"},
+		{"P-18_generate_series_in_select", "SELECT generate_series(1, 3)"},
+		{"P-18_unnest", "SELECT * FROM unnest(ARRAY[1, 2])"},
+		{"P-18_regexp_split_to_table", "SELECT regexp_split_to_table('a,b', ',')"},
 		{"P-10_lateral", "SELECT * FROM t, LATERAL (SELECT 1) s"},
 		{"P-3_ci_non_literal", "SELECT * FROM t WHERE a ~* b"},
 		// A separator SQLite cannot keep alongside DISTINCT. Answering with a

--- a/dialect/token.go
+++ b/dialect/token.go
@@ -385,7 +385,7 @@ func scanNumber(s string, i int) int {
 // multiCharOperators lists the multi-byte operators to recognize as one token,
 // longest first so matchOperator prefers the longest match.
 var multiCharOperators = []string{
-	"<=>", "!~*", "->>", "!~", "~*", "->", "<=", ">=", "<>", "!=", "||", "<<", ">>", "::", ":=",
+	"<=>", "!~*", "->>", "!~", "~*", "->", "<=", ">=", "<>", "!=", "||", "&&", "<<", ">>", "::", ":=",
 }
 
 // matchOperator returns the operator or punctuation token starting at s[i],


### PR DESCRIPTION
Three related dialect gaps, all reported against sqly: a query written for the source dialect reached SQLite untranslated and failed with a message about SQLite's parser or catalog rather than about the construct.

## MySQL's operator family (nao1215/sqly#893)

`||` was translated to `OR` and its siblings were not, so `&&`, `!`, and `^` arrived at SQLite's tokenizer as unrecognized tokens.

- `a && b` becomes `a AND b`. `&&` is now one token to the tokenizer, which is what lets it be replaced as a unit.
- `!a` becomes `(NOT a)`. The parentheses are the substance: MySQL's `!` binds tighter than a comparison while SQLite's `NOT` binds looser, so `!a = b` written as a bare `NOT` would negate the comparison instead of the operand. `!=` is one token, so a not-equal comparison never reaches the pass.
- `a ^ b` becomes `mysql_bit_xor(a, b)`. SQLite has `&`, `|`, and `~` but no XOR operator, and the `(a|b)&~(a&b)` expansion would evaluate each operand twice — a difference a `random()` operand would show.
- `a XOR b` is refused. Its precedence sits between `OR` and `AND`, which SQLite has no operator for, so its operands are whole AND-expressions rather than the primaries a rewrite can pick out; translating it as if they were would reassociate `a AND b XOR c`. The message names the expansion to write by hand.

`&`, `|`, `<<`, and `>>`, which SQLite shares, are untouched, and PostgreSQL's `^` still means exponentiation.

## BigQuery's SAFE. prefix (nao1215/sqly#894)

Only the underscore spelling was recognized, so `SAFE.DIVIDE(1, 0)` — the form BigQuery's own documentation uses — reached SQLite as a qualified name and reported on the `(` that followed. `SAFE.f(args)` now folds into the `safe_f` helper the rest of the pass already knows, for the five functions that have one. A `SAFE.` prefix on any other function is refused rather than dropped: dropping it would answer with the plain function, which raises where the caller asked for a NULL. A `safe` that is not a call — a column of that name, or a table qualifying one — is left alone.

## Constructs SQLite cannot represent (nao1215/sqly#895)

A GoogleSQL array literal came back as `no such column: 1,2,3`, because SQLite reads `[...]` as identifier quoting, and PostgreSQL's `generate_series` as `no such table`, which reads as a missing input file. Both now say which construct is unsupported. Under GoogleSQL a `[` is never quoting — backticks are — so every one of them is an array. The PostgreSQL list names only the set-returning functions with no SQLite counterpart; the json ones are left out on purpose, because SQLite's json1 extension has `json_each` and `json_tree` and refusing them would take away something that works.

## Tests

Each operator is covered in the rewrite table and at the positions where an operand that stopped at the wrong token has shown up before: a WHERE clause, a CASE, a window's PARTITION BY, and a GROUP BY. The refusals are covered by name, and a column or table merely named like a set-returning function still translates unchanged.

Refs nao1215/sqly#893, nao1215/sqly#894, nao1215/sqly#895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved MySQL compatibility for `&&`, unary `!`, and `^` operators.
  - Added BigQuery `SAFE.` function translation for supported functions.
  - Added clearer handling of unsupported SQL constructs across MySQL, BigQuery, PostgreSQL, and SQLite.

- **Bug Fixes**
  - Replaced confusing SQLite errors with descriptive messages for unsupported arrays, subscripts, and PostgreSQL set-returning functions.
  - Added clear errors for unsupported or malformed syntax, including MySQL `XOR` and invalid `SAFE.` calls.

- **Documentation**
  - Updated compatibility documentation and the unreleased changelog with the latest dialect support and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->