### PR TITLE
test: give the deadline cases a deadline that has already passed

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -483,15 +483,14 @@ func ExampleOpen_errorHandling() {
 		fmt.Printf("Expected error for non-existent file: %v\n", err)
 	}
 
-	// Example 2: Context timeout handling
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond) // Very short timeout
+	// Example 2: Context timeout handling. The deadline is already in the
+	// past, so the load stops before it reads anything.
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
 	defer cancel()
 
-	// This will likely timeout
 	tmpDir := createTempTestData()
 	defer os.RemoveAll(tmpDir)
 
-	time.Sleep(10 * time.Millisecond) // Ensure timeout triggers
 	_, err = filesql.OpenContext(ctx, tmpDir)
 	if err != nil {
 		// Extract the core error message (context deadline exceeded)

--- a/filesql_test.go
+++ b/filesql_test.go
@@ -1208,8 +1208,11 @@ func TestOpenContext(t *testing.T) {
 		{
 			name: "Timeout during operation",
 			setupCtx: func() (context.Context, context.CancelFunc) {
-				// Very short timeout to trigger during ping
-				return context.WithTimeout(t.Context(), 1*time.Nanosecond)
+				// A deadline already in the past, so the context carries its
+				// error the moment it is built. A very short timeout does not:
+				// its error arrives when the runtime timer fires, which on a
+				// loaded Windows runner is late enough to lose the race.
+				return context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
 			},
 			paths:       []string{filepath.Join("testdata", "sample.csv")},
 			wantErr:     true,
@@ -1223,11 +1226,6 @@ func TestOpenContext(t *testing.T) {
 
 			ctx, cancel := tt.setupCtx()
 			defer cancel()
-
-			// For timeout test, add a small delay to ensure timeout triggers
-			if tt.name == "Timeout during operation" {
-				time.Sleep(10 * time.Millisecond)
-			}
 
 			db, err := OpenContext(ctx, tt.paths...)
 			if tt.wantErr {


### PR DESCRIPTION
A context built with a one nanosecond timeout carries its error only once the runtime timer fires, and a ten millisecond sleep in front of the call was standing in for that. The Windows runner lost that race on the release branch: TestOpenContext/Timeout_during_operation saw OpenContext return no error and failed, on a tree whose only change was the changelog. ExampleOpen_errorHandling had the same shape and would have failed the same way.

Both now build their context with context.WithDeadline on a time already past, which cancels it as it is built, so each holds its claim without sleeping and the two tests get shorter rather than longer.