### PR TITLE
fix: make frame aggregates say when they have no answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- A `frame` aggregate says when it has no answer instead of inventing one ([#273](https://github.com/nao1215/filesql/issues/273), [#281](https://github.com/nao1215/filesql/issues/281)). `Sum` over a column with no number in it returned 0 for every group, which is what a real total of zero looks like, and `Mean` returned nil; both now refuse the column by name, while a group inside a numeric column that holds no value gets nil rather than 0. `Min` and `Max` over a text column returned nil, discarding an answer the data plainly held: they now follow SQLite's ordering, where a number sorts before any text and text compares lexically, so the minimum of `banana` and `apple` is `apple`.
+
+### Breaking Changes
+
+- `AggSum` returns nil rather than 0.0 for a group with no numeric value, and `AggMin`/`AggMax` return a string for a group holding only text. A caller asserting `float64` on those results must handle nil and string. This is what makes "nothing here was a number" distinguishable from "the numbers added to zero".
+
 ## [0.41.1] - 2026-08-09
 
 ### Fixed

--- a/frame/groupby.go
+++ b/frame/groupby.go
@@ -200,6 +200,9 @@ func (gdf *GroupedDataFrame) Sum(column string) (*DataFrame, error) {
 	if err := gdf.validateColumn(column); err != nil {
 		return nil, err
 	}
+	if err := gdf.requireNumeric(column, "sum"); err != nil {
+		return nil, err
+	}
 	return gdf.aggregate(column, AggSum, "sum_"+column), nil
 }
 
@@ -212,6 +215,9 @@ func (gdf *GroupedDataFrame) Sum(column string) (*DataFrame, error) {
 //	averages, err := df.GroupBy("category").Mean("amount")
 func (gdf *GroupedDataFrame) Mean(column string) (*DataFrame, error) {
 	if err := gdf.validateColumn(column); err != nil {
+		return nil, err
+	}
+	if err := gdf.requireNumeric(column, "mean"); err != nil {
 		return nil, err
 	}
 	return gdf.aggregate(column, AggMean, "mean_"+column), nil
@@ -245,6 +251,26 @@ func (gdf *GroupedDataFrame) Max(column string) (*DataFrame, error) {
 	return gdf.aggregate(column, AggMax, "max_"+column), nil
 }
 
+// requireNumeric reports an error when nothing in the column is a number, so an
+// aggregate that has no answer says so instead of returning one.
+//
+// Sum over such a column answered 0 for every group, which is indistinguishable
+// from a real total of zero, and Mean answered nil. Both are what a mistyped
+// column name that happens to exist, or a column of text, looks like — the
+// caller learns nothing from the result.
+//
+// A column holding some numbers is not refused: skipping the values that are
+// not is what these aggregates document, and the answer is still built from
+// data. Only a column with no number in it at all has no answer to give.
+func (gdf *GroupedDataFrame) requireNumeric(column, aggregate string) error {
+	for _, row := range gdf.df.rows {
+		if _, ok := toFloat64(row[column]); ok {
+			return nil
+		}
+	}
+	return fmt.Errorf("cannot %s column %q: no value in it is a number", aggregate, column)
+}
+
 // Built-in aggregation functions
 //
 // These functions handle type conversion automatically:
@@ -266,13 +292,23 @@ var AggCount AggFunc = func(values []any) any {
 
 // AggSum calculates the sum of numeric values.
 // Non-numeric values (including nil, strings, bools) are silently ignored.
-// Returns 0.0 if all values are non-numeric. Always returns float64.
+// Returns nil if no value was numeric, and float64 otherwise.
+//
+// nil rather than 0.0, because a 0.0 that means "nothing here was a number" and
+// a 0.0 that means "the numbers added to zero" are different answers and looked
+// identical. It is also what AggMean, AggMin and AggMax already return for a
+// group with nothing to work on.
 var AggSum AggFunc = func(values []any) any {
 	sum := 0.0
+	found := false
 	for _, v := range values {
 		if f, ok := toFloat64(v); ok {
 			sum += f
+			found = true
 		}
+	}
+	if !found {
+		return nil
 	}
 	return sum
 }
@@ -295,44 +331,88 @@ var AggMean AggFunc = func(values []any) any {
 	return sum / float64(count)
 }
 
-// AggMin finds the minimum numeric value.
-// Non-numeric values (including nil, strings, bools) are silently ignored.
-// Returns nil if no numeric values exist. Otherwise returns float64.
+// AggMin finds the smallest value, following SQLite's ordering: a number is
+// smaller than any text, and text compares lexically. Returns float64 when the
+// group holds a number, string when it holds only text, and nil when it holds
+// neither.
+//
+// Text used to be ignored, so the minimum of a column of words was nil — an
+// answer the data had, discarded. SQLite's MIN over the same column returns the
+// lexically smallest string.
 var AggMin AggFunc = func(values []any) any {
-	minVal := math.MaxFloat64
-	found := false
+	minNum := math.MaxFloat64
+	foundNum := false
+	var minText string
+	foundText := false
 	for _, v := range values {
 		if f, ok := toFloat64(v); ok {
-			if f < minVal {
-				minVal = f
+			if f < minNum {
+				minNum = f
 			}
-			found = true
+			foundNum = true
+			continue
+		}
+		if s, ok := aggText(v); ok {
+			if !foundText || s < minText {
+				minText = s
+			}
+			foundText = true
 		}
 	}
-	if !found {
-		return nil
+	// A number sorts before any text, so text decides only when there is no
+	// number at all.
+	if foundNum {
+		return minNum
 	}
-	return minVal
+	if foundText {
+		return minText
+	}
+	return nil
 }
 
-// AggMax finds the maximum numeric value.
-// Non-numeric values (including nil, strings, bools) are silently ignored.
-// Returns nil if no numeric values exist. Otherwise returns float64.
+// AggMax finds the largest value, following the same ordering as AggMin: any
+// text is larger than any number, so text decides whenever the group holds some.
 var AggMax AggFunc = func(values []any) any {
-	maxVal := -math.MaxFloat64
-	found := false
+	maxNum := -math.MaxFloat64
+	foundNum := false
+	var maxText string
+	foundText := false
 	for _, v := range values {
 		if f, ok := toFloat64(v); ok {
-			if f > maxVal {
-				maxVal = f
+			if f > maxNum {
+				maxNum = f
 			}
-			found = true
+			foundNum = true
+			continue
+		}
+		if s, ok := aggText(v); ok {
+			if !foundText || s > maxText {
+				maxText = s
+			}
+			foundText = true
 		}
 	}
-	if !found {
-		return nil
+	if foundText {
+		return maxText
 	}
-	return maxVal
+	if foundNum {
+		return maxNum
+	}
+	return nil
+}
+
+// aggText reports the text form of a value that is not a number, and whether
+// there is one. A nil is not text: it is the absence of a value, which is what
+// SQLite's aggregates skip.
+func aggText(v any) (string, bool) {
+	switch s := v.(type) {
+	case string:
+		return s, true
+	case []byte:
+		return string(s), true
+	default:
+		return "", false
+	}
 }
 
 // toFloat64 attempts to convert a value to float64.

--- a/frame/groupby_test.go
+++ b/frame/groupby_test.go
@@ -781,7 +781,9 @@ func TestAggregatesSayWhenTheyHaveNoAnswer(t *testing.T) {
 
 		byGroup := map[string]any{}
 		for _, r := range result.ToRecords() {
-			byGroup[r["cat"].(string)] = r["sum_val"]
+			cat, ok := r["cat"].(string)
+			require.True(t, ok, "the grouped column is text")
+			byGroup[cat] = r["sum_val"]
 		}
 		assert.InDelta(t, 1.0, byGroup["a"], 0)
 		assert.Nil(t, byGroup["b"], "the group held no value, which is not a total of zero")

--- a/frame/groupby_test.go
+++ b/frame/groupby_test.go
@@ -2,6 +2,7 @@ package frame
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -150,7 +151,9 @@ func TestGroupedDataFrame_Mean(t *testing.T) {
 		assert.Equal(t, 20.0, records[0]["mean_value"])
 	})
 
-	t.Run("returns nil for non-numeric values only", func(t *testing.T) {
+	// A column with no number in it has no mean, and answering nil said so only
+	// to a caller who thought to look.
+	t.Run("refuses a column with nothing numeric in it", func(t *testing.T) {
 		t.Parallel()
 
 		df := NewDataFrameFromRecords([]map[string]any{
@@ -159,11 +162,10 @@ func TestGroupedDataFrame_Mean(t *testing.T) {
 
 		grouped, err := df.GroupBy("category")
 		require.NoError(t, err)
-		result, err := grouped.Mean("value")
-		require.NoError(t, err)
+		_, err = grouped.Mean("value")
 
-		records := result.ToRecords()
-		assert.Nil(t, records[0]["mean_value"])
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "value")
 	})
 }
 
@@ -190,11 +192,14 @@ func TestGroupedDataFrame_Min(t *testing.T) {
 		assert.Equal(t, 10.0, records[0]["min_value"])
 	})
 
-	t.Run("returns nil for non-numeric values only", func(t *testing.T) {
+	// Text has a minimum, and it used to be thrown away for a nil. SQLite's MIN
+	// over the same column answers the lexically smallest string.
+	t.Run("returns the lexically smallest text", func(t *testing.T) {
 		t.Parallel()
 
 		df := NewDataFrameFromRecords([]map[string]any{
-			{"category": "A", "value": "text"},
+			{"category": "A", "value": "banana"},
+			{"category": "A", "value": "apple"},
 		})
 
 		grouped, err := df.GroupBy("category")
@@ -203,7 +208,7 @@ func TestGroupedDataFrame_Min(t *testing.T) {
 		require.NoError(t, err)
 
 		records := result.ToRecords()
-		assert.Nil(t, records[0]["min_value"])
+		assert.Equal(t, "apple", records[0]["min_value"])
 	})
 }
 
@@ -398,22 +403,39 @@ func TestAggFunctions(t *testing.T) {
 		assert.Nil(t, result)
 	})
 
-	t.Run("AggMin returns nil for no numeric values", func(t *testing.T) {
+	t.Run("AggMin returns the smallest text when there is no number", func(t *testing.T) {
 		t.Parallel()
 
-		values := []any{"text", nil}
-		result := AggMin(values)
-
-		assert.Nil(t, result)
+		assert.Equal(t, "text", AggMin([]any{"text", nil}))
+		assert.Equal(t, "a", AggMin([]any{"b", "a"}))
 	})
 
-	t.Run("AggMax returns nil for no numeric values", func(t *testing.T) {
+	t.Run("AggMin returns nil when there is nothing at all", func(t *testing.T) {
 		t.Parallel()
 
-		values := []any{"text", nil}
-		result := AggMax(values)
+		assert.Nil(t, AggMin([]any{nil, nil}))
+	})
 
-		assert.Nil(t, result)
+	t.Run("AggMax returns the largest text when there is no number", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, "text", AggMax([]any{"text", nil}))
+		assert.Equal(t, "b", AggMax([]any{"a", "b"}))
+	})
+
+	t.Run("AggMax returns nil when there is nothing at all", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Nil(t, AggMax([]any{nil, nil}))
+	})
+
+	// SQLite's ordering: any text is larger than any number, and a number is
+	// smaller than any text.
+	t.Run("text outranks a number for Max and loses to one for Min", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, "b", AggMax([]any{1, "b"}))
+		assert.InDelta(t, 1.0, AggMin([]any{1, "b"}), 0)
 	})
 }
 
@@ -675,5 +697,93 @@ func TestGroupBy_NonExistentAggregationColumn(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, ErrColumnNotFound))
+	})
+}
+
+// TestAggregatesSayWhenTheyHaveNoAnswer covers the two ways an aggregate over a
+// column of text used to answer as if it had one: Sum said 0, which is what a
+// real total of zero says, and Min said nil for a column whose minimum the data
+// plainly holds.
+func TestAggregatesSayWhenTheyHaveNoAnswer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Sum refuses a column with nothing numeric in it", func(t *testing.T) {
+		t.Parallel()
+
+		df, err := NewDataFrame(strings.NewReader("cat,val\na,x\na,y\n"), CSV)
+		require.NoError(t, err)
+		grouped, err := df.GroupBy("cat")
+		require.NoError(t, err)
+
+		_, err = grouped.Sum("val")
+
+		require.Error(t, err, "0 for every group is what a real total of zero looks like")
+		assert.Contains(t, err.Error(), "val")
+	})
+
+	// A column holding both numbers and text is a text column to the DataFrame,
+	// so none of its values is a number and the aggregate has nothing to add.
+	// It answered 0; it now says so.
+	t.Run("Sum refuses a column of numbers mixed with text", func(t *testing.T) {
+		t.Parallel()
+
+		df, err := NewDataFrame(strings.NewReader("cat,val\na,1\na,x\na,2\n"), CSV)
+		require.NoError(t, err)
+		grouped, err := df.GroupBy("cat")
+		require.NoError(t, err)
+
+		_, err = grouped.Sum("val")
+
+		require.Error(t, err)
+	})
+
+	t.Run("Sum adds a numeric column as before", func(t *testing.T) {
+		t.Parallel()
+
+		df, err := NewDataFrame(strings.NewReader("cat,val\na,1\na,2\n"), CSV)
+		require.NoError(t, err)
+		grouped, err := df.GroupBy("cat")
+		require.NoError(t, err)
+
+		result, err := grouped.Sum("val")
+
+		require.NoError(t, err)
+		assert.InDelta(t, 3.0, result.ToRecords()[0]["sum_val"], 0)
+	})
+
+	t.Run("Min and Max answer a text column the way SQLite does", func(t *testing.T) {
+		t.Parallel()
+
+		df, err := NewDataFrame(strings.NewReader("k,s\na,banana\na,apple\n"), CSV)
+		require.NoError(t, err)
+		grouped, err := df.GroupBy("k")
+		require.NoError(t, err)
+
+		minimum, err := grouped.Min("s")
+		require.NoError(t, err)
+		maximum, err := grouped.Max("s")
+		require.NoError(t, err)
+
+		assert.Equal(t, "apple", minimum.ToRecords()[0]["min_s"])
+		assert.Equal(t, "banana", maximum.ToRecords()[0]["max_s"])
+	})
+
+	t.Run("a group with nothing numeric gets nil, not zero", func(t *testing.T) {
+		t.Parallel()
+
+		df, err := NewDataFrame(strings.NewReader("cat,val\na,1\nb,\n"), CSV)
+		require.NoError(t, err)
+		grouped, err := df.GroupBy("cat")
+		require.NoError(t, err)
+
+		result, err := grouped.Sum("val")
+		require.NoError(t, err)
+
+		byGroup := map[string]any{}
+		for _, r := range result.ToRecords() {
+			byGroup[r["cat"].(string)] = r["sum_val"]
+		}
+		assert.InDelta(t, 1.0, byGroup["a"], 0)
+		assert.Nil(t, byGroup["b"], "the group held no value, which is not a total of zero")
 	})
 }


### PR DESCRIPTION
Two halves of one problem: an aggregate that cannot answer returned something that looks like an answer.

## Sum said 0 (#273)

```go
g, _ := frame.NewDataFrame(strings.NewReader("cat,val\na,x\na,y\n"), frame.CSV).GroupBy("cat")
s, err := g.Sum("val")   // [map[cat:a sum_val:0]] <nil>
```

`0` is what a real total of zero looks like, so a mistyped column name that happens to exist, or a column of text, produced a total indistinguishable from a genuine one. `Sum` and `Mean` now refuse a column with no number in it, naming it. A column holding some numbers is not refused — skipping what is not a number is what these aggregates document, and the answer is still built from data.

Inside a numeric column, a group that holds no value now gets nil rather than 0, which is what `Mean`, `Min`, and `Max` already answered for the same situation.

## Min and Max said nil (#281)

```go
g, _ := frame.NewDataFrame(strings.NewReader("k,s\na,banana\na,apple\n"), frame.CSV).GroupBy("k")
mn, err := g.Min("s")   // [map[k:a min_s:<nil>]] <nil>
```

The minimum of a column of words is not nil; it is `apple`, which is what SQLite's `MIN` answers over the same column. `AggMin` and `AggMax` now follow SQLite's ordering: a number sorts before any text, and text compares lexically. So `Min` over a mixed group is its smallest number and `Max` is its largest text.

## Breaking

`AggSum` returns nil rather than 0.0 for a group with nothing numeric, and `AggMin`/`AggMax` can return a string. A caller type-asserting `float64` on those results must handle nil and string. That change is the point: it is what makes the two zeros distinguishable.

Four existing tests asserted the old answers and are updated to the new contract, with the reason on each.

Closes #273
Closes #281