### PR TITLE
docs(changelog): stamp v0.43.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.43.1] - 2026-08-09
 
 ### Fixed
 
@@ -1230,7 +1230,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
-[Unreleased]: https://github.com/nao1215/filesql/compare/v0.43.0...HEAD
+[Unreleased]: https://github.com/nao1215/filesql/compare/v0.43.1...HEAD
 [0.30.1]: https://github.com/nao1215/filesql/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/nao1215/filesql/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/nao1215/filesql/compare/v0.28.0...v0.29.0


### PR DESCRIPTION
Stamps the Unreleased section as v0.43.1: the reserved `_filesql_` table prefix now refuses an input that would occupy it, so no caller table can be hidden by the filter that keeps this package's own tables out of dumps and listings.