### PR TITLE
fix: keep a numeric-looking value that the file padded with whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A value the file quoted with surrounding whitespace keeps it, whatever it looks like ([#266](https://github.com/nao1215/filesql/issues/266)). SQLite's numeric affinity converts `" 5 "` to 5 on the way into a numeric column, so the spaces the quotes made part of the value were gone, while the text column beside it kept its own — the same input preserved or rewritten depending on what it looked like, and a fixed-width padded code (`"  42"`) rewritten silently. Such a value is now text, which is the rule already applied to a zero-padded code and an integer past int64: a value SQLite's affinity would change on the way in has no numeric form that holds it.
+
 - A zero-padded code survives the `frame` package ([#274](https://github.com/nao1215/filesql/issues/274), [#278](https://github.com/nao1215/filesql/issues/278)). The parser's own type inference had none of the guards the SQLite load path was given: it called `007` an integer, so a DataFrame stored 7, and a round trip through `NewDataFrame` and `ToCSV` wrote back a file whose codes had lost their zeros. `Distinct` merged `007` into `7`, and `Join` matched a `007` account to a `7` account — a row pair in neither input. A zero-padded literal is now text wherever the parser classifies a value, and a `frame` column called numeric keeps a value the conversion would change, since the type is decided from a sample and a code can arrive below it. Decimal scale is unchanged: `1.50` is the real 1.5 here as everywhere else in filesql, because the quantity survives and only the way it was written does not.
 
 ## [0.41.0] - 2026-08-09

--- a/column_zero_padded_test.go
+++ b/column_zero_padded_test.go
@@ -162,3 +162,69 @@ func TestOpenContextPreservesZeroPaddedCodes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "00501", got)
 }
+
+// TestSurroundingWhitespaceKeepsAValueText covers the other way a numeric column
+// rewrites what it was given. SQLite's affinity converts " 5 " to 5, so the
+// spaces the file quoted were gone, while the text column beside it kept its
+// own: the same input was preserved or altered depending on what it looked like.
+//
+// A value with no surrounding whitespace is unaffected, and whitespace around
+// something that is not a number was already text.
+func TestSurroundingWhitespaceKeepsAValueText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "a padded integer", value: " 5 ", want: true},
+		{name: "a leading-space integer", value: "  42", want: true},
+		{name: "a trailing-space integer", value: "42 ", want: true},
+		{name: "a padded real", value: " 1.5 ", want: true},
+		{name: "a padded negative", value: " -7 ", want: true},
+		{name: "a plain integer", value: "5", want: false},
+		{name: "a plain real", value: "1.5", want: false},
+		{name: "padded text", value: " ab ", want: false},
+		{name: "whitespace only", value: "   ", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := mustStayText(tt.value); got != tt.want {
+				t.Errorf("mustStayText(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestQuotedWhitespaceSurvivesTheLoad is the same rule seen through a load: both
+// columns keep the bytes the file quoted, which is what the quotes said.
+func TestQuotedWhitespaceSurvivesTheLoad(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "padded.csv")
+	if err := os.WriteFile(path, []byte("num,txt\n\" 5 \",\" ab \"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := OpenContext(ctx, path)
+	if err != nil {
+		t.Fatalf("OpenContext: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var num, txt string
+	if err := db.QueryRowContext(ctx, "SELECT num, txt FROM padded").Scan(&num, &txt); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if num != " 5 " {
+		t.Errorf("num = %q, want %q: the quotes made the spaces part of the value", num, " 5 ")
+	}
+	if txt != " ab " {
+		t.Errorf("txt = %q, want %q", txt, " ab ")
+	}
+}

--- a/types.go
+++ b/types.go
@@ -778,13 +778,21 @@ func isFloat(value string) bool {
 // column, and no later inspection can recover what it said. So every value is
 // asked this question, and only the leftovers are sampled.
 func mustStayText(value string) bool {
-	value = strings.TrimSpace(value)
-	if value == "" {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
 		return false
 	}
-	return isZeroPaddedIntegerLiteral(value) ||
-		isIntegerLiteralOverflowingInt64(value) ||
-		hasGoOnlyNumericSyntax(value)
+	// Surrounding whitespace on a value that would otherwise be a number is the
+	// same kind of loss. SQLite's numeric affinity converts " 5 " to 5 and the
+	// spaces are gone, while the text column beside it keeps its own — so the
+	// same input was preserved or rewritten depending on what it looked like.
+	// A fixed-width padded code ("  42") is the case that costs.
+	if trimmed != value && (isInteger(trimmed) || isFloat(trimmed)) {
+		return true
+	}
+	return isZeroPaddedIntegerLiteral(trimmed) ||
+		isIntegerLiteralOverflowingInt64(trimmed) ||
+		hasGoOnlyNumericSyntax(trimmed)
 }
 
 // hasGoOnlyNumericSyntax reports whether value uses numeric syntax that Go's


### PR DESCRIPTION
A quoted CSV field means the quotes enclose the value, spaces included. A numeric-looking one lost them and the text beside it did not:

```csv
num,txt
" 5 "," ab "
```

```
num=[5] length 1     txt=[ ab ] length 4
```

The column was typed numeric, and SQLite's affinity converts `" 5 "` to 5 on the way in, so the spaces were gone at exit 0. The same input was preserved or rewritten depending on what it looked like — and a fixed-width padded code (`"  42"`), where the padding is the point, was rewritten silently.

`mustStayText` already answers this question for three other cases: a zero-padded code, a literal past int64, and Go-only numeric syntax are all values SQLite's affinity would change the moment they reach a numeric column, and no later inspection can recover what they said. Surrounding whitespace on a numeric-looking value is the same thing, so it joins them.

The check is narrow: it applies only when trimming the value changes it *and* the trimmed form is a number. A value with no surrounding whitespace is untouched, and whitespace around something that is not a number was already text. The whole existing suite passes unchanged, which is the blast radius.

Tests cover the classifier directly (padded integer, real, negative, leading- and trailing-space forms, and the plain and non-numeric cases that must not change) and a load asserting both columns come back with the bytes the file quoted.

Closes #266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved surrounding whitespace in quoted, numeric-looking values instead of allowing SQLite to convert them.
  * Continued preserving zero-padded, overflowing, and other values that could lose their original formatting.
  * Empty values and ordinary numbers retain their existing behavior.

* **Tests**
  * Added coverage for whitespace-preserving numeric and textual values during data loading.

* **Documentation**
  * Added an unreleased changelog entry describing the preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->