### PR TITLE
chore: release v0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.49.0] - 2026-08-27
 
 ### Breaking Changes
 
@@ -1891,6 +1891,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
+[0.49.0]: https://github.com/nao1215/filesql/compare/v0.48.0...v0.49.0
 [0.48.0]: https://github.com/nao1215/filesql/compare/v0.47.0...v0.48.0
 [0.47.0]: https://github.com/nao1215/filesql/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/nao1215/filesql/compare/v0.45.0...v0.46.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,8 @@ Security fixes are provided for the latest published release series only.
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| `0.48.x` | Yes | Current published release series as of August 27, 2026 |
-| `0.47.x` and earlier | No | Upgrade to the latest `0.48.x` release |
+| `0.49.x` | Yes | Current published release series as of August 27, 2026 |
+| `0.48.x` and earlier | No | Upgrade to the latest `0.49.x` release |
 
 Security fixes are not backported to unsupported release series. When the next
 series is published, support moves to it.


### PR DESCRIPTION
Dates the Unreleased section as v0.49.0 and adds the compare link.

The release carries four breaking changes, all API-surface reduction: `prep.Stream` is replaced by `ProcessResult.OutputFormat` (#690), `DBBuilder.DisableAutoSave` is removed (#691), the `ach.TableSet` and `wire.TableSet` fields are unexported behind their getters with the three missing IAT getters added (#692), and four members of the compression surface are unexported or removed (#693). Each entry in the changelog states the migration.

It also deprecates `DBBuilder.Build` (#694): `Open`, `OpenReadOnly`, `LoadInto` and `LoadIntoTx` validate the builder themselves, so a builder can be opened in one call. `Build` still works, and this is the release that gives callers of it a version to migrate from.

The rest is the load-cancellation and parser work already merged: `DumpDatabaseContext`, the context-error propagation on a canceled load, the source read that stops with the context, the two doubled error messages, the JSON trailing-bracket and element-size bounds, and the LTSV field that names no label.
