### PR TITLE
fix: release what the Parquet read built when it fails part way

### DIFF
--- a/parser/parquet.go
+++ b/parser/parquet.go
@@ -58,22 +58,33 @@ func readArrowTable(ctx context.Context, arrowReader *pqarrow.FileReader) (tbl a
 	for _, col := range columnIndices {
 		includedLeaves[col] = true
 	}
-	readers := make([]*pqarrow.ColumnReader, len(fieldIndices))
-	fields := make([]arrow.Field, len(fieldIndices))
-	for i, fieldIndex := range fieldIndices {
+	// The readers are collected as they are built and released together, so a
+	// failure part way through this loop does not leave the ones before it
+	// unreleased.
+	readers := make([]*pqarrow.ColumnReader, 0, len(fieldIndices))
+	defer func() {
+		for _, reader := range readers {
+			reader.Release()
+		}
+	}()
+	fields := make([]arrow.Field, 0, len(fieldIndices))
+	for _, fieldIndex := range fieldIndices {
 		reader, readerErr := arrowReader.GetFieldReader(ctx, fieldIndex, includedLeaves, rowGroups)
 		if readerErr != nil {
 			return nil, readerErr
 		}
-		readers[i] = reader
-		fields[i] = *reader.Field()
-	}
-	for i := range readers {
-		defer readers[i].Release()
+		if reader == nil || reader.Field() == nil {
+			return nil, fmt.Errorf("parquet data is damaged: no reader for field %d", fieldIndex)
+		}
+		readers = append(readers, reader)
+		fields = append(fields, *reader.Field())
 	}
 	schema := arrow.NewSchema(fields, arrowReader.Manifest.SchemaMeta)
 
-	columns := make([]arrow.Column, schema.NumFields())
+	// The columns are appended as they are built, so the cleanup below releases
+	// the ones that exist and never a zero value, whose Release dereferences a
+	// chunk it does not have.
+	columns := make([]arrow.Column, 0, len(readers))
 	defer func() {
 		// The columns are copied into the table, which owns them from then on;
 		// on the way out with an error they are this function's to release.
@@ -89,7 +100,7 @@ func readArrowTable(ctx context.Context, arrowReader *pqarrow.FileReader) (tbl a
 		if readErr != nil {
 			return nil, readErr
 		}
-		columns[i] = *arrow.NewColumn(schema.Field(i), chunked)
+		columns = append(columns, *arrow.NewColumn(schema.Field(i), chunked))
 		chunked.Release()
 	}
 

--- a/stream.go
+++ b/stream.go
@@ -80,22 +80,33 @@ func readArrowTable(ctx context.Context, arrowReader *pqarrow.FileReader) (tbl a
 	for _, col := range columnIndices {
 		includedLeaves[col] = true
 	}
-	readers := make([]*pqarrow.ColumnReader, len(fieldIndices))
-	fields := make([]arrow.Field, len(fieldIndices))
-	for i, fieldIndex := range fieldIndices {
+	// The readers are collected as they are built and released together, so a
+	// failure part way through this loop does not leave the ones before it
+	// unreleased.
+	readers := make([]*pqarrow.ColumnReader, 0, len(fieldIndices))
+	defer func() {
+		for _, reader := range readers {
+			reader.Release()
+		}
+	}()
+	fields := make([]arrow.Field, 0, len(fieldIndices))
+	for _, fieldIndex := range fieldIndices {
 		reader, readerErr := arrowReader.GetFieldReader(ctx, fieldIndex, includedLeaves, rowGroups)
 		if readerErr != nil {
 			return nil, readerErr
 		}
-		readers[i] = reader
-		fields[i] = *reader.Field()
-	}
-	for i := range readers {
-		defer readers[i].Release()
+		if reader == nil || reader.Field() == nil {
+			return nil, fmt.Errorf("parquet data is damaged: no reader for field %d", fieldIndex)
+		}
+		readers = append(readers, reader)
+		fields = append(fields, *reader.Field())
 	}
 	schema := arrow.NewSchema(fields, arrowReader.Manifest.SchemaMeta)
 
-	columns := make([]arrow.Column, schema.NumFields())
+	// The columns are appended as they are built, so the cleanup below releases
+	// the ones that exist and never a zero value, whose Release dereferences a
+	// chunk it does not have.
+	columns := make([]arrow.Column, 0, len(readers))
 	defer func() {
 		// The columns are copied into the table, which owns them from then on;
 		// on the way out with an error they are this function's to release.
@@ -111,7 +122,7 @@ func readArrowTable(ctx context.Context, arrowReader *pqarrow.FileReader) (tbl a
 		if readErr != nil {
 			return nil, readErr
 		}
-		columns[i] = *arrow.NewColumn(schema.Field(i), chunked)
+		columns = append(columns, *arrow.NewColumn(schema.Field(i), chunked))
 		chunked.Release()
 	}
 


### PR DESCRIPTION
Two defects on the error path of the read loop #415 introduced, both raised in review of that pull request after it had been merged. This is the follow-up.

## What changed

The field readers were registered for release in a second loop that ran only after every one of them was built, so a failure part way through the first loop left the readers before it unreleased. They are collected as they are built now and released together in one deferred loop, which holds however far the loop got. A reader or a field that comes back nil is reported as damaged data rather than dereferenced.

The columns were pre-sized with `make` and every element released on the way out with an error — including the ones never assigned. Releasing a zero-value `arrow.Column` dereferences a chunk it does not have, so the cleanup itself panicked: the recover above it caught that and turned the real `ReadColumn` error into `parquet data is damaged`, and the columns that had been built leaked. They are appended as they are built now, so the cleanup sees only what exists and the caller sees the error that actually happened.

Both copies of the loop are fixed, in `parser/parquet.go` and in `stream.go`.

## Verification

`make test`, `make lint`, and the Parquet tests including the damaged-file regressions from #415. `go test -fuzz=FuzzParseBinary` still ends in a worker dying on the unbounded allocation of #414, which this does not address and which is why that issue is open.

Refs #413
