### PR TITLE
docs(changelog): stamp v0.41.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.41.1] - 2026-08-09
 
 ### Fixed
 
@@ -1184,7 +1184,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.41.0...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.41.1...HEAD
 [0.30.1]: https://github.com/nao1215/filesql/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/nao1215/filesql/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/nao1215/filesql/compare/v0.28.0...v0.29.0


### PR DESCRIPTION
Stamps the Unreleased section as v0.41.1. Four import and export fixes, all of the same shape — a value the destination cannot hold as it was given: a quoted value padded with whitespace stays text instead of losing its spaces to numeric affinity, LTSV labels that are one column to SQLite are refused by name, a zero-padded code survives the frame package, and frame's ToTSV writes tab-separated records rather than CSV with its comma changed.