### PR TITLE
docs(changelog): stamp v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.41.0] - 2026-08-09
 
 ### Added
 
@@ -1172,7 +1172,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.40.1...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.41.0...HEAD
 [0.30.1]: https://github.com/nao1215/filesql/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/nao1215/filesql/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/nao1215/filesql/compare/v0.28.0...v0.29.0


### PR DESCRIPTION
Stamps the Unreleased section as v0.41.0. It adds MySQL's operator family (&&, !, ^) and BigQuery's SAFE. call prefix to the dialect translation, and refuses by name the constructs SQLite cannot represent — GoogleSQL arrays, PostgreSQL set-returning functions, and MySQL's XOR — which previously reached SQLite's parser and reported on a column or table the query never wrote. The bump is a minor because the translation accepts syntax it did not before.