### PR TITLE
docs: credit SAY-5 in a contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,3 +571,24 @@ If filesql is useful in your work:
 ## License
 
 filesql is released under the [MIT License](./LICENSE).
+
+## Contributors ✨
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://debimate.jp/"><img src="https://avatars.githubusercontent.com/u/22737008?v=4?s=75" width="75px;" alt="CHIKAMATSU Naohiro"/><br /><sub><b>CHIKAMATSU Naohiro</b></sub></a><br /><a href="https://github.com/nao1215/filesql/commits?author=nao1215" title="Code">💻</a> <a href="https://github.com/nao1215/filesql/commits?author=nao1215" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://sayportfolio.vercel.app/"><img src="https://avatars.githubusercontent.com/u/240962040?v=4?s=75" width="75px;" alt="Sai Asish Y"/><br /><sub><b>Sai Asish Y</b></sub></a><br /><a href="https://github.com/nao1215/filesql/pulls?q=is%3Apr+author%3ASAY-5" title="Documentation">📖</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
SAY-5 sent #509, correcting `commitStagedFile`'s doc comment, which still described the rename-aside fallback that the copy strategy replaced in v0.24.0. The same correction had landed on main minutes earlier in #508, so their PR was not the one merged — but the reading behind it was right and the work was real, and the repository had no contributors section to record it in.

This adds one, in the all-contributors format the sibling repositories (sqly, gup, atago) use, so a later addition can go through the same tooling. SAY-5 is credited for documentation and linked to their pull requests rather than to commits, since the commit that carries the fix is not theirs.
