### PR TITLE
docs(readme): add the Awesome Go badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # filesql
 
+[![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
 [![Go Reference](https://pkg.go.dev/badge/github.com/nao1215/filesql.svg)](https://pkg.go.dev/github.com/nao1215/filesql)
 [![MultiPlatformUnitTest](https://github.com/nao1215/filesql/actions/workflows/unit_test.yml/badge.svg)](https://github.com/nao1215/filesql/actions/workflows/unit_test.yml)
 ![Coverage](https://raw.githubusercontent.com/nao1215/octocovs-central-repo/main/badges/nao1215/filesql/coverage.svg)


### PR DESCRIPTION
## Summary

filesql is listed in awesome-go under Database Tools (avelino/awesome-go#6577), so the README carries the badge, as gup, sqly, and markdown do.

## Changes

- `README.md`: the "Mentioned in Awesome Go" badge, first in the badge block, matching the other repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Awesome Go “Mentioned” badge beneath the project title in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->