### PR TITLE
fix(dialect): write the strftime dispatch as a chain rather than a switch

### DIFF
--- a/dialect/functions.go
+++ b/dialect/functions.go
@@ -1991,21 +1991,21 @@ func strftimeRender(tm time.Time, format string) string {
 			continue
 		}
 		spec := format[i+1]
-		switch {
-		case spec == '%':
-			b.WriteByte('%')
-		default:
-			if layout, ok := strftimeToGoLayout[spec]; ok {
-				b.WriteString(tm.Format(layout))
-			} else if computed, ok := strftimeComputed(tm, spec); ok {
-				b.WriteString(computed)
-			} else {
-				// An unknown specifier is its own letter, which is what
-				// BigQuery does.
-				b.WriteByte(spec)
-			}
-		}
 		i++
+		if spec == '%' {
+			b.WriteByte('%')
+			continue
+		}
+		if layout, ok := strftimeToGoLayout[spec]; ok {
+			b.WriteString(tm.Format(layout))
+			continue
+		}
+		if computed, ok := strftimeComputed(tm, spec); ok {
+			b.WriteString(computed)
+			continue
+		}
+		// An unknown specifier is its own letter, which is what BigQuery does.
+		b.WriteByte(spec)
 	}
 	return b.String()
 }


### PR DESCRIPTION
main is red on staticcheck after #448. It reported `QF1002: could use tagged switch on spec` against the dispatch in `strftimeRender`, whose first case compares `spec` while the other two do not compare anything: one is a map lookup and one is a function call. Written as a chain of ifs the intent is the same, the order of the three lookups is on the page, and each is evaluated only if the ones before it missed — the switch had to compute the third before entering.

staticcheck runs on pushes to main rather than on pull requests, because a run whose cache misses takes tens of minutes, so #448 was green here and turned main red on merge. This branch was checked by running `make lint-staticcheck` locally before opening it, which is the only pre-merge signal available for that linter.

`make test` and `make lint` are clean.
