### PR TITLE
fix(dialect): answer FORMAT_DATE, ROUND and SUBSTR the way BigQuery does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `FORMAT_DATE`, `FORMAT_DATETIME` and `FORMAT_TIMESTAMP` write the value rather than the letter for twenty BigQuery specifiers ([#445](https://github.com/nao1215/filesql/issues/445)). `%j`, `%s`, `%C`, `%Q`, `%D`, `%x`, `%X`, `%c`, `%h`, `%k`, `%l`, `%P`, `%u`, `%w`, `%G`, `%V`, `%U`, `%W`, `%n` and `%t` came back as their own letter, which is also what BigQuery does for a specifier it does not know, so a report formatted with `'%F %X'` returned `2024-02-29 X` and looked like it had worked. The cause was structural rather than a missing table entry: the whole format string was turned into a Go reference-time layout, and a day of the year, a week number and an epoch second are computed rather than spelled, so there was nowhere for them to go. Rendering has its own walk over the format now and the layout is built only for `PARSE_DATE`, which is unchanged. Building the answer rather than a layout also stops the text around the specifiers being read as one: a literal `2006` or `1` in a format string used to reach `time.Format` and be rendered as the year or the month, so `FORMAT_DATE('year 2006 month 1', d)` came back as `year 2024 month 2` and is copied verbatim now. It is the same fault `DATE_FORMAT` had in [#436](https://github.com/nao1215/filesql/issues/436), in the other dialect's spelling.
+
+- `ROUND(x, n)` with a negative `n` rounds to a power of ten instead of returning `x` unchanged ([#446](https://github.com/nao1215/filesql/issues/446)). `ROUND(12345, -2)` is `12300` in MySQL, PostgreSQL and BigQuery alike and was `12345` under every one of them, because the call reached SQLite's own `round()`, whose second argument is a digit count after the decimal point and which ignores a negative one. A column of amounts rounded to the nearest thousand came back at full precision with nothing to say the rounding had not happened. All three engines agree on every value, half away from zero, so one helper answers all three rather than each naming its own the way `mysql_lpad` and `postgresql_lpad` do. `dialect.SQLite` is not rewritten: ignoring a negative digit count is SQLite's documented behavior and is what a caller who named no dialect asked for. The one-argument form is left alone in every dialect.
+
+- GoogleSQL `SUBSTR` and `SUBSTRING` follow BigQuery's rule rather than SQLite's ([#447](https://github.com/nao1215/filesql/issues/447)). [#428](https://github.com/nao1215/filesql/issues/428) gave MySQL and PostgreSQL each their own helper and left GoogleSQL on SQLite's, because no BigQuery was available to check its rule against. BigQuery's turns out to be a third rule: position 0 means position 1, a negative position counts back from the end, and a position that lands before the string clamps to its start with the length measured from there rather than consumed by the part that fell outside. So `SUBSTR('abcdef', 0, 2)` is `ab` where MySQL gives the empty string and PostgreSQL gives `a`, and `SUBSTR('abcdef', -10, 3)` is `abc` where both of the others give the empty string. Positions count characters, not bytes, as in the other two.
+
+### Changed
+
+- The GoogleSQL translations are checked against a BigQuery that runs them. `goccy/bigquery-emulator` serves the reference implementation locally, which is what the three fixes above were measured against, alongside MySQL 8.4 and PostgreSQL 17 for the dialects they also touch. Five of the emulator's answers are its own defects rather than BigQuery's and were taken from the documented definitions instead: it renders `%U` and `%W` as the ISO week, answers `%w` with 8 and `%I` with 13 where a 12-hour clock reads 01, drops the zero padding from `%j` and the week numbers, and slices bytes rather than characters in `SUBSTR` and `STRPOS`. Nothing is being reported to that project, per this repository's rule about third-party repositories.
+
 ## [0.44.0] - 2026-08-21
 
 ### Added

--- a/dialect/functions.go
+++ b/dialect/functions.go
@@ -139,6 +139,8 @@ func registerAll() error {
 		// dialect's rewrite names its own helper.
 		"mysql_substr":      {-1, fnMySQLSubstr},
 		"postgresql_substr": {-1, fnPostgreSQLSubstr},
+		"googlesql_substr":  {-1, fnGoogleSQLSubstr},
+		"dialect_round":     {2, fnDialectRound},
 		"repeat":            {2, fnRepeat},
 		"space":             {1, fnSpace},
 		"truncate":          {2, fnTruncate},
@@ -970,6 +972,103 @@ func fnPostgreSQLSubstr(args []driver.Value) (driver.Value, error) {
 		return "", nil
 	}
 	return string(runes[from-1 : to-1]), nil
+}
+
+// fnGoogleSQLSubstr implements BigQuery SUBSTR(s, position[, length]), which is
+// neither of the other two dialects' rules.
+//
+// Position 0 means position 1, a negative position counts back from the end
+// where -1 is the last character, and a position that lands before the string
+// clamps to its start with the length measured from there rather than consumed
+// by the part that fell outside. That last clause is what separates it from
+// PostgreSQL, where the out-of-range prefix eats the length, and the first is
+// what separates it from MySQL, where position 0 is no position at all.
+//
+// Positions count characters, not bytes.
+func fnGoogleSQLSubstr(args []driver.Value) (driver.Value, error) {
+	if len(args) < 2 || len(args) > 3 {
+		return nil, fmt.Errorf("dialect: SUBSTR expects 2 or 3 arguments, got %d", len(args))
+	}
+	s, ok1 := toString(args[0])
+	pos, ok2 := toCount(args[1])
+	if !ok1 || !ok2 {
+		return nil, nil
+	}
+	runes := []rune(s)
+	length := int64(len(runes))
+
+	start := pos - 1
+	if pos == 0 {
+		start = 0
+	} else if pos < 0 {
+		start = length + pos
+	}
+	// A position before the string starts the result at its first character.
+	start = max(start, 0)
+	if start >= length {
+		return "", nil
+	}
+
+	end := length
+	if len(args) == 3 {
+		count, ok := toCount(args[2])
+		if !ok {
+			return nil, nil
+		}
+		if count <= 0 {
+			return "", nil
+		}
+		if count < length-start {
+			end = start + count
+		}
+	}
+	return string(runes[start:end]), nil
+}
+
+// fnDialectRound implements ROUND(x, n) for the digit counts SQLite's own
+// round() will not take.
+//
+// A negative n rounds to a power of ten -- ROUND(12345, -2) is 12300 -- which is
+// how MySQL, PostgreSQL and BigQuery all spell "round to the nearest hundred".
+// SQLite reads the second argument as digits after the decimal point and ignores
+// a negative one, so the call succeeded and returned its input. All three
+// engines agree on every answer, half away from zero, so one helper serves them;
+// dialect.SQLite is not rewritten onto it, because ignoring a negative count is
+// SQLite's documented behavior and is what a caller who named no dialect asked
+// for.
+func fnDialectRound(args []driver.Value) (driver.Value, error) {
+	value, ok := toFloat(args[0])
+	if !ok {
+		return nil, nil
+	}
+	digits, ok := toCount(args[1])
+	if !ok {
+		return nil, nil
+	}
+	if digits >= 0 {
+		// What SQLite already does, kept here so one function answers the whole
+		// call rather than the rewrite having to decide which one to emit.
+		return roundHalfAwayFromZero(value, digits), nil
+	}
+	scale := math.Pow(10, float64(-digits))
+	rounded := roundHalfAwayFromZero(value/scale, 0) * scale
+	// A whole result is returned as an integer so a rounded count does not
+	// arrive with a decimal point the engines do not put there.
+	if rounded == math.Trunc(rounded) && math.Abs(rounded) < 1e15 {
+		return int64(rounded), nil
+	}
+	return rounded, nil
+}
+
+// roundHalfAwayFromZero is value rounded to digits places after the decimal
+// point, with a half rounded away from zero, which is what all three engines do
+// and what SQLite's round() does.
+func roundHalfAwayFromZero(value float64, digits int64) float64 {
+	if digits == 0 {
+		return math.Round(value)
+	}
+	scale := math.Pow(10, float64(digits))
+	return math.Round(value*scale) / scale
 }
 
 // fnSubstringIndex implements MySQL SUBSTRING_INDEX(str, delim, count).
@@ -1812,6 +1911,12 @@ var strftimeToGoLayout = map[byte]string{
 	'F': layoutDateOnly,
 	'T': layoutTimeOnly,
 	'R': "15:04",
+	'h': layoutMonthShort,
+	'P': "pm",
+	'D': "01/02/06",
+	'x': "01/02/06",
+	'X': layoutTimeOnly,
+	'c': "Mon Jan _2 15:04:05 2006",
 }
 
 // strftimeLayout converts a GoogleSQL format string into a Go layout. An
@@ -1836,6 +1941,96 @@ func strftimeLayout(format string) string {
 	return b.String()
 }
 
+// strftimeRender writes tm according to a GoogleSQL format string.
+//
+// Rendering is separate from strftimeLayout, which builds a Go layout for
+// PARSE_DATE, because a layout can only carry what Go has a reference-time
+// fragment for. A day of the year, a week number and an epoch second are
+// computed rather than spelled, so twenty specifiers had nowhere to go and were
+// written as their own letter -- which is what BigQuery does for a specifier it
+// does not know, so a format asking for a time came back holding an "X" and
+// looked like it had worked.
+//
+// Building the answer rather than a layout also stops the text around the
+// specifiers being read as one. A literal "2006" or "1" in a format string used
+// to reach time.Format, which rendered it as the year or the month; the
+// characters between specifiers are copied verbatim now.
+func strftimeRender(tm time.Time, format string) string {
+	var b strings.Builder
+	for i := 0; i < len(format); i++ {
+		if format[i] != '%' || i+1 >= len(format) {
+			b.WriteByte(format[i])
+			continue
+		}
+		spec := format[i+1]
+		switch {
+		case spec == '%':
+			b.WriteByte('%')
+		default:
+			if layout, ok := strftimeToGoLayout[spec]; ok {
+				b.WriteString(tm.Format(layout))
+			} else if computed, ok := strftimeComputed(tm, spec); ok {
+				b.WriteString(computed)
+			} else {
+				// An unknown specifier is its own letter, which is what
+				// BigQuery does.
+				b.WriteByte(spec)
+			}
+		}
+		i++
+	}
+	return b.String()
+}
+
+// strftimeComputed handles the specifiers with no Go layout fragment: the ones
+// whose value is calculated from the date rather than spelled out of it.
+//
+// The week numbers are the four strftime defines. %V and %G are the ISO pair Go
+// answers directly; %U counts weeks from the year's first Sunday and %W from its
+// first Monday, both numbering the days before that week 0, which is the
+// calculation the C library does and is written out here rather than derived
+// from the ISO pair, since the three disagree at every turn of the year.
+func strftimeComputed(tm time.Time, spec byte) (string, bool) {
+	switch spec {
+	case 'j':
+		return fmt.Sprintf("%03d", tm.YearDay()), true
+	case 's':
+		return strconv.FormatInt(tm.Unix(), 10), true
+	case 'C':
+		return fmt.Sprintf("%02d", tm.Year()/100), true
+	case 'Q':
+		return strconv.Itoa((int(tm.Month())-1)/3 + 1), true
+	case 'k':
+		return fmt.Sprintf("%2d", tm.Hour()), true
+	case 'l':
+		hour := tm.Hour() % 12
+		if hour == 0 {
+			hour = 12
+		}
+		return fmt.Sprintf("%2d", hour), true
+	case 'u':
+		return strconv.Itoa(weekdayIndex(tm, true) + 1), true
+	case 'w':
+		return strconv.Itoa(int(tm.Weekday())), true
+	case 'G':
+		year, _ := tm.ISOWeek()
+		return strconv.Itoa(year), true
+	case 'V':
+		_, week := tm.ISOWeek()
+		return fmt.Sprintf("%02d", week), true
+	case 'U':
+		return fmt.Sprintf("%02d", (tm.YearDay()-1+7-int(tm.Weekday()))/7), true
+	case 'W':
+		return fmt.Sprintf("%02d", (tm.YearDay()-1+7-weekdayIndex(tm, true))/7), true
+	case 'n':
+		return "\n", true
+	case 't':
+		return "\t", true
+	default:
+		return "", false
+	}
+}
+
 // fnFormatDate implements GoogleSQL FORMAT_DATE/FORMAT_DATETIME/
 // FORMAT_TIMESTAMP(format, value). The format comes first, the reverse of MySQL
 // DATE_FORMAT.
@@ -1848,7 +2043,7 @@ func fnFormatDate(args []driver.Value) (driver.Value, error) {
 	if !ok {
 		return nil, nil
 	}
-	return tm.Format(strftimeLayout(format)), nil
+	return strftimeRender(tm, format), nil
 }
 
 // fnParseDate implements GoogleSQL PARSE_DATE(format, text) and fnParseTimestamp

--- a/dialect/functions.go
+++ b/dialect/functions.go
@@ -1046,9 +1046,21 @@ func fnDialectRound(args []driver.Value) (driver.Value, error) {
 		return nil, nil
 	}
 	if digits >= 0 {
+		// Past the precision a float64 carries there is nothing left to round,
+		// and the scale would be infinite: ROUND(1.5, 400) is 1.5 in MySQL and
+		// in BigQuery, not the NaN that dividing by an infinite scale gives.
+		if digits > float64SignificantDigits {
+			return value, nil
+		}
 		// What SQLite already does, kept here so one function answers the whole
 		// call rather than the rewrite having to decide which one to emit.
 		return roundHalfAwayFromZero(value, digits), nil
+	}
+	// Below the smallest power of ten a float64 holds, the whole value is under
+	// the rounding unit: ROUND(12345, -400) is 0 in MySQL and in BigQuery. The
+	// comparison comes before the negation because negating math.MinInt64 wraps.
+	if digits < -float64MaxDecimalExponent {
+		return int64(0), nil
 	}
 	scale := math.Pow(10, float64(-digits))
 	rounded := roundHalfAwayFromZero(value/scale, 0) * scale
@@ -1059,6 +1071,14 @@ func fnDialectRound(args []driver.Value) (driver.Value, error) {
 	}
 	return rounded, nil
 }
+
+// The bounds beyond which a float64 cannot carry the rounding: 10 to the power
+// of either would be infinite, and an infinite scale turns a finite value into
+// a NaN rather than into the answer every engine gives.
+const (
+	float64SignificantDigits  = 17
+	float64MaxDecimalExponent = 308
+)
 
 // roundHalfAwayFromZero is value rounded to digits places after the decimal
 // point, with a half rounded away from zero, which is what all three engines do

--- a/dialect/functions.go
+++ b/dialect/functions.go
@@ -1046,12 +1046,6 @@ func fnDialectRound(args []driver.Value) (driver.Value, error) {
 		return nil, nil
 	}
 	if digits >= 0 {
-		// Past the precision a float64 carries there is nothing left to round,
-		// and the scale would be infinite: ROUND(1.5, 400) is 1.5 in MySQL and
-		// in BigQuery, not the NaN that dividing by an infinite scale gives.
-		if digits > float64SignificantDigits {
-			return value, nil
-		}
 		// What SQLite already does, kept here so one function answers the whole
 		// call rather than the rewrite having to decide which one to emit.
 		return roundHalfAwayFromZero(value, digits), nil
@@ -1063,7 +1057,14 @@ func fnDialectRound(args []driver.Value) (driver.Value, error) {
 		return int64(0), nil
 	}
 	scale := math.Pow(10, float64(-digits))
-	rounded := roundHalfAwayFromZero(value/scale, 0) * scale
+	rounded := math.Round(value/scale) * scale
+	if math.IsInf(rounded, 0) {
+		// Rounding a value near the largest float64 up to the next unit lands
+		// past what a float64 holds. BigQuery raises on the overflow rather
+		// than answering, and an infinity here would flow into the rest of the
+		// query as a number.
+		return nil, fmt.Errorf("dialect: ROUND: rounding %v to %d digits overflows", value, digits)
+	}
 	// A whole result is returned as an integer so a rounded count does not
 	// arrive with a decimal point the engines do not put there.
 	if rounded == math.Trunc(rounded) && math.Abs(rounded) < 1e15 {
@@ -1072,23 +1073,30 @@ func fnDialectRound(args []driver.Value) (driver.Value, error) {
 	return rounded, nil
 }
 
-// The bounds beyond which a float64 cannot carry the rounding: 10 to the power
-// of either would be infinite, and an infinite scale turns a finite value into
-// a NaN rather than into the answer every engine gives.
-const (
-	float64SignificantDigits  = 17
-	float64MaxDecimalExponent = 308
-)
+// float64MaxDecimalExponent is the largest power of ten a float64 holds. Ten to
+// anything beyond it is infinite, and an infinite scale turns a finite value
+// into a NaN rather than into the answer every engine gives.
+const float64MaxDecimalExponent = 308
 
 // roundHalfAwayFromZero is value rounded to digits places after the decimal
 // point, with a half rounded away from zero, which is what all three engines do
 // and what SQLite's round() does.
+//
+// A digit count so large that the scaling cannot be represented leaves the value
+// alone rather than answering NaN. The test is on what the scaling produces
+// rather than on the count, because the two are not the same question: at 18
+// digits the scale is finite and 5e-19 does round, to 1e-18, while at 400 the
+// scale is infinite and nothing can.
 func roundHalfAwayFromZero(value float64, digits int64) float64 {
 	if digits == 0 {
 		return math.Round(value)
 	}
 	scale := math.Pow(10, float64(digits))
-	return math.Round(value*scale) / scale
+	scaled := value * scale
+	if math.IsInf(scale, 0) || math.IsInf(scaled, 0) {
+		return value
+	}
+	return math.Round(scaled) / scale
 }
 
 // fnSubstringIndex implements MySQL SUBSTRING_INDEX(str, delim, count).

--- a/dialect/functions_test.go
+++ b/dialect/functions_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -851,5 +852,322 @@ func TestDateFormatKeepsAnUnknownSpecifierAsItsLetter(t *testing.T) {
 	}
 	if got.String != "q%Z" {
 		t.Fatalf("%s = %q, want %q", query, got.String, "q%Z")
+	}
+}
+
+// TestGoogleSQLSubstrFollowsBigQuery pins BigQuery's rule for SUBSTR beside the
+// two the other dialects follow, so the three are stated together.
+//
+// BigQuery reads position 0 as position 1, counts a negative position back from
+// the end, and clamps a position that lands before the string to its start with
+// the length measured from there. MySQL answers an empty string for position 0,
+// and PostgreSQL lets the out-of-range prefix consume the length.
+//
+// The values were read from BigQuery through goccy/bigquery-emulator, except
+// the multibyte rows: it slices bytes there and returns broken UTF-8, which is
+// its own defect. A position is a character position in all three dialects.
+func TestGoogleSQLSubstrFollowsBigQuery(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tests := []struct {
+		call                      string
+		google, mysql, postgresql string
+	}{
+		{"'abcdef', 0, 2", "ab", "", "a"},
+		{"'abcdef', 0, 1", "a", "", ""},
+		{"'abcdef', 0, 3", "abc", "", "ab"},
+		{"'abcdef', 1, 2", "ab", "ab", "ab"},
+		{"'abcdef', 3, 100", "cdef", "cdef", "cdef"},
+		{"'abcdef', 10, 2", "", "", ""},
+		{"'abcdef', 1, 0", "", "", ""},
+		{"'abcdef', -2, 3", "ef", "ef", ""},
+		{"'abcdef', -7, 2", "ab", "", ""},
+		{"'abcdef', -10, 3", "abc", "", ""},
+		{"'abcdef', -100, 100", "abcdef", "", ""},
+		{"'日本語です', 2, 2", "本語", "本語", "本語"},
+		{"'日本語です', 0, 2", "日本", "", "日"},
+	}
+
+	for _, tt := range tests {
+		for _, helper := range []struct {
+			fn   string
+			want string
+		}{
+			{"googlesql_substr", tt.google},
+			{"mysql_substr", tt.mysql},
+			{"postgresql_substr", tt.postgresql},
+		} {
+			query := "SELECT " + helper.fn + "(" + tt.call + ")"
+			var got sql.NullString
+			if err := db.QueryRowContext(context.Background(), query).Scan(&got); err != nil {
+				t.Errorf("%s: %v", query, err)
+				continue
+			}
+			if got.String != helper.want {
+				t.Errorf("%s = %q, want %q", query, got.String, helper.want)
+			}
+		}
+	}
+}
+
+// TestRoundHonorsANegativeDigitCount pins that rounding to a ten, a hundred or a
+// thousand happens. MySQL, PostgreSQL and BigQuery agree on every value below,
+// so one helper answers all three; SQLite's own round() ignores a negative
+// digit count, which is its documented behavior and stays the answer for
+// dialect.SQLite.
+//
+// Read from MySQL 8.4, PostgreSQL 17 and goccy/bigquery-emulator.
+func TestRoundHonorsANegativeDigitCount(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tests := map[string]string{
+		"12345, -1":  "12350",
+		"12345, -2":  "12300",
+		"12345, -3":  "12000",
+		"12345, -5":  "0",
+		"-12345, -2": "-12300",
+		"15, -1":     "20",
+		"25, -1":     "30",
+		"-15, -1":    "-20",
+		"999, -3":    "1000",
+		"0, -3":      "0",
+		"12345, 0":   "12345",
+		"1.26, 1":    "1.3",
+	}
+
+	for call, want := range tests {
+		query := "SELECT dialect_round(" + call + ")"
+		var got sql.NullString
+		if err := db.QueryRowContext(context.Background(), query).Scan(&got); err != nil {
+			t.Errorf("%s: %v", query, err)
+			continue
+		}
+		if got.String != want {
+			t.Errorf("%s = %q, want %q", query, got.String, want)
+		}
+	}
+
+	var null sql.NullString
+	if err := db.QueryRowContext(context.Background(), "SELECT dialect_round(NULL, -2)").Scan(&null); err != nil {
+		t.Fatalf("dialect_round(NULL, -2): %v", err)
+	}
+	if null.Valid {
+		t.Fatalf("dialect_round(NULL, -2) = %q, want NULL", null.String)
+	}
+}
+
+// TestFormatDateKnowsItsSpecifiers pins FORMAT_DATE against BigQuery one
+// specifier at a time. Twenty of them used to be written as the letter itself,
+// which is what BigQuery does for a specifier it does not know, so a format
+// string asking for a time came back holding an "X".
+//
+// The values were read from BigQuery through goccy/bigquery-emulator, except
+// four it answers wrongly: it renders %U and %W as the ISO week, answers %w
+// with 8, and drops the zero padding from %j, %U, %V and %W. Those come from
+// the documented definitions instead -- %j is 001 to 366 and the week numbers
+// are 00 to 53 -- and %I, which it answers with 13 where a 12-hour clock reads
+// 01, was already right here.
+func TestFormatDateKnowsItsSpecifiers(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Each row is one specifier and what BigQuery writes for it, for the four
+	// datetimes below. The dates are the ones where the four week numberings
+	// disagree with each other and where the week year is not the date's year.
+	dates := []string{"2024-02-29 13:05:09", "2024-01-01 00:00:00", "2023-01-01 00:00:00", "2024-12-31 00:00:00"}
+	tests := []struct {
+		spec string
+		want [4]string
+	}{
+		{"%j", [4]string{"060", "001", "001", "366"}},
+		{"%C", [4]string{"20", "20", "20", "20"}},
+		{"%Q", [4]string{"1", "1", "1", "4"}},
+		{"%D", [4]string{"02/29/24", "01/01/24", "01/01/23", "12/31/24"}},
+		{"%x", [4]string{"02/29/24", "01/01/24", "01/01/23", "12/31/24"}},
+		{"%X", [4]string{"13:05:09", "00:00:00", "00:00:00", "00:00:00"}},
+		{"%c", [4]string{"Thu Feb 29 13:05:09 2024", "Mon Jan  1 00:00:00 2024", "Sun Jan  1 00:00:00 2023", "Tue Dec 31 00:00:00 2024"}},
+		{"%h", [4]string{"Feb", "Jan", "Jan", "Dec"}},
+		{"%k", [4]string{"13", " 0", " 0", " 0"}},
+		{"%l", [4]string{" 1", "12", "12", "12"}},
+		{"%P", [4]string{"pm", "am", "am", "am"}},
+		{"%u", [4]string{"4", "1", "7", "2"}},
+		{"%w", [4]string{"4", "1", "0", "2"}},
+		{"%G", [4]string{"2024", "2024", "2022", "2025"}},
+		{"%V", [4]string{"09", "01", "52", "01"}},
+		{"%U", [4]string{"08", "00", "01", "52"}},
+		{"%W", [4]string{"09", "01", "00", "53"}},
+		{"%n", [4]string{"\n", "\n", "\n", "\n"}},
+		{"%t", [4]string{"\t", "\t", "\t", "\t"}},
+	}
+
+	for _, tt := range tests {
+		for i, date := range dates {
+			query := `SELECT FORMAT_DATETIME('` + tt.spec + `', '` + date + `')`
+			var got sql.NullString
+			if err := db.QueryRowContext(context.Background(), query).Scan(&got); err != nil {
+				t.Errorf("%s: %v", query, err)
+				continue
+			}
+			if got.String != tt.want[i] {
+				t.Errorf("%s on %s = %q, want %q", tt.spec, date, got.String, tt.want[i])
+			}
+		}
+	}
+}
+
+// TestFormatDateKeepsAnUnknownSpecifierAsItsLetter pins the fallback that hid
+// the twenty above as deliberate, and TestParseDateStillParses that splitting
+// rendering from parsing left parsing alone.
+func TestFormatDateKeepsAnUnknownSpecifierAsItsLetter(t *testing.T) {
+	if err := RegisterFunctions(); err != nil {
+		t.Fatalf("RegisterFunctions() error: %v", err)
+	}
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	tests := map[string]string{
+		// An unknown specifier is its own letter, and %% is a percent sign.
+		`'%v%%%L'`: "v%L",
+		// Text around the specifiers is copied rather than read as a format.
+		// The whole string used to become a Go layout, so "2006" and "1" were
+		// rendered as the year and the month: this came back as
+		// "year 2024 month 2".
+		`'year 2006 month 1'`: "year 2006 month 1",
+		`'%Y-%m-%d'`:          "2024-02-29",
+	}
+
+	for format, want := range tests {
+		query := `SELECT FORMAT_DATETIME(` + format + `, '2024-02-29 13:05:09')`
+		var got sql.NullString
+		if err := db.QueryRowContext(context.Background(), query).Scan(&got); err != nil {
+			t.Errorf("%s: %v", query, err)
+			continue
+		}
+		if got.String != want {
+			t.Errorf("%s = %q, want %q", query, got.String, want)
+		}
+	}
+}
+
+// TestRoundIsRewrittenOnlyWhereADialectDisagrees pins which calls reach the
+// helper. The two-argument form goes to it in every translated dialect, because
+// all three answer a negative digit count the same way and SQLite answers none.
+// The one-argument form is left alone: rounding to a whole number is what
+// SQLite already does, and rewriting it would put a helper in front of a call
+// nobody disagrees about.
+func TestRoundIsRewrittenOnlyWhereADialectDisagrees(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		dialect Dialect
+		input   string
+		want    string
+	}{
+		{MySQL, "SELECT ROUND(a, -2) FROM t", `SELECT dialect_round(a, -2) AS "ROUND(a, -2)" FROM t`},
+		{PostgreSQL, "SELECT ROUND(a, -2) FROM t", `SELECT dialect_round(a, -2) AS "ROUND(a, -2)" FROM t`},
+		{GoogleSQL, "SELECT ROUND(a, -2) FROM t", `SELECT dialect_round(a, -2) AS "ROUND(a, -2)" FROM t`},
+		{MySQL, "SELECT ROUND(a) FROM t", "SELECT ROUND(a) FROM t"},
+		{GoogleSQL, "SELECT ROUND(a) FROM t", "SELECT ROUND(a) FROM t"},
+		{SQLite, "SELECT ROUND(a, -2) FROM t", "SELECT ROUND(a, -2) FROM t"},
+	}
+
+	for _, tt := range tests {
+		got, err := Translate(tt.dialect, tt.input)
+		if err != nil {
+			t.Errorf("Translate(%v, %q): %v", tt.dialect, tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("Translate(%v, %q)\n  = %q\nwant %q", tt.dialect, tt.input, got, tt.want)
+		}
+	}
+}
+
+// TestGoogleSQLSubstrIsRoutedToItsOwnHelper pins that the GoogleSQL rewrite
+// reaches the helper above rather than SQLite's substr, beside the other two
+// dialects so the three stay apart.
+func TestGoogleSQLSubstrIsRoutedToItsOwnHelper(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		dialect Dialect
+		want    string
+	}{
+		{GoogleSQL, `SELECT googlesql_substr(s, 0, 2) AS "SUBSTR(s, 0, 2)" FROM t`},
+		{MySQL, `SELECT mysql_substr(s, 0, 2) AS "SUBSTR(s, 0, 2)" FROM t`},
+		{PostgreSQL, `SELECT postgresql_substr(s, 0, 2) AS "SUBSTR(s, 0, 2)" FROM t`},
+		{SQLite, "SELECT SUBSTR(s, 0, 2) FROM t"},
+	}
+
+	for _, tt := range tests {
+		got, err := Translate(tt.dialect, "SELECT SUBSTR(s, 0, 2) FROM t")
+		if err != nil {
+			t.Errorf("Translate(%v): %v", tt.dialect, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("Translate(%v)\n  = %q\nwant %q", tt.dialect, got, tt.want)
+		}
+	}
+}
+
+// TestSubstrAndRoundAnswerNullAndBadArity pins the edges the tables above do not
+// reach: a NULL argument is NULL rather than an error, and a call with the wrong
+// number of arguments is refused by name.
+func TestSubstrAndRoundAnswerNullAndBadArity(t *testing.T) {
+	t.Parallel()
+
+	nulls := map[string][]driver.Value{
+		"googlesql_substr null string": {nil, int64(1)},
+		"googlesql_substr null pos":    {"abc", nil},
+		"googlesql_substr null len":    {"abc", int64(1), nil},
+		"dialect_round null value":     {nil, int64(-2)},
+		"dialect_round null digits":    {float64(1), nil},
+	}
+	for name, args := range nulls {
+		var got driver.Value
+		var err error
+		if strings.HasPrefix(name, "dialect_round") {
+			got, err = fnDialectRound(args)
+		} else {
+			got, err = fnGoogleSQLSubstr(args)
+		}
+		if err != nil {
+			t.Errorf("%s: %v", name, err)
+			continue
+		}
+		if got != nil {
+			t.Errorf("%s = %v, want NULL", name, got)
+		}
+	}
+
+	if _, err := fnGoogleSQLSubstr([]driver.Value{"abc"}); err == nil {
+		t.Error("googlesql_substr accepted one argument")
+	}
+	if _, err := fnGoogleSQLSubstr([]driver.Value{"abc", int64(1), int64(2), int64(3)}); err == nil {
+		t.Error("googlesql_substr accepted four arguments")
 	}
 }

--- a/dialect/functions_test.go
+++ b/dialect/functions_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"math"
 	"regexp"
 	"strings"
 	"testing"
@@ -1189,5 +1190,50 @@ func TestSubstrAndRoundAnswerNullAndBadArity(t *testing.T) {
 	}
 	if _, err := fnGoogleSQLSubstr([]driver.Value{"abc", int64(1), int64(2), int64(3)}); err == nil {
 		t.Error("googlesql_substr accepted four arguments")
+	}
+}
+
+// TestRoundAtTheEdgesOfAFloat64 pins the digit counts where the scaling itself
+// is the problem. The guard is on what the scaling produces rather than on the
+// count, because the two are not the same question: at 18 digits the scale is
+// finite and a value below it does round, while at 400 the scale is infinite and
+// nothing can.
+func TestRoundAtTheEdgesOfAFloat64(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		value   float64
+		digits  int64
+		want    float64
+		wantErr bool
+	}{
+		"a value below the last place still rounds":       {value: 5e-19, digits: 18, want: 1e-18},
+		"a scale too large to represent leaves the value": {value: 1.5, digits: 400, want: 1.5},
+		"a large value at a large scale leaves the value": {value: 1e300, digits: 300, want: 1e300},
+		"a large value rounded to a ten is unchanged":     {value: math.MaxFloat64, digits: -1, want: math.MaxFloat64},
+		// Rounding the largest float64 up to the next unit of 1e308 lands past
+		// what a float64 holds. BigQuery raises on the overflow, and an infinity
+		// here would flow into the rest of the query as a number.
+		"a result past the largest float64 is refused": {value: math.MaxFloat64, digits: -308, wantErr: true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := fnDialectRound([]driver.Value{tt.value, tt.digits})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("dialect_round(%v, %d) = %v, want an error", tt.value, tt.digits, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("dialect_round(%v, %d): %v", tt.value, tt.digits, err)
+			}
+			if got != tt.want {
+				t.Fatalf("dialect_round(%v, %d) = %v, want %v", tt.value, tt.digits, got, tt.want)
+			}
+		})
 	}
 }

--- a/dialect/functions_test.go
+++ b/dialect/functions_test.go
@@ -910,6 +910,10 @@ func TestGoogleSQLSubstrFollowsBigQuery(t *testing.T) {
 				t.Errorf("%s: %v", query, err)
 				continue
 			}
+			if !got.Valid {
+				t.Errorf("%s = NULL, want %q", query, helper.want)
+				continue
+			}
 			if got.String != helper.want {
 				t.Errorf("%s = %q, want %q", query, got.String, helper.want)
 			}
@@ -947,6 +951,21 @@ func TestRoundHonorsANegativeDigitCount(t *testing.T) {
 		"0, -3":      "0",
 		"12345, 0":   "12345",
 		"1.26, 1":    "1.3",
+		// A tie rounds away from zero in all three engines, which is also what
+		// SQLite's own round() does.
+		"0.5, 0":  "1",
+		"1.5, 0":  "2",
+		"2.5, 0":  "3",
+		"-2.5, 0": "-3",
+		"1.25, 1": "1.3",
+		"1.35, 1": "1.4",
+		// A digit count past what a float64 carries: the value comes back as it
+		// is, and a count past the smallest power of ten it holds rounds the
+		// whole value away. Both are what MySQL and BigQuery answer, and both
+		// used to come back NaN from an infinite scale.
+		"1.5, 400":                    "1.5",
+		"12345, -400":                 "0",
+		"12345, -9223372036854775808": "0",
 	}
 
 	for call, want := range tests {
@@ -1000,6 +1019,7 @@ func TestFormatDateKnowsItsSpecifiers(t *testing.T) {
 		want [4]string
 	}{
 		{"%j", [4]string{"060", "001", "001", "366"}},
+		{"%s", [4]string{"1709211909", "1704067200", "1672531200", "1735603200"}},
 		{"%C", [4]string{"20", "20", "20", "20"}},
 		{"%Q", [4]string{"1", "1", "1", "4"}},
 		{"%D", [4]string{"02/29/24", "01/01/24", "01/01/23", "12/31/24"}},

--- a/dialect/googlesql.go
+++ b/dialect/googlesql.go
@@ -236,6 +236,10 @@ func googlesqlRewriteCall(tokens []token, nameIdx, open, closeIdx int) ([]token,
 		return rewriteRenameCall(tokens, open, closeIdx, "json_extract", googlesqlCallPass)
 	case "JSON_QUERY":
 		return rewriteJSONQuery(tokens, open, closeIdx, googlesqlCallPass)
+	case fnNameSubstring, fnNameSubstr:
+		return rewriteSubstringCall(tokens, open, closeIdx, "googlesql_substr", googlesqlCallPass)
+	case fnNameRound:
+		return rewriteRoundCall(tokens, open, closeIdx, googlesqlCallPass)
 	case "BYTE_LENGTH":
 		return rewriteRenameCall(tokens, open, closeIdx, "octet_length", googlesqlCallPass)
 	case fnNameCharLen, fnNameCharLen2:

--- a/dialect/mysql.go
+++ b/dialect/mysql.go
@@ -165,8 +165,10 @@ func mysqlRewriteCall(tokens []token, nameIdx, open, closeIdx int) ([]token, boo
 		return rewriteTimestampAdd(tokens, open, closeIdx, mysqlCallPass)
 	case "POSITION":
 		return rewritePosition(tokens, open, closeIdx, mysqlCallPass)
-	case "SUBSTRING", "SUBSTR":
+	case fnNameSubstring, fnNameSubstr:
 		return rewriteSubstringCall(tokens, open, closeIdx, "mysql_substr", mysqlCallPass)
+	case fnNameRound:
+		return rewriteRoundCall(tokens, open, closeIdx, mysqlCallPass)
 	case "LENGTH", "OCTET_LENGTH":
 		// MySQL LENGTH counts bytes; SQLite's counts characters.
 		return rewriteRenameCall(tokens, open, closeIdx, "octet_length", mysqlCallPass)

--- a/dialect/postgresql.go
+++ b/dialect/postgresql.go
@@ -181,8 +181,10 @@ func pgRewriteCall(tokens []token, nameIdx, open, closeIdx int) ([]token, bool, 
 		return rewriteExtractCall(tokens, open, closeIdx, pgCallPass)
 	case "POSITION":
 		return rewritePosition(tokens, open, closeIdx, pgCallPass)
-	case "SUBSTRING", "SUBSTR":
+	case fnNameSubstring, fnNameSubstr:
 		return rewriteSubstringCall(tokens, open, closeIdx, "postgresql_substr", pgCallPass)
+	case fnNameRound:
+		return rewriteRoundCall(tokens, open, closeIdx, pgCallPass)
 	case fnNameTrim:
 		return rewriteTrim(tokens, open, closeIdx, pgCallPass)
 	case "OVERLAY":

--- a/dialect/rewrite.go
+++ b/dialect/rewrite.go
@@ -20,6 +20,9 @@ const (
 	fnNameCharLen   = "CHAR_LENGTH"
 	fnNameCharLen2  = "CHARACTER_LENGTH"
 	fnNameStringAgg = "STRING_AGG"
+	fnNameRound     = "ROUND"
+	fnNameSubstring = "SUBSTRING"
+	fnNameSubstr    = "SUBSTR"
 )
 
 // callRecurser rewrites a slice of argument tokens with a dialect's call pass so
@@ -355,6 +358,18 @@ func topLevelComma(toks []token, open, closeIdx int) int {
 		}
 	}
 	return -1
+}
+
+// rewriteRoundCall routes the two-argument ROUND onto the helper that honors a
+// negative digit count, which SQLite's own round() ignores: ROUND(12345, -2) is
+// 12300 in MySQL, PostgreSQL and BigQuery alike, and was 12345 here. The
+// one-argument form is left alone, since rounding to a whole number is what
+// SQLite already does and there is nothing for a dialect to disagree about.
+func rewriteRoundCall(tokens []token, open, closeIdx int, recurse callRecurser) ([]token, bool, error) {
+	if len(topLevelCommas(tokens, open, closeIdx)) != 1 {
+		return nil, false, nil
+	}
+	return rewriteRenameCall(tokens, open, closeIdx, "dialect_round", recurse)
 }
 
 // topLevelCommas returns the indices of every "," at depth 1 inside the call


### PR DESCRIPTION
BigQuery has an emulator. `goccy/bigquery-emulator` runs the reference implementation locally, so the GoogleSQL translations can be measured against a BigQuery that answers rather than reasoned about from documentation. That closes the gap #428 and #430 both stopped at, where MySQL and PostgreSQL were fixed against their own engines and GoogleSQL was left on SQLite's answer because there was nothing to check it against.

Three divergences, the first two of which turn out to affect MySQL and PostgreSQL as well.

`FORMAT_DATE`, `FORMAT_DATETIME` and `FORMAT_TIMESTAMP` wrote the specifier letter instead of the value for twenty specifiers — `%j %s %C %Q %D %x %X %c %h %k %l %P %u %w %G %V %U %W %n %t` — which is also what BigQuery does for a specifier it does not know, so a report formatted with `'%F %X'` came back as `2024-02-29 X` and looked like it had worked. The cause was structural: the whole format string was turned into a Go reference-time layout, and a day of the year, a week number and an epoch second are computed rather than spelled. Rendering has its own walk over the format now, and the layout is built only for `PARSE_DATE`, which is unchanged. Building the answer rather than a layout also stops the text around the specifiers being read as one: `FORMAT_DATE('year 2006 month 1', d)` used to come back as `year 2024 month 2`.

`ROUND(x, n)` with a negative `n` returned `x` unchanged in every dialect, because the call reached SQLite's own `round()`, whose second argument is a digit count after the decimal point. `ROUND(12345, -2)` is `12300` in MySQL 8.4, PostgreSQL 17 and BigQuery alike, and all three agree on every value in the table, so one helper answers all three rather than each naming its own. `dialect.SQLite` is not rewritten: ignoring a negative digit count is SQLite's documented behavior and is what a caller who named no dialect asked for.

GoogleSQL `SUBSTR` used SQLite's rule. BigQuery's is a third rule, different from the two #428 gave the other dialects: position 0 means position 1, a negative position counts back from the end, and a position landing before the string clamps to its start with the length measured from there rather than consumed by the part that fell outside.

Five of the emulator's answers are its own defects rather than BigQuery's, and those came from the documented definitions instead: it renders `%U` and `%W` as the ISO week, answers `%w` with 8 and `%I` with 13 where a 12-hour clock reads 01, drops the zero padding from `%j` and the week numbers, and slices bytes rather than characters in `SUBSTR` and `STRPOS`. Each is called out where it is used. Nothing is being reported to that project, per this repository's rule about third-party repositories.

The sweep found more than this PR fixes. `EXTRACT(WEEK)` gives the ISO week where BigQuery's is Sunday-first, `DATE_TRUNC(d, WEEK)` truncates to Monday where BigQuery truncates to Sunday, `ISOWEEK` and `ISOYEAR` are refused, `EXTRACT` from a `TIMESTAMP` literal returns NULL, and `DIV`, `CONTAINS_SUBSTR`, `IEEE_DIVIDE` and the two-argument `LAST_DAY` are missing. Those are filed separately rather than folded in here.

One thing to carry downstream: sqly's dialects page says GoogleSQL `SUBSTR` keeps SQLite's answer "because no BigQuery was available to check its rule against", and its E2E pins that. Both stop being true when sqly next takes filesql, and its own spec file says a scenario failing that way means a limit became a fix. Running sqly's suite against this branch fails exactly that one scenario and nothing else.

`make test` and `make lint` are clean, and the cross-builds for windows/amd64 and darwin/arm64 pass.

Closes #445
Closes #446
Closes #447


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed date and timestamp formatting so computed specifiers, literals, escaped characters, and unknown specifiers render correctly.
  - Corrected negative-precision rounding, such as `ROUND(12345, -2)` returning `12300`.
  - Updated GoogleSQL `SUBSTR` and `SUBSTRING` to follow BigQuery behavior for zero, negative, and out-of-range positions.
  - Preserved correct NULL handling and validation for affected functions.

- **Tests**
  - Expanded coverage for date formatting, rounding, substring behavior, and dialect-specific translations.
  - Added verification against supported SQL dialect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->