### PR TITLE
docs(changelog): release v0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.47.0] - 2026-08-26
 
 ### Breaking Changes
 
@@ -1697,6 +1697,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
+[0.47.0]: https://github.com/nao1215/filesql/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/nao1215/filesql/compare/v0.45.0...v0.46.0
 [0.45.0]: https://github.com/nao1215/filesql/compare/v0.44.0...v0.45.0
 [0.44.0]: https://github.com/nao1215/filesql/compare/v0.43.1...v0.44.0


### PR DESCRIPTION
Release v0.47.0. The `## [Unreleased]` section becomes `## [0.47.0] - 2026-08-26` and gains its compare link; nothing else changes.

A minor rather than a patch, because the release carries breaking changes as well as fixes. `frame.DataFrame`'s `DistinctBy` and `DropNASubset` now return an error and refuse a column name the frame does not have, and the third round of API removals took `RegisterTranslator`, `TranslatorFunc`, `CompressionFactory.CreateWriterForFile` and the `prep` wrappers. Both have migration steps written into their entries.

The rest of the release is in three groups. The v1.0.0 preparation work: the API reduction across four rounds, the hardening pass, the Go 1.25.13 baseline and the release gate. The ACH and Fedwire write-back fixes: a row now holds against the coordinate it was read from, and a Fedwire message is read back and compared column by column before it reaches the caller's writer. And the MySQL dialect work from this week's differential sweep against MySQL 8.4: six calls that were translated, ran, and answered something MySQL would not, plus the thirty-eight functions MySQL has that SQLite has no spelling for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Published release notes for version 0.47.0 dated August 26, 2026.
  * Added a comparison link covering changes from version 0.46.0 to 0.47.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->