### PR TITLE
docs: release v0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.46.0] - 2026-08-25
 
 ### Added
 
@@ -1608,6 +1608,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
+[0.46.0]: https://github.com/nao1215/filesql/compare/v0.45.0...v0.46.0
 [0.45.0]: https://github.com/nao1215/filesql/compare/v0.44.0...v0.45.0
 [0.44.0]: https://github.com/nao1215/filesql/compare/v0.43.1...v0.44.0
 [0.43.1]: https://github.com/nao1215/filesql/compare/v0.43.0...v0.43.1


### PR DESCRIPTION
This turns the unreleased notes into the 0.46.0 section and adds its compare link. No code changes.

The release carries one new package-level capability and a long run of correctness fixes. `prep` gained the dialect spellings it was missing — `alphanum`, `alphanumspace`, `required_with_all` and `required_without_all` — and the `parser` package's exported surface is now documented and tested where a caller meets it. A nightly job fuzzes each target for ten minutes.

The fixes are spread across the dialect translation, the load path and `prep`. MySQL's `WEEK`, `WEEKOFYEAR`, `YEARWEEK`, `QUARTER`, `ADDDATE` and `SUBDATE` answer instead of failing, `STR_TO_DATE` reads an unpadded month, day or time, and a PostgreSQL date plus an interval answers a timestamp as postgres:17 does. A load's wait for the lock is bounded and reports the context error when it stops. `prep`'s cross-field tags now read every field and value pair they name and let an empty cell pass, which is the rule the rest of the package follows.

The breaking changes remove four exported symbols nothing referred to: `parser.WriteTSVRecord`, `parser.WriteTSVRecordLineEnding`, `ContextLogger`, `SlogContextAdapter` and `NewSlogContextAdapter`. Each entry in the changelog names what a caller writes instead. sqly builds and its tests pass against this tree.
