### PR TITLE
docs(changelog): stamp v0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.42.0] - 2026-08-09
 
 ### Breaking Changes
 
@@ -1204,7 +1204,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.41.1...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.42.0...HEAD
 [0.30.1]: https://github.com/nao1215/filesql/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/nao1215/filesql/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/nao1215/filesql/compare/v0.28.0...v0.29.0


### PR DESCRIPTION
Stamps the Unreleased section as v0.42.0, a minor because the frame package's Select and Drop now return an error.

Seven issues, all of the same shape — an operation that could not do what it was asked answered as though it had. Select and Drop ignored a column that does not exist and Select accepted a repeated name; Sum answered 0 for a column with no number in it while Min and Max threw away the answer a text column plainly held; DropNA and FillNA disagreed about what is missing; Concat refused frames ConcatAll accepted, and ConcatAll dropped a nil frame Concat refused. Plus an import fix: an Excel date cell now arrives as an ISO date rather than as whatever its number format rendered.