### PR TITLE
fix: keep a zero-padded code text in the parser and the frame package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- A zero-padded code survives the `frame` package ([#274](https://github.com/nao1215/filesql/issues/274), [#278](https://github.com/nao1215/filesql/issues/278)). The parser's own type inference had none of the guards the SQLite load path was given: it called `007` an integer, so a DataFrame stored 7, and a round trip through `NewDataFrame` and `ToCSV` wrote back a file whose codes had lost their zeros. `Distinct` merged `007` into `7`, and `Join` matched a `007` account to a `7` account — a row pair in neither input. A zero-padded literal is now text wherever the parser classifies a value, and a `frame` column called numeric keeps a value the conversion would change, since the type is decided from a sample and a code can arrive below it. Decimal scale is unchanged: `1.50` is the real 1.5 here as everywhere else in filesql, because the quantity survives and only the way it was written does not.
+
 ## [0.41.0] - 2026-08-09
 
 ### Added

--- a/frame/dataframe.go
+++ b/frame/dataframe.go
@@ -111,14 +111,25 @@ func NewDataFrameFromPath(path string) (*DataFrame, error) {
 	return dataFrameFromParseResult(result), nil
 }
 
-// convertStringValue converts a string value to the appropriate Go type based on ColumnType.
+// convertStringValue converts a string value to the appropriate Go type based on
+// ColumnType.
+//
+// The column's type is decided from a sample, so a value that only text holds
+// can arrive in a column already called numeric — a zero-padded code below the
+// codes the sample saw. Such a value keeps its text form: the type says what the
+// column mostly is, and the value says what it is.
+//
+// Losslessness is asked of the integer conversion by rendering it back. It is
+// not asked of the real one: "1.50" is the real 1.5 here as it is everywhere
+// else in filesql, because the quantity survives and only the way it was
+// written does not.
 func convertStringValue(s string, ct parser.ColumnType) any {
 	switch ct {
 	case parser.TypeInteger:
 		if s == "" {
 			return s
 		}
-		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		if i, err := strconv.ParseInt(s, 10, 64); err == nil && strconv.FormatInt(i, 10) == s {
 			return i
 		}
 		return s

--- a/frame/dataframe_test.go
+++ b/frame/dataframe_test.go
@@ -2787,3 +2787,124 @@ func TestCompareValues(t *testing.T) {
 		assert.NotEqual(t, 0, result) // Just check it doesn't panic
 	})
 }
+
+// TestDataFrameKeepsValuesOnlyTextHolds pins the fidelity the SQLite load path
+// was given: a value that looks numeric but cannot be one without loss keeps its
+// text form. A zero-padded code and an integer past int64 are the two, and both
+// used to come back changed — 007 as 7, an account number as 1.104032026e+19 —
+// from a round trip that only read the file and wrote it out again.
+//
+// Decimal scale is not among them: "1.50" loads as the real 1.5 here as it does
+// everywhere else in filesql, because the quantity survives and only the way it
+// was written does not.
+func TestDataFrameKeepsValuesOnlyTextHolds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "a zero-padded code keeps its zeros",
+			input: "code\n007\n010\n",
+			want:  "code\n007\n010\n",
+		},
+		{
+			name:  "an integer past int64 keeps its digits",
+			input: "n\n99999999999999999999\n",
+			want:  "n\n99999999999999999999\n",
+		},
+		{
+			name:  "an ordinary integer is still a number",
+			input: "n\n1\n2\n",
+			want:  "n\n1\n2\n",
+		},
+		{
+			name:  "a decimal keeps its quantity, not its scale",
+			input: "amt\n1.50\n2.00\n",
+			want:  "amt\n1.5\n2\n",
+		},
+		{
+			name:  "a zero-padded code mixed with a plain one keeps both",
+			input: "code\n007\n42\n",
+			want:  "code\n007\n42\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			df, err := NewDataFrame(strings.NewReader(tt.input), CSV)
+			if err != nil {
+				t.Fatalf("NewDataFrame: %v", err)
+			}
+
+			out := filepath.Join(t.TempDir(), "out.csv")
+			if err := df.ToCSV(out); err != nil {
+				t.Fatalf("ToCSV: %v", err)
+			}
+			got, err := os.ReadFile(out) //nolint:gosec // test-owned path
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("round trip = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDistinctAndJoinCompareValuesAsWritten covers what typing a value costs
+// when the value is an identifier. Both used to coerce: Distinct merged 007 into
+// 7 and kept the one without its zeros, and Join matched a 007 account to a 7
+// account, a row pair that exists in neither input.
+//
+// Values equal as numbers and written differently — 1, 1.0, 1.00 — still
+// collapse. That is the decimal-scale trade-off filesql makes everywhere: the
+// quantity survives and the spelling does not.
+func TestDistinctAndJoinCompareValuesAsWritten(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a zero-padded code is not the code without its zeros", func(t *testing.T) {
+		t.Parallel()
+
+		df, err := NewDataFrame(strings.NewReader("code\n007\n7\n7\n"), CSV)
+		require.NoError(t, err)
+
+		got := df.Distinct().ToRecords()
+
+		// Both are text: a column holding a code is a text column, and the two
+		// codes in it are two values.
+		assert.Equal(t, []map[string]any{{"code": "007"}, {"code": "7"}}, got)
+	})
+
+	t.Run("a join does not match a code to its numeric reading", func(t *testing.T) {
+		t.Parallel()
+
+		left, err := NewDataFrame(strings.NewReader("id,x\n007,a\n"), CSV)
+		require.NoError(t, err)
+		right, err := NewDataFrame(strings.NewReader("id,y\n7,Z\n"), CSV)
+		require.NoError(t, err)
+
+		joined, err := left.Join(right, JoinOption{On: []string{"id"}, How: InnerJoin})
+		require.NoError(t, err)
+
+		assert.Empty(t, joined.ToRecords(), "007 and 7 are different identifiers")
+	})
+
+	t.Run("a join still matches a code to itself", func(t *testing.T) {
+		t.Parallel()
+
+		left, err := NewDataFrame(strings.NewReader("id,x\n007,a\n"), CSV)
+		require.NoError(t, err)
+		right, err := NewDataFrame(strings.NewReader("id,y\n007,Z\n"), CSV)
+		require.NoError(t, err)
+
+		joined, err := left.Join(right, JoinOption{On: []string{"id"}, How: InnerJoin})
+		require.NoError(t, err)
+
+		assert.Equal(t, []map[string]any{{"id": "007", "x": "a", "y": "Z"}}, joined.ToRecords())
+	})
+}

--- a/parser/types.go
+++ b/parser/types.go
@@ -107,6 +107,13 @@ func isInteger(s string) bool {
 		return false
 	}
 
+	// A zero-padded literal is not one. The leading zero is what the value means
+	// — a ZIP code, a product ID — and every numeric type drops it, so the only
+	// form that holds the value is text.
+	if isZeroPaddedIntegerLiteral(s) {
+		return false
+	}
+
 	_, err := strconv.ParseInt(s, 10, 64)
 	return err == nil
 }
@@ -123,8 +130,35 @@ func isFloat(s string) bool {
 		return false
 	}
 
+	if isZeroPaddedIntegerLiteral(s) {
+		return false
+	}
+
 	_, err := strconv.ParseFloat(s, 64)
 	return err == nil
+}
+
+// isZeroPaddedIntegerLiteral reports whether s is an integer literal with a
+// redundant leading zero, such as "007" or "02134".
+//
+// Decimal scale is deliberately not treated the same way. "1.50" is the real
+// 1.5 here as it is everywhere else in filesql: the quantity survives and only
+// the way it was written does not, while a leading zero is the value itself.
+// A lone "0" is an ordinary integer.
+func isZeroPaddedIntegerLiteral(s string) bool {
+	digits := s
+	if len(digits) > 0 && (digits[0] == '+' || digits[0] == '-') {
+		digits = digits[1:]
+	}
+	if len(digits) < 2 || digits[0] != '0' {
+		return false
+	}
+	for i := range len(digits) {
+		if digits[i] < '0' || digits[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // isDatetime checks if the string represents a datetime value.


### PR DESCRIPTION
The `frame` package lost a zero-padded code, and two of its operations went wrong on top of that loss. All three come from one place: the `parser` package's type inference has none of the guards the SQLite load path was given in #255.

```go
df, _ := frame.NewDataFrame(strings.NewReader("code\n007\n010\n"), frame.CSV)
df.ToCSV("out.csv")   // code\n7\n10\n  — the zeros are gone
```

`isInteger` called `007` an integer, so the column was INTEGER and the DataFrame stored 7. From there:

- a round trip that only read a file and wrote it out again changed the data (#274);
- `Distinct` merged `007` into `7` and kept the one without its zeros (#276, in part);
- `Join` matched a `007` account to a `7` account (#278) — a row pair that exists in neither input, which is the difference between a correct join and a silently wrong one.

A zero-padded literal is now text wherever the parser classifies a value, which is the rule the root package's `types.go` already applies: the leading zero is what the value means — a ZIP code, a product ID — and every numeric type drops it, so text is the only form that holds it.

`frame`'s own conversion also asks the integer case whether it is lossless, by rendering the parsed number back. The column's type comes from a sample, so a code below the values the sample saw can arrive in a column already called numeric; the type says what the column mostly is, and the value says what it is.

Decimal scale is deliberately unchanged. `1.50` is the real 1.5 here as it is everywhere else in filesql, because the quantity survives and only the way it was written does not. That is why this closes #274 and #278 but only half of #276: `007` and `7` are two values now, while `1`, `1.0`, and `1.00` still collapse — the trade-off the load path documents, applied consistently rather than differently in one package.

Tests: a round trip of a zero-padded code, an integer past int64, an ordinary integer, a decimal, and a mixed column; `Distinct` keeping two codes apart; `Join` refusing `007` against `7` and still matching `007` against `007`.

Closes #274
Closes #278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved zero-padded numeric codes, such as `007`, as text during parsing and data operations.
  * Prevented large integers and other values from being converted when conversion would change their original representation.
  * Ensured distinct and join operations compare identifiers as written.
  * Maintained existing decimal and standard numeric conversion behavior.

* **Documentation**
  * Added changelog details covering the updated value-preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->