### PR TITLE
fix: make Select and Drop refuse a column they cannot act on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- `frame.DataFrame.Select` and `Drop` return `(*DataFrame, error)` ([#272](https://github.com/nao1215/filesql/issues/272), [#282](https://github.com/nao1215/filesql/issues/282), [#283](https://github.com/nao1215/filesql/issues/283)). Both silently ignored a column that does not exist, so a typo returned a frame quietly missing a column, or one still holding the column the caller believed was dropped — while `Sort`, `GroupBy`, `Rename` and `Concat` all refused the same typo. `Select` also accepted a repeated name and produced a frame whose two representations disagreed: `Columns` and `ToCSV` kept both, `ToRecords` kept one, because a row is a map and a map cannot hold the name twice. Both now refuse what they cannot do, which is the contract the rest of the package already had. A caller updates `df.Select(...)` to take the error the sibling methods already return.
+
 ### Fixed
 
 - `DropNA` and `FillNA` agree on what is missing ([#271](https://github.com/nao1215/filesql/issues/271)). `DropNA` counted an empty string as missing and `FillNA` counted only a real nil, so on the same frame `DropNA` removed a row that `FillNA` would not fill — and a caller who filled a frame to make it safe for later processing was left holding the cell that made it unsafe. A CSV has no null, so `""` is how a missing value arrives from the format most frames are read from, and it now counts for both. A column `FillNAByColumn` was not given a value for keeps its cells rather than having them normalized to nil.

--- a/frame/dataframe.go
+++ b/frame/dataframe.go
@@ -310,31 +310,44 @@ func formatValue(v any) string {
 	return fmt.Sprintf("%v", v)
 }
 
-// Select returns a new DataFrame with only the specified columns.
-// Columns that do not exist are silently ignored.
+// Select returns a new DataFrame with only the specified columns, in the order
+// given.
+//
+// Returns an error if a column does not exist, or if one is named twice.
+//
+// A missing column used to be skipped, so a typo returned a frame quietly
+// missing that column while Sort, GroupBy and Rename all refused the same typo.
+// A repeated name used to produce a frame whose two representations disagreed:
+// Columns and ToCSV kept both, and ToRecords kept one, because a row is a map
+// and a map cannot hold the name twice.
 //
 // Example:
 //
-//	selected := df.Select("name", "age")
-func (df *DataFrame) Select(columns ...string) *DataFrame {
+//	selected, err := df.Select("name", "age")
+func (df *DataFrame) Select(columns ...string) (*DataFrame, error) {
 	if len(columns) == 0 {
 		return &DataFrame{
 			columns: []string{},
 			rows:    []map[string]any{},
-		}
+		}, nil
 	}
 
-	// Filter to only existing columns, preserving order
 	existingCols := make(map[string]struct{}, len(df.columns))
 	for _, col := range df.columns {
 		existingCols[col] = struct{}{}
 	}
 
 	selectedCols := make([]string, 0, len(columns))
+	seen := make(map[string]struct{}, len(columns))
 	for _, col := range columns {
-		if _, exists := existingCols[col]; exists {
-			selectedCols = append(selectedCols, col)
+		if _, exists := existingCols[col]; !exists {
+			return nil, fmt.Errorf("column %q does not exist", col)
 		}
+		if _, dup := seen[col]; dup {
+			return nil, fmt.Errorf("column %q is selected twice, and a row cannot hold one name twice", col)
+		}
+		seen[col] = struct{}{}
+		selectedCols = append(selectedCols, col)
 	}
 
 	// Create new rows with only selected columns
@@ -350,7 +363,7 @@ func (df *DataFrame) Select(columns ...string) *DataFrame {
 	return &DataFrame{
 		columns: selectedCols,
 		rows:    newRows,
-	}
+	}, nil
 }
 
 // Filter returns a new DataFrame containing only rows that satisfy the predicate.
@@ -1175,19 +1188,30 @@ func (df *DataFrame) Limit(n int) *DataFrame {
 }
 
 // Drop returns a new DataFrame with the specified columns removed.
-// Columns that do not exist are silently ignored.
+// Returns an error if a column does not exist.
+//
+// A missing column used to be skipped, so a typo returned the frame unchanged
+// and the caller believed a column had been dropped that was still there —
+// while Sort, GroupBy and Rename all refused the same typo.
 //
 // Example:
 //
-//	dropped := df.Drop("temp_col", "debug_col")
-func (df *DataFrame) Drop(columns ...string) *DataFrame {
+//	dropped, err := df.Drop("temp_col", "debug_col")
+func (df *DataFrame) Drop(columns ...string) (*DataFrame, error) {
 	if len(columns) == 0 {
-		return df.clone()
+		return df.clone(), nil
 	}
 
-	// Create set of columns to drop
+	existingCols := make(map[string]struct{}, len(df.columns))
+	for _, col := range df.columns {
+		existingCols[col] = struct{}{}
+	}
+
 	dropSet := make(map[string]struct{}, len(columns))
 	for _, col := range columns {
+		if _, exists := existingCols[col]; !exists {
+			return nil, fmt.Errorf("column %q does not exist", col)
+		}
 		dropSet[col] = struct{}{}
 	}
 
@@ -1212,7 +1236,7 @@ func (df *DataFrame) Drop(columns ...string) *DataFrame {
 	return &DataFrame{
 		columns: newColumns,
 		rows:    newRows,
-	}
+	}, nil
 }
 
 // Rename returns a new DataFrame with the specified column renamed.

--- a/frame/dataframe_test.go
+++ b/frame/dataframe_test.go
@@ -310,7 +310,8 @@ func TestDataFrame_Select(t *testing.T) {
 			{"a": 1, "b": 2, "c": 3},
 		})
 
-		result := df.Select("a", "c")
+		result, err := df.Select("a", "c")
+		require.NoError(t, err)
 
 		assert.Equal(t, []string{"a", "c"}, result.Columns())
 		records := result.ToRecords()
@@ -319,16 +320,33 @@ func TestDataFrame_Select(t *testing.T) {
 		assert.Nil(t, records[0]["b"])
 	})
 
-	t.Run("ignores non-existent columns silently", func(t *testing.T) {
+	// A typo used to be skipped, so the frame came back quietly missing that
+	// column while Sort, GroupBy and Rename all refused the same typo.
+	t.Run("refuses a column that does not exist", func(t *testing.T) {
 		t.Parallel()
 
 		df := NewDataFrameFromRecords([]map[string]any{
 			{"a": 1, "b": 2},
 		})
 
-		result := df.Select("a", "nonexistent")
+		_, err := df.Select("a", "nonexistent")
 
-		assert.Equal(t, []string{"a"}, result.Columns())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nonexistent")
+	})
+
+	// Columns and ToCSV kept both, and ToRecords kept one, because a row is a
+	// map and a map cannot hold the name twice.
+	t.Run("refuses the same column twice", func(t *testing.T) {
+		t.Parallel()
+
+		df := NewDataFrameFromRecords([]map[string]any{
+			{"a": 1, "b": 2},
+		})
+
+		_, err := df.Select("a", "a")
+
+		require.Error(t, err)
 	})
 
 	t.Run("returns empty DataFrame when no columns specified", func(t *testing.T) {
@@ -338,7 +356,8 @@ func TestDataFrame_Select(t *testing.T) {
 			{"a": 1},
 		})
 
-		result := df.Select()
+		result, err := df.Select()
+		require.NoError(t, err)
 
 		assert.Empty(t, result.Columns())
 		assert.Empty(t, result.ToRecords())
@@ -351,7 +370,8 @@ func TestDataFrame_Select(t *testing.T) {
 			{"a": 1, "b": 2, "c": 3},
 		})
 
-		result := df.Select("c", "a", "b")
+		result, err := df.Select("c", "a", "b")
+		require.NoError(t, err)
 
 		assert.Equal(t, []string{"c", "a", "b"}, result.Columns())
 	})
@@ -1099,7 +1119,8 @@ func TestNewDataFrameFromPathWithOperations(t *testing.T) {
 		df, err := NewDataFrameFromPath(filepath.Join("testdata", "products.tsv"))
 		require.NoError(t, err)
 
-		selected := df.Select("name", "price")
+		selected, err := df.Select("name", "price")
+		require.NoError(t, err)
 
 		assert.Equal(t, []string{"name", "price"}, selected.Columns())
 		assert.Equal(t, 3, selected.Len())
@@ -1142,8 +1163,9 @@ func TestNewDataFrameFromPathWithOperations(t *testing.T) {
 		df, err := NewDataFrameFromPath(filepath.Join("testdata", "sample.csv.gz"))
 		require.NoError(t, err)
 
-		result := df.
-			Select("name", "age").
+		selected, err := df.Select("name", "age")
+		require.NoError(t, err)
+		result := selected.
 			Filter(func(row map[string]any) bool {
 				age, ok := row["age"].(int64)
 				return ok && age >= 25
@@ -1180,7 +1202,9 @@ func TestDataFrameCombinedOperations(t *testing.T) {
 		require.NoError(t, err)
 
 		// Select only name and age, then filter by age
-		result := df.Select("name", "age").Filter(func(row map[string]any) bool {
+		selected, err := df.Select("name", "age")
+		require.NoError(t, err)
+		result := selected.Filter(func(row map[string]any) bool {
 			age, ok := row["age"].(int64)
 			return ok && age >= 30
 		})
@@ -1235,14 +1259,16 @@ func TestDataFrameCombinedOperations(t *testing.T) {
 		require.NoError(t, err)
 
 		// Add full_name column, then select only that column
-		result := df.Mutate("full_name", func(row map[string]any) any {
+		mutated := df.Mutate("full_name", func(row map[string]any) any {
 			first, ok1 := row["first"].(string)
 			last, ok2 := row["last"].(string)
 			if !ok1 || !ok2 {
 				return ""
 			}
 			return first + " " + last
-		}).Select("full_name")
+		})
+		result, err := mutated.Select("full_name")
+		require.NoError(t, err)
 
 		assert.Equal(t, 2, result.Len())
 		assert.Equal(t, []string{"full_name"}, result.Columns())
@@ -1323,8 +1349,9 @@ func TestDataFrameCombinedOperations(t *testing.T) {
 		df, err := NewDataFrame(reader, CSV)
 		require.NoError(t, err)
 
-		result := df.
-			Select("name", "age", "salary").
+		selected, err := df.Select("name", "age", "salary")
+		require.NoError(t, err)
+		result := selected.
 			Filter(func(row map[string]any) bool {
 				age, ok := row["age"].(int64)
 				return ok && age >= 28
@@ -1366,7 +1393,7 @@ func TestDataFrameCombinedOperations(t *testing.T) {
 		originalCols := df.Columns()
 
 		// Perform various operations
-		_ = df.Select("name")
+		_, _ = df.Select("name")
 		_ = df.Filter(func(_ map[string]any) bool { return false })
 		_ = df.Mutate("new_col", func(_ map[string]any) any { return "value" })
 
@@ -2365,7 +2392,8 @@ func TestDataFrame_Drop(t *testing.T) {
 			{"name": "Alice", "age": int64(30), "city": "Tokyo"},
 		})
 
-		dropped := df.Drop("age", "city")
+		dropped, err := df.Drop("age", "city")
+		require.NoError(t, err)
 
 		assert.Equal(t, []string{"name"}, dropped.Columns())
 		records := dropped.ToRecords()
@@ -2374,14 +2402,30 @@ func TestDataFrame_Drop(t *testing.T) {
 		assert.False(t, hasAge)
 	})
 
-	t.Run("ignores non-existent columns silently", func(t *testing.T) {
+	// A typo used to be skipped, so the frame came back with the column the
+	// caller believed had been dropped.
+	t.Run("refuses a column that does not exist", func(t *testing.T) {
 		t.Parallel()
 
 		df := NewDataFrameFromRecords([]map[string]any{
 			{"name": "Alice", "age": int64(30)},
 		})
 
-		dropped := df.Drop("unknown", "age")
+		_, err := df.Drop("unknown", "age")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown")
+	})
+
+	t.Run("drops a column that does exist", func(t *testing.T) {
+		t.Parallel()
+
+		df := NewDataFrameFromRecords([]map[string]any{
+			{"name": "Alice", "age": int64(30)},
+		})
+
+		dropped, err := df.Drop("age")
+		require.NoError(t, err)
 
 		assert.Equal(t, []string{"name"}, dropped.Columns())
 	})
@@ -2393,7 +2437,8 @@ func TestDataFrame_Drop(t *testing.T) {
 			{"name": "Alice"},
 		})
 
-		dropped := df.Drop()
+		dropped, err := df.Drop()
+		require.NoError(t, err)
 
 		assert.Equal(t, df.Columns(), dropped.Columns())
 		assert.Equal(t, df.ToRecords(), dropped.ToRecords())
@@ -2406,7 +2451,7 @@ func TestDataFrame_Drop(t *testing.T) {
 			{"name": "Alice", "age": int64(30)},
 		})
 
-		_ = df.Drop("age")
+		_, _ = df.Drop("age")
 
 		assert.Equal(t, []string{"age", "name"}, df.Columns())
 	})

--- a/frame/dataframe_test.go
+++ b/frame/dataframe_test.go
@@ -1393,7 +1393,8 @@ func TestDataFrameCombinedOperations(t *testing.T) {
 		originalCols := df.Columns()
 
 		// Perform various operations
-		_, _ = df.Select("name")
+		_, err = df.Select("name")
+		require.NoError(t, err)
 		_ = df.Filter(func(_ map[string]any) bool { return false })
 		_ = df.Mutate("new_col", func(_ map[string]any) any { return "value" })
 
@@ -2451,7 +2452,8 @@ func TestDataFrame_Drop(t *testing.T) {
 			{"name": "Alice", "age": int64(30)},
 		})
 
-		_, _ = df.Drop("age")
+		_, err := df.Drop("age")
+		require.NoError(t, err)
 
 		assert.Equal(t, []string{"age", "name"}, df.Columns())
 	})

--- a/frame/doc.go
+++ b/frame/doc.go
@@ -30,17 +30,24 @@
 //	}
 //
 //	// Select columns and filter rows
-//	result := df.
-//	    Select("product", "amount", "category").
-//	    Filter(func(row map[string]any) bool {
-//	        amount, ok := row["amount"].(float64)
-//	        return ok && amount > 1000
-//	    })
+//	selected, err := df.Select("product", "amount", "category")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	result := selected.Filter(func(row map[string]any) bool {
+//	    amount, ok := row["amount"].(float64)
+//	    return ok && amount > 1000
+//	})
 //
 //	// Group by and aggregate
-//	grouped := result.
-//	    GroupBy("category").
-//	    Sum("amount")
+//	byCategory, err := result.GroupBy("category")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	grouped, err := byCategory.Sum("amount")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
 //
 //	// Output to CSV
 //	if err := grouped.ToCSV("summary.csv"); err != nil {

--- a/frame/example_api_test.go
+++ b/frame/example_api_test.go
@@ -118,7 +118,7 @@ func ExampleDataFrame_Select() {
 		{"name": "apple", "qty": 3, "region": "north"},
 	})
 
-	selected := df.Select("name", "region")
+	selected, _ := df.Select("name", "region") //nolint:errcheck // the columns exist
 	fmt.Println(selected.Columns())
 	// Output:
 	// [name region]

--- a/frame/example_test.go
+++ b/frame/example_test.go
@@ -743,7 +743,7 @@ func Example_dropRename() {
 	fmt.Printf("Original columns: %v\n", df.Columns())
 
 	// Drop internal column
-	cleaned := df.Drop("internal_code")
+	cleaned, _ := df.Drop("internal_code") //nolint:errcheck // the column exists
 	fmt.Printf("After Drop: %v\n", cleaned.Columns())
 
 	// Rename columns for clarity
@@ -836,7 +836,7 @@ func Example_dataframePipeline() {
 	df, _ := frame.NewDataFrame(strings.NewReader(salesCSV), frame.CSV) //nolint:errcheck
 
 	// Pipeline: Clean -> Transform -> Aggregate -> Sort -> Limit
-	result := df.
+	transformed := df.
 		// 1. Fill missing salesperson
 		FillNAByColumn(map[string]any{"salesperson": "Unknown"}).
 		// 2. Add calculated column
@@ -844,9 +844,9 @@ func Example_dataframePipeline() {
 			qty, _ := row["quantity"].(int64) //nolint:errcheck
 			price, _ := row["price"].(int64)  //nolint:errcheck
 			return float64(qty) * float64(price)
-		}).
-		// 3. Select relevant columns
-		Select("region", "product", "revenue", "salesperson")
+		})
+	// 3. Select relevant columns
+	result, _ := transformed.Select("region", "product", "revenue", "salesperson") //nolint:errcheck // the columns exist
 
 	// Group by region and sum revenue
 	grouped, _ := result.GroupBy("region") //nolint:errcheck


### PR DESCRIPTION
Three issues, one contract gap: `Select` and `Drop` were the only column operations that treated naming a column that is not there as acceptable.

```go
df.Select("a", "nonexistent")  // [a]         — the typo vanished
df.Drop("unknown", "age")      // [name]      — "unknown" ignored
df.Sort("nonexistent", ...)    // error       — the same typo refused
```

A caller who mistyped got a frame quietly missing a column, or one still holding the column they believed had been dropped, and nothing said so. `Sort`, `GroupBy`, `Rename`, `RenameColumns` and `Concat` all refuse the same typo, so the package disagreed with itself about what a wrong column name means.

`Select` had a second problem (#283). It accepted a repeated name:

```go
s, _ := mustCSV("a,b\n1,2\n").Select("a", "a")
s.Columns()    // [a a]
s.ToRecords()  // [map[a:1]]   — one "a", the other gone
s.ToCSV(...)   // a,a\n1,1\n   — two "a" columns
```

A row is a `map[string]any`, so a map cannot hold the name twice while the ordered column list can. Which output the caller happened to use decided whether the column was there. The import side already refuses a duplicate header for the same reason, so `Select` refuses one too.

## Breaking

`Select` and `Drop` now return `(*DataFrame, error)`, the shape `Sort`, `Rename`, `GroupBy` and `Concat` already have. A caller takes the error the sibling methods already returned. The alternative — a deferred error surfaced later — would have added a second way to learn about a failure to a package that already has one.

The two tests asserting the old silent behavior are updated to the new contract with the reason on each, and `doc.go`'s pipeline example is rewritten to handle the errors it now has to.

Closes #272
Closes #282
Closes #283