### PR TITLE
fix: make Concat and ConcatAll agree on what frames go together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Concat` and `ConcatAll` agree on what frames go together ([#275](https://github.com/nao1215/filesql/issues/275), [#284](https://github.com/nao1215/filesql/issues/284)). `Concat` compared column slices positionally and refused frames whose columns were the same set in a different order, reporting `different columns` about columns that were the same, while `ConcatAll` accepted that very pair; it now compares the set, since a row is a map keyed by column name and there is nothing to reconcile, and the result keeps the receiver's order. `ConcatAll` dropped a nil frame silently, producing a result quietly missing that data, while `Concat` rejected the same nil — a nil is almost always a constructor whose error was mishandled, so both now refuse it.
+
 - A `frame` aggregate says when it has no answer instead of inventing one ([#273](https://github.com/nao1215/filesql/issues/273), [#281](https://github.com/nao1215/filesql/issues/281)). `Sum` over a column with no number in it returned 0 for every group, which is what a real total of zero looks like, and `Mean` returned nil; both now refuse the column by name, while a group inside a numeric column that holds no value gets nil rather than 0. `Min` and `Max` over a text column returned nil, discarding an answer the data plainly held: they now follow SQLite's ordering, where a number sorts before any text and text compares lexically, so the minimum of `banana` and `apple` is `apple`.
 
 ### Breaking Changes

--- a/frame/dataframe.go
+++ b/frame/dataframe.go
@@ -689,12 +689,16 @@ func (df *DataFrame) hasColumn(name string) bool {
 // This is useful for combining data from multiple sources with the same schema.
 //
 // Requirements:
-//   - All DataFrames must have exactly the same columns in the same order
-//   - If columns differ, use ConcatAll instead for flexible concatenation
+//   - All DataFrames must hold the same columns, in any order
+//   - If the columns differ, use ConcatAll, which takes the union of them
+//
+// The result keeps the receiver's column order. Order does not decide whether a
+// concat is allowed, because a row is a map keyed by column name and there is
+// nothing to reconcile.
 //
 // Returns an error if:
 //   - Any DataFrame is nil
-//   - Columns don't match (different names or different order)
+//   - The columns are not the same set
 //
 // Example - Combining monthly data:
 //
@@ -720,12 +724,16 @@ func (df *DataFrame) Concat(others ...*DataFrame) (*DataFrame, error) {
 		return df.clone(), nil
 	}
 
-	// Validate all DataFrames have the same columns
+	// Validate all DataFrames hold the same columns
 	for i, other := range others {
 		if other == nil {
 			return nil, fmt.Errorf("DataFrame at index %d is nil", i+1)
 		}
-		if !slices.Equal(df.columns, other.columns) {
+		// The set, not the order. A row is a map keyed by column name, so a frame
+		// whose columns are the same in a different order concatenates without
+		// anything to reconcile — and refusing it said "different columns" about
+		// columns that were the same, while ConcatAll accepted the very pair.
+		if !sameColumnSet(df.columns, other.columns) {
 			return nil, fmt.Errorf("DataFrame at index %d has different columns: expected %v, got %v",
 				i+1, df.columns, other.columns)
 		}
@@ -759,6 +767,25 @@ func (df *DataFrame) Concat(others ...*DataFrame) (*DataFrame, error) {
 		columns: resultColumns,
 		rows:    resultRows,
 	}, nil
+}
+
+// sameColumnSet reports whether two column lists name the same columns, in any
+// order. A duplicate name would make the counts disagree, which the length check
+// catches before the membership one.
+func sameColumnSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	inA := make(map[string]struct{}, len(a))
+	for _, col := range a {
+		inA[col] = struct{}{}
+	}
+	for _, col := range b {
+		if _, ok := inA[col]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // ConcatAll concatenates multiple DataFrames vertically, automatically handling
@@ -802,12 +829,18 @@ func ConcatAll(frames ...*DataFrame) (*DataFrame, error) {
 		}, nil
 	}
 
+	// A nil frame is almost always an upstream constructor whose error was
+	// mishandled. Skipping it produced a result quietly missing that data, while
+	// Concat rejected the same nil — so the two disagreed about what a nil means.
+	for i, df := range frames {
+		if df == nil {
+			return nil, fmt.Errorf("DataFrame at index %d is nil", i)
+		}
+	}
+
 	// Collect all unique columns
 	columnSet := make(map[string]struct{})
 	for _, df := range frames {
-		if df == nil {
-			continue
-		}
 		for _, col := range df.columns {
 			columnSet[col] = struct{}{}
 		}
@@ -823,17 +856,12 @@ func ConcatAll(frames ...*DataFrame) (*DataFrame, error) {
 	// Calculate total rows
 	totalRows := 0
 	for _, df := range frames {
-		if df != nil {
-			totalRows += len(df.rows)
-		}
+		totalRows += len(df.rows)
 	}
 
 	// Build result rows
 	resultRows := make([]map[string]any, 0, totalRows)
 	for _, df := range frames {
-		if df == nil {
-			continue
-		}
 		for _, row := range df.rows {
 			newRow := make(map[string]any, len(allColumns))
 			for _, col := range allColumns {

--- a/frame/dataframe_test.go
+++ b/frame/dataframe_test.go
@@ -1816,15 +1816,18 @@ func TestConcatAll(t *testing.T) {
 		assert.Empty(t, result.Columns())
 	})
 
-	t.Run("skips nil DataFrames", func(t *testing.T) {
+	// A nil frame is almost always a constructor whose error was mishandled.
+	// Skipping it returned a result quietly missing that data, while Concat
+	// rejected the same nil.
+	t.Run("rejects a nil DataFrame, as Concat does", func(t *testing.T) {
 		t.Parallel()
 
 		df := NewDataFrameFromRecords([]map[string]any{{"id": int64(1)}})
 
-		result, err := ConcatAll(df, nil, df)
+		_, err := ConcatAll(df, nil, df)
 
-		require.NoError(t, err)
-		assert.Equal(t, 2, result.Len())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "index 1")
 	})
 
 	t.Run("handles DataFrames with completely different columns", func(t *testing.T) {
@@ -2967,5 +2970,68 @@ func TestToTSVTakesFieldsLiterally(t *testing.T) {
 		reloaded, err := NewDataFrameFromPath(out)
 		require.NoError(t, err)
 		assert.Equal(t, df.ToRecords(), reloaded.ToRecords())
+	})
+}
+
+// TestConcatAndConcatAllAgreeOnCompatibleFrames pins the two ways they used to
+// disagree about the same pair of frames.
+//
+// Concat compared column slices positionally and refused frames whose columns
+// were the same set in a different order, reporting "different columns" about
+// columns that were the same — while ConcatAll accepted that very pair. And
+// ConcatAll dropped a nil frame silently while Concat rejected it.
+func TestConcatAndConcatAllAgreeOnCompatibleFrames(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Concat accepts the same columns in a different order", func(t *testing.T) {
+		t.Parallel()
+
+		left, err := NewDataFrame(strings.NewReader("b,a\n1,2\n"), CSV)
+		require.NoError(t, err)
+		right, err := NewDataFrame(strings.NewReader("a,b\n3,4\n"), CSV)
+		require.NoError(t, err)
+
+		got, err := left.Concat(right)
+
+		require.NoError(t, err)
+		// The receiver's order is the result's, which is what it was before for
+		// the frames Concat already accepted.
+		assert.Equal(t, []string{"b", "a"}, got.Columns())
+		assert.Equal(t, []map[string]any{
+			{"b": int64(1), "a": int64(2)},
+			{"b": int64(4), "a": int64(3)},
+		}, got.ToRecords())
+	})
+
+	t.Run("Concat still refuses a genuinely different set", func(t *testing.T) {
+		t.Parallel()
+
+		left, err := NewDataFrame(strings.NewReader("a,b\n1,2\n"), CSV)
+		require.NoError(t, err)
+		right, err := NewDataFrame(strings.NewReader("a,c\n3,4\n"), CSV)
+		require.NoError(t, err)
+
+		_, err = left.Concat(right)
+
+		require.Error(t, err)
+	})
+
+	t.Run("Concat still refuses a nil", func(t *testing.T) {
+		t.Parallel()
+
+		left, err := NewDataFrame(strings.NewReader("a\n1\n"), CSV)
+		require.NoError(t, err)
+
+		_, err = left.Concat(nil)
+
+		require.Error(t, err)
+	})
+
+	t.Run("ConcatAll refuses a lone nil", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := ConcatAll(nil)
+
+		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
The two concatenations disagreed about the same pair of frames, in opposite directions.

## Column order (#275)

```go
a := mustCSV("b,a\n1,2\n")
b := mustCSV("a,b\n3,4\n")

a.Concat(b)        // error: different columns: expected [b a], got [a b]
frame.ConcatAll(a, b)  // fine — aligned by name
```

`Concat` compared the column slices positionally and reported "different columns" about columns that were the same set. A row here is a `map[string]any` keyed by column name, so the order costs nothing to reconcile — there is nothing to reconcile. `Concat` now compares the set and keeps the receiver's column order in the result, which is what it did for the frames it already accepted. A genuinely different set is still refused with the same message, which is now true when it appears.

## A nil frame (#284)

```go
c, err := frame.ConcatAll(mustCSV("a\n1\n"), nil, mustCSV("a\n2\n"))
// [map[a:1] map[a:2]] <nil>   — the nil vanished
```

A nil frame is almost always a constructor whose `(nil, err)` was mishandled upstream, so skipping it returned a result quietly missing that data, while `Concat` rejected the identical nil. Both refuse it now, naming the index.

The existing "skips nil DataFrames" test is updated to the new contract with the reason on it; that behavior is what the issue reports.

Closes #275
Closes #284