### PR TITLE
feat(frame): add Row accessors that read a row without guessing its types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `frame.Row` reads a callback's row without guessing what the load typed it as ([#277](https://github.com/nao1215/filesql/issues/277)). A CSV column of digits arrives as `int64`, so the natural `row["id"] == "1"` matched nothing and reported nothing — a filter that looks correct returning an empty result. `frame.Row(row).String("id")` answers with the value as the file spelled it, `Int` and `Float` with it as a number, and each returns false rather than a zero value when the column is absent, holds nil, or holds something it cannot represent, so a mistyped column name shows up in the predicate. The callbacks still take `map[string]any`, which converts to `Row` for free.
+
+### Documentation
+
+- What the `frame` type inference preserves is written down ([#276](https://github.com/nao1215/filesql/issues/276)). The quantity survives and the way it was written does not, so `1`, `1.0` and `1.00` are one value: `Distinct` collapses them to a single row and `Join` matches them to each other. Keeping the three apart would mean keeping the column as text, where `9.00` does not compare as less than `10.00`. A zero-padded code and an integer past `int64` are the values kept as text instead, because converting those changes what they are rather than how they look, and they stay distinct — that half was fixed in v0.41.1.
+
 ### Fixed
 
 - An ACH or Fedwire dump writes the file its own database was loaded from ([#210](https://github.com/nao1215/filesql/issues/210)). The structure a dump needs lived in a process-global map keyed by the base table name alone, so `/a/payment.ach` and `/b/payment.ach` were one key: loading the second replaced the first, and dumping the first database applied its rows to the second file's structure — an error when the shapes disagreed, and silently the wrong output when they happened to line up. Each database now records its own sources in a reserved table, `_filesql_sources`, so two databases cannot collide, nothing has to be released when a database closes, and a rolled-back load discards the metadata with the tables it describes. Table names beginning with `_filesql_` are reserved for this package and are hidden from `DumpDatabase` and from the table listings filesql returns.

--- a/README.md
+++ b/README.md
@@ -326,13 +326,13 @@ north,apple,1,100
 	}
 
 	sales := df.Mutate("revenue", func(row map[string]any) any {
-		qty, _ := row["qty"].(int64)
-		price, _ := row["price"].(int64)
+		qty, _ := frame.Row(row).Int("qty")
+		price, _ := frame.Row(row).Int("price")
 		return qty * price
 	})
 
 	northOnly := sales.Filter(func(row map[string]any) bool {
-		region, _ := row["region"].(string)
+		region, _ := frame.Row(row).String("region")
 		return region == "north"
 	})
 
@@ -367,6 +367,8 @@ Which of the three a column gets is decided from a sample. Whether a cell surviv
 | `1_000`, `0x1p4` | TEXT | Go parses these, SQLite's affinity does not convert them |
 
 What is not on that list is decimal formatting. `2.50` loads as the REAL `2.5`, `1.00` as `1`, and `1e3` as `1000`: the quantity is preserved and the way it was written is not. Storing those as TEXT would keep the spelling and break the arithmetic — SQLite compares a TEXT column against a number as text, so `WHERE amount > 9.5` over `9.00` and `10.00` returns nothing at all. A column of money is worth more as numbers than as the string it was typed as, so the trailing zeros go. Keep the source file if you need the original spelling, or read the column into a TEXT column of your own before loading.
+
+`frame` applies the same rules to its own values. `1`, `1.0` and `1.00` are one value there too, so `Distinct` collapses them to a single row and `Join` matches them to each other, while `007` and `7` stay two codes. A `frame` row therefore holds an `int64` or a `float64` where the file held text, which is what `frame.Row` is for: `frame.Row(row).String("code")` gives the value as the file spelled it, and `Int` and `Float` give it as a number, so a predicate does not have to guess which type the inference picked.
 
 ### Memory and streaming
 
@@ -499,6 +501,7 @@ The GoDoc examples are fully tested with `go test`. The tables below show the fa
 | Build a DataFrame directly from Go records | `ExampleNewDataFrameFromRecords` | [frame/example_api_test.go](./frame/example_api_test.go) |
 | Write transformed data back to CSV or TSV | `ExampleDataFrame_ToCSV`, `ExampleDataFrame_ToTSV` | [frame/example_api_test.go](./frame/example_api_test.go) |
 | Select, filter, and mutate rows | `ExampleDataFrame_Select`, `ExampleDataFrame_Filter`, `ExampleDataFrame_Mutate` | [frame/example_api_test.go](./frame/example_api_test.go) |
+| Read a callback's row without guessing its types | `ExampleRow` | [frame/example_api_test.go](./frame/example_api_test.go) |
 | Join in-memory tables | `ExampleDataFrame_Join` | [frame/example_api_test.go](./frame/example_api_test.go) |
 | Append frames with matching or mixed schemas | `ExampleDataFrame_Concat`, `ExampleConcatAll` | [frame/example_api_test.go](./frame/example_api_test.go) |
 | Group rows for aggregation | `ExampleDataFrame_GroupBy`, `ExampleGroupedDataFrame_Count` | [frame/example_api_test.go](./frame/example_api_test.go) |

--- a/frame/dataframe.go
+++ b/frame/dataframe.go
@@ -370,10 +370,14 @@ func (df *DataFrame) Select(columns ...string) (*DataFrame, error) {
 // The predicate function receives a copy of each row to prevent accidental mutation
 // of the original DataFrame.
 //
+// A row holds values typed by the load, not the text they were read from.
+// Convert it to Row to compare without depending on which type the inference
+// chose.
+//
 // Example:
 //
 //	filtered := df.Filter(func(row map[string]any) bool {
-//	    age, ok := row["age"].(int64)
+//	    age, ok := frame.Row(row).Int("age")
 //	    return ok && age >= 18
 //	})
 func (df *DataFrame) Filter(fn func(row map[string]any) bool) *DataFrame {

--- a/frame/dataframe_test.go
+++ b/frame/dataframe_test.go
@@ -2931,6 +2931,20 @@ func TestDistinctAndJoinCompareValuesAsWritten(t *testing.T) {
 		assert.Equal(t, []map[string]any{{"code": "007"}, {"code": "7"}}, got)
 	})
 
+	t.Run("values equal as numbers are one value however they were written", func(t *testing.T) {
+		t.Parallel()
+
+		df, err := NewDataFrame(strings.NewReader("v\n1\n1.0\n1.00\n"), CSV)
+		require.NoError(t, err)
+
+		got := df.Distinct().ToRecords()
+
+		// Keeping the three spellings apart would mean keeping the column as
+		// text, where 9.00 does not compare as less than 10.00. The quantity is
+		// worth more than the spelling, so the scale goes.
+		assert.Equal(t, []map[string]any{{"v": 1.0}}, got)
+	})
+
 	t.Run("a join does not match a code to its numeric reading", func(t *testing.T) {
 		t.Parallel()
 

--- a/frame/doc.go
+++ b/frame/doc.go
@@ -35,7 +35,7 @@
 //	    log.Fatal(err)
 //	}
 //	result := selected.Filter(func(row map[string]any) bool {
-//	    amount, ok := row["amount"].(float64)
+//	    amount, ok := frame.Row(row).Float("amount")
 //	    return ok && amount > 1000
 //	})
 //
@@ -53,6 +53,28 @@
 //	if err := grouped.ToCSV("summary.csv"); err != nil {
 //	    log.Fatal(err)
 //	}
+//
+// # Value Types
+//
+// CSV, TSV and LTSV carry no types, so a column's type is inferred from a
+// sample of its values and each cell is stored as an int64, a float64, or the
+// text it was read from. A callback therefore receives a value that may not be
+// the string the file held, which is what Row is for: its accessors return the
+// value in the form the caller asks for.
+//
+// What the inference preserves is the quantity, not the way it was written.
+// 1, 1.0 and 1.00 are all the real 1, so they are one value: Distinct collapses
+// them to a single row and a join matches them to each other. Keeping the
+// spelling instead would mean keeping the values as text, where 9.00 does not
+// compare as less than 10.00 and arithmetic on a column of money stops working.
+// A file whose decimal scale is meaningful is better read into a column of your
+// own declared as text, and formatted on the way out.
+//
+// Two kinds of value are kept as text for the opposite reason, because
+// converting them would change what they are rather than how they look: a
+// zero-padded code, where 007 and 7 are two different codes, and an integer
+// past the range of int64, which has no exact numeric form. Those stay distinct
+// through Distinct and Join.
 //
 // # Architecture
 //

--- a/frame/example_api_test.go
+++ b/frame/example_api_test.go
@@ -143,6 +143,28 @@ func ExampleDataFrame_Filter() {
 	// apple
 }
 
+// A CSV carries no types, so the load infers them: this column of digits
+// becomes int64 and the obvious row["id"] == "1" matches nothing. Row.String
+// answers with the value as the file spelled it.
+func ExampleRow() {
+	df, err := frame.NewDataFrame(strings.NewReader("id,qty\n1,3\n2,1\n"), frame.CSV)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	filtered := df.Filter(func(row map[string]any) bool {
+		id, ok := frame.Row(row).String("id")
+		return ok && id == "1"
+	})
+
+	for _, row := range filtered.ToRecords() {
+		qty, _ := frame.Row(row).Int("qty")
+		fmt.Println(qty)
+	}
+	// Output:
+	// 3
+}
+
 func ExampleDataFrame_Mutate() {
 	df := frame.NewDataFrameFromRecords([]map[string]any{
 		{"product": "apple", "qty": int64(3), "price": int64(4)},

--- a/frame/row.go
+++ b/frame/row.go
@@ -1,0 +1,105 @@
+package frame
+
+import (
+	"math"
+	"strconv"
+)
+
+// Row is one row of a DataFrame, addressed by column name.
+//
+// A DataFrame stores values typed rather than as the text they were read from,
+// so a CSV column of digits arrives as int64 and a decimal column as float64.
+// A predicate written against the raw map therefore matches nothing and reports
+// nothing: row["id"] == "1" is false when the value is int64(1). The accessors
+// below return the value in the form the caller asks for, so a predicate can be
+// written against the file rather than against a guess about it.
+//
+// The callbacks of Filter, Mutate, and the aggregation functions take
+// map[string]any, which converts to Row for free:
+//
+//	filtered := df.Filter(func(row map[string]any) bool {
+//	    id, ok := frame.Row(row).String("id")
+//	    return ok && id == "1"
+//	})
+//
+// Every accessor reports false instead of silently returning a zero value when
+// the column is absent, holds nil, or holds something it cannot represent, so a
+// mistyped column name is visible in the predicate rather than costing rows.
+type Row map[string]any
+
+// String returns the value of column as text.
+//
+// A value stored as text is returned unchanged, so a zero-padded code stays
+// "007". Only decimal formatting is rewritten by the load, so every other value
+// comes back spelled as the file had it; a real is rendered in the shortest
+// form that reads back exactly, which for a whole 2.0 is "2".
+//
+// The second result is false when the column is absent or holds nil. An empty
+// cell is a value, so it returns ("", true).
+func (r Row) String(column string) (string, bool) {
+	value, ok := r[column]
+	if !ok {
+		return "", false
+	}
+
+	switch v := value.(type) {
+	case string:
+		return v, true
+	case int64:
+		return strconv.FormatInt(v, 10), true
+	case float64:
+		return strconv.FormatFloat(v, 'g', -1, 64), true
+	default:
+		return "", false
+	}
+}
+
+// Int returns the value of column as an int64.
+//
+// Text that spells an integer converts, so a column kept as text because its
+// values are zero-padded is still comparable as a number: "007" is 7. A real
+// converts only when it is whole and fits, because rounding 7.5 to 7 would
+// answer a question the caller did not ask.
+//
+// The second result is false when the column is absent, holds nil, or holds a
+// value with no exact integer form.
+func (r Row) Int(column string) (int64, bool) {
+	switch v := r[column].(type) {
+	case int64:
+		return v, true
+	case float64:
+		// The bounds are the float64 values that bracket the int64 range; the
+		// endpoints themselves are excluded because int64's own limits are not
+		// exactly representable as float64.
+		if math.IsNaN(v) || v != math.Trunc(v) || v <= math.MinInt64 || v >= math.MaxInt64 {
+			return 0, false
+		}
+		return int64(v), true
+	case string:
+		i, err := strconv.ParseInt(v, 10, 64)
+		return i, err == nil
+	default:
+		return 0, false
+	}
+}
+
+// Float returns the value of column as a float64.
+//
+// An integer widens, and text that spells a number converts, so a column kept
+// as text is still comparable as a quantity.
+//
+// The second result is false when the column is absent, holds nil, or holds a
+// value with no numeric form.
+func (r Row) Float(column string) (float64, bool) {
+	switch v := r[column].(type) {
+	case float64:
+		return v, true
+	case int64:
+		return float64(v), true
+	case string:
+		f, err := strconv.ParseFloat(v, 64)
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}

--- a/frame/row_test.go
+++ b/frame/row_test.go
@@ -1,0 +1,169 @@
+package frame
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+// TestFilterStringPredicateMatchesDigits pins the case the typed accessors
+// exist for: a CSV column of digits arrives as int64, so the obvious
+// row["id"] == "1" matched nothing and said nothing. Row.String answers with
+// the value as the file spelled it.
+func TestFilterStringPredicateMatchesDigits(t *testing.T) {
+	t.Parallel()
+
+	df, err := NewDataFrame(strings.NewReader("id\n1\n2\n"), CSV)
+	if err != nil {
+		t.Fatalf("NewDataFrame: %v", err)
+	}
+
+	got := df.Filter(func(row map[string]any) bool {
+		v, ok := Row(row).String("id")
+		return ok && v == "1"
+	}).ToRecords()
+
+	if len(got) != 1 {
+		t.Fatalf("Filter matched %d rows, want 1: %v", len(got), got)
+	}
+}
+
+// TestFilterKeepsZeroPaddedCodeComparable is the other half: a column that must
+// stay text compares as the text it is, through the same accessor.
+func TestFilterKeepsZeroPaddedCodeComparable(t *testing.T) {
+	t.Parallel()
+
+	df, err := NewDataFrame(strings.NewReader("code\n007\n7\n"), CSV)
+	if err != nil {
+		t.Fatalf("NewDataFrame: %v", err)
+	}
+
+	got := df.Filter(func(row map[string]any) bool {
+		v, ok := Row(row).String("code")
+		return ok && v == "007"
+	}).ToRecords()
+
+	if len(got) != 1 {
+		t.Fatalf("Filter matched %d rows, want 1: %v", len(got), got)
+	}
+}
+
+func TestRowString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		row    Row
+		column string
+		want   string
+		wantOK bool
+	}{
+		{"text stays as it is", Row{"c": "007"}, "c", "007", true},
+		{"an integer renders without a decimal point", Row{"c": int64(1)}, "c", "1", true},
+		{"a negative integer keeps its sign", Row{"c": int64(-42)}, "c", "-42", true},
+		{"a real renders in its shortest exact form", Row{"c": 1.5}, "c", "1.5", true},
+		{"a real that is whole renders without a decimal point", Row{"c": 2.0}, "c", "2", true},
+		{"an empty string is a value", Row{"c": ""}, "c", "", true},
+		{"a missing column is not a value", Row{"c": "x"}, "other", "", false},
+		{"a nil is not a value", Row{"c": nil}, "c", "", false},
+		{"a nil row has no value", nil, "c", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := tt.row.String(tt.column)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("String(%q) = (%q, %v), want (%q, %v)", tt.column, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestRowInt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		row    Row
+		column string
+		want   int64
+		wantOK bool
+	}{
+		{"an integer is itself", Row{"c": int64(7)}, "c", 7, true},
+		{"digits held as text convert", Row{"c": "7"}, "c", 7, true},
+		{"a zero-padded code converts to its number", Row{"c": "007"}, "c", 7, true},
+		{"a whole real converts", Row{"c": 7.0}, "c", 7, true},
+		{"a real with a fraction does not convert", Row{"c": 7.5}, "c", 0, false},
+		{"a real too large for int64 does not convert", Row{"c": math.MaxFloat64}, "c", 0, false},
+		{"a NaN does not convert", Row{"c": math.NaN()}, "c", 0, false},
+		{"text that is not a number does not convert", Row{"c": "seven"}, "c", 0, false},
+		{"an empty string is not a number", Row{"c": ""}, "c", 0, false},
+		{"a missing column is not a number", Row{"c": int64(1)}, "other", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := tt.row.Int(tt.column)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("Int(%q) = (%d, %v), want (%d, %v)", tt.column, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestRowFloat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		row    Row
+		column string
+		want   float64
+		wantOK bool
+	}{
+		{"a real is itself", Row{"c": 1.5}, "c", 1.5, true},
+		{"an integer widens", Row{"c": int64(7)}, "c", 7, true},
+		{"a decimal held as text converts", Row{"c": "1.50"}, "c", 1.5, true},
+		{"text that is not a number does not convert", Row{"c": "one"}, "c", 0, false},
+		{"a missing column is not a number", Row{"c": 1.5}, "other", 0, false},
+		{"a nil is not a number", Row{"c": nil}, "c", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := tt.row.Float(tt.column)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("Float(%q) = (%v, %v), want (%v, %v)", tt.column, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+// TestRowStringRoundTripsTheSourceText checks the property the accessor is for:
+// whatever a CSV cell held, String gives it back as the file spelled it, so a
+// predicate can be written against the file rather than against an inference.
+func TestRowStringRoundTripsTheSourceText(t *testing.T) {
+	t.Parallel()
+
+	// An empty line is not an empty cell to a CSV reader, so the empty value is
+	// covered by the table test above rather than here.
+	cells := []string{"1", "2", "007", "1.5", "-3", "hello", "9223372036854775808"}
+	df, err := NewDataFrame(strings.NewReader("v\n"+strings.Join(cells, "\n")+"\n"), CSV)
+	if err != nil {
+		t.Fatalf("NewDataFrame: %v", err)
+	}
+
+	rows := df.ToRecords()
+	if len(rows) != len(cells) {
+		t.Fatalf("got %d rows, want %d", len(rows), len(cells))
+	}
+	for i, want := range cells {
+		got, ok := Row(rows[i]).String("v")
+		if !ok || got != want {
+			t.Errorf("row %d: String(%q) = (%q, %v), want (%q, true)", i, "v", got, ok, want)
+		}
+	}
+}

--- a/readme_examples_test.go
+++ b/readme_examples_test.go
@@ -91,21 +91,21 @@ north,apple,1,100
 	}
 
 	sales := df.Mutate("revenue", func(row map[string]any) any {
-		qty, ok := row["qty"].(int64)
+		qty, ok := frame.Row(row).Int("qty")
 		if !ok {
-			t.Fatalf("row[qty] has type %T, want int64", row["qty"])
+			t.Fatalf("row[qty] = %v, want a number", row["qty"])
 		}
-		price, ok := row["price"].(int64)
+		price, ok := frame.Row(row).Int("price")
 		if !ok {
-			t.Fatalf("row[price] has type %T, want int64", row["price"])
+			t.Fatalf("row[price] = %v, want a number", row["price"])
 		}
 		return qty * price
 	})
 
 	northOnly := sales.Filter(func(row map[string]any) bool {
-		region, ok := row["region"].(string)
+		region, ok := frame.Row(row).String("region")
 		if !ok {
-			t.Fatalf("row[region] has type %T, want string", row["region"])
+			t.Fatalf("row[region] = %v, want text", row["region"])
 		}
 		return region == "north"
 	})


### PR DESCRIPTION
A DataFrame stores values typed by the load rather than as the text they were read from, so a CSV column of digits arrives as `int64`. The natural predicate `row["id"] == "1"` is therefore false for every row, and nothing says so: a filter that looks correct returns an empty result, and the caller has no way to tell from the callback that the value is not the string the file held.

`frame.Row` is a named type over the same `map[string]any` the callbacks already take, so it converts for free and no signature moves. `Row.String` gives the value as the file spelled it, `Row.Int` and `Row.Float` give it as a number, and each of the three reports false rather than silently returning a zero value when the column is absent, holds nil, or holds something it cannot represent — so a mistyped column name is visible in the predicate instead of quietly costing rows.

The accessors convert across the inference rather than around it. `Int` takes text that spells an integer, so a column kept as text because its codes are zero-padded is still comparable as a number, and refuses a real with a fraction rather than rounding it. `String` renders a number the way filesql writes it back out, which is the spelling the file had for every value the load did not rewrite — and decimal formatting is the only thing it rewrites.

That last point is the subject of #276, which asked for `Distinct` not to merge `1`, `1.0` and `1.00`. It is a deliberate trade-off rather than a defect, so it is written down instead of changed: the quantity survives and the way it was written does not, because keeping the three apart means keeping the column as text, where `9.00` does not compare as less than `10.00` and arithmetic on a column of money stops working. The values kept as text are the ones where converting changes what they are rather than how they look — a zero-padded code, an integer past `int64` — and those stay distinct through `Distinct` and `Join`, which was fixed in v0.41.1. The `frame` package doc now states the rule, the README repeats it in one sentence, and a `Distinct` case pins it.

Tests: a table per accessor covering text, integers, reals, whole and fractional, the int64 boundary, NaN, absent columns and nil; the two cases the issue named, driven through `Filter`; and a property check that a CSV cell comes back from `String` as the file spelled it, decimal scale aside.

Closes #277
Closes #276
