### PR TITLE
refactor!: remove DBBuilder.Build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking Changes
+
+- `DBBuilder.Build` is removed ([#694](https://github.com/nao1215/filesql/issues/694)). v0.49.0 deprecated it, because `Open`, `OpenReadOnly`, `LoadInto` and `LoadIntoTx` validate the builder themselves; this release drops it. Migration: delete the `Build` call and the error check that followed it, and call the terminal method on the builder -- `filesql.NewBuilder().AddPath("users.csv").Open(ctx)` in place of `Build` then `Open`. The errors are the same ones `Build` reported, from the method that now reports them, and `SkippedRows` is read from the builder, which is what `Build` was handing back. A caller who wants the validation without loading anything has `OpenReadOnly` followed by a close, which validates the same inputs and reads nothing until a query asks for it.
+
 ## [0.49.0] - 2026-08-27
 
 ### Breaking Changes

--- a/ach_test.go
+++ b/ach_test.go
@@ -171,7 +171,7 @@ func TestBuilderAddPathACH(t *testing.T) {
 
 	ctx := context.Background()
 	builder := NewBuilder().AddPath(testFile)
-	builder, err := builder.Build(ctx)
+	builder, err := buildForTest(ctx, builder)
 	require.NoError(t, err)
 
 	db, err := builder.Open(ctx)

--- a/atomic_write_test.go
+++ b/atomic_write_test.go
@@ -259,9 +259,11 @@ func TestDumpDatabase_LongOutputFileName(t *testing.T) {
 
 	ctx := t.Context()
 	tableName := strings.Repeat("t", 246)
-	validated, err := NewBuilder().
-		AddReader(strings.NewReader("id,name\n1,alice\n"), tableName, FileTypeCSV).
-		Build(ctx)
+	validated, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddReader(strings.NewReader("id,name\n1,alice\n"), tableName, FileTypeCSV))
+
 	require.NoError(t, err)
 	db, err := validated.Open(ctx)
 	require.NoError(t, err)

--- a/autosave_test.go
+++ b/autosave_test.go
@@ -310,7 +310,7 @@ func autoSaveSource(t *testing.T, body string) string {
 func openAutoSave(t *testing.T, path string, configure func(*DBBuilder) *DBBuilder) *sql.DB {
 	t.Helper()
 
-	validated, err := configure(NewBuilder().AddPath(path)).Build(t.Context())
+	validated, err := buildForTest(t.Context(), configure(NewBuilder().AddPath(path)))
 	require.NoError(t, err)
 	db, err := validated.Open(t.Context())
 	require.NoError(t, err)
@@ -655,7 +655,7 @@ func TestSaveLineEndingByDestination(t *testing.T) {
 
 		path := newSource(t)
 		ctx := t.Context()
-		validated, err := NewBuilder().AddPath(path).EnableAutoSave(filepath.Dir(path)).Build(ctx)
+		validated, err := buildForTest(ctx, NewBuilder().AddPath(path).EnableAutoSave(filepath.Dir(path)))
 		require.NoError(t, err)
 		db, err := validated.Open(ctx)
 		require.NoError(t, err)
@@ -690,10 +690,12 @@ func TestSaveLineEndingByDestination(t *testing.T) {
 
 		path := newSource(t)
 		ctx := t.Context()
-		validated, err := NewBuilder().
-			AddPath(path).
-			EnableAutoSave(filepath.Dir(path), NewDumpOptions().WithLineEnding(LineEndingCRLF)).
-			Build(ctx)
+		validated, err := buildForTest(
+
+			ctx, NewBuilder().
+				AddPath(path).
+				EnableAutoSave(filepath.Dir(path), NewDumpOptions().WithLineEnding(LineEndingCRLF)))
+
 		require.NoError(t, err)
 		db, err := validated.Open(ctx)
 		require.NoError(t, err)
@@ -767,7 +769,7 @@ func autoSaveOverwrite(t *testing.T, paths []string, stmts ...string) error {
 	for _, p := range paths {
 		builder = builder.AddPath(p)
 	}
-	validated, err := builder.EnableAutoSave("").Build(ctx)
+	validated, err := buildForTest(ctx, builder.EnableAutoSave(""))
 	require.NoError(t, err)
 
 	db, err := validated.Open(ctx)
@@ -946,7 +948,7 @@ func TestAutoSaveOverwriteRefusesFormatItCannotWrite(t *testing.T) {
 
 			// The extension is the whole of the answer, so Build is where the
 			// caller hears it: no database is opened and no file is touched.
-			_, err := NewBuilder().AddPath(src).EnableAutoSave("").Build(t.Context())
+			_, err := buildForTest(t.Context(), NewBuilder().AddPath(src).EnableAutoSave(""))
 			require.Error(t, err)
 			assert.ErrorIs(t, err, ErrUnsupportedFormat)
 			assert.Contains(t, err.Error(), tt.file)
@@ -1158,7 +1160,7 @@ func TestAutoSaveOverwriteXLSX(t *testing.T) {
 		before, err := os.ReadFile(src) //nolint:gosec // src is under t.TempDir()
 		require.NoError(t, err)
 
-		validated, err := NewBuilder().AddPath(src).EnableAutoSave("").Build(ctx)
+		validated, err := buildForTest(ctx, NewBuilder().AddPath(src).EnableAutoSave(""))
 		require.NoError(t, err)
 		db, err := validated.Open(ctx)
 		require.NoError(t, err)
@@ -1289,7 +1291,7 @@ func TestAutoSaveOverwriteKeepsTheFileItWasGiven(t *testing.T) {
 			src := filepath.Join(dir, name)
 			require.NoError(t, os.WriteFile(src, []byte("id,v\n1,a\n"), 0o600))
 
-			validated, err := NewBuilder().AddPath(src).EnableAutoSave("").Build(ctx)
+			validated, err := buildForTest(ctx, NewBuilder().AddPath(src).EnableAutoSave(""))
 			require.NoError(t, err)
 			db, err := validated.Open(ctx)
 			require.NoError(t, err)
@@ -1326,7 +1328,7 @@ func TestAutoSaveOverwriteRefusesCodecItCannotWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(src, fixture, 0o600)) //nolint:gosec // src is under t.TempDir()
 
-	_, err = NewBuilder().AddPath(src).EnableAutoSave("").Build(t.Context())
+	_, err = buildForTest(t.Context(), NewBuilder().AddPath(src).EnableAutoSave(""))
 	require.Error(t, err, "a codec this package cannot write must not report a successful save")
 	assert.Contains(t, err.Error(), "bzip2")
 	// The codec is read off the name, so the refusal comes from Build, before
@@ -1399,7 +1401,7 @@ func TestAutoSaveCloseWithAnOpenTransaction(t *testing.T) {
 		src := filepath.Join(dir, "users.csv")
 		require.NoError(t, os.WriteFile(src, []byte("id,name\n1,alice\n"), 0o600))
 
-		validated, err := enable(NewBuilder().AddPath(src)).Build(t.Context())
+		validated, err := buildForTest(t.Context(), enable(NewBuilder().AddPath(src)))
 		require.NoError(t, err)
 		db, err := validated.Open(t.Context())
 		require.NoError(t, err)
@@ -1562,7 +1564,7 @@ func TestAutoSaveOverwriteRefusesASourceItCannotWriteBeforeOpening(t *testing.T)
 	jsonPath := filepath.Join(dir, "zzz.json")
 	require.NoError(t, os.WriteFile(jsonPath, []byte(`[{"id":1}]`), 0o600))
 
-	_, err := NewBuilder().AddPath(csvPath).AddPath(jsonPath).EnableAutoSave("").Build(t.Context())
+	_, err := buildForTest(t.Context(), NewBuilder().AddPath(csvPath).AddPath(jsonPath).EnableAutoSave(""))
 	require.Error(t, err, "a set that cannot be saved must be refused before it is loaded")
 	assert.ErrorIs(t, err, ErrUnsupportedFormat)
 	assert.Contains(t, err.Error(), "zzz.json")
@@ -1578,7 +1580,7 @@ func TestAutoSaveOverwriteRefusesASourceItCannotWriteBeforeOpening(t *testing.T)
 		// so a source with no writer is read and written out as CSV and no
 		// source file is replaced. The refusal is about overwrite mode only.
 		out := filepath.Join(t.TempDir(), "out")
-		validated, buildErr := NewBuilder().AddPath(csvPath).AddPath(jsonPath).EnableAutoSave(out).Build(t.Context())
+		validated, buildErr := buildForTest(t.Context(), NewBuilder().AddPath(csvPath).AddPath(jsonPath).EnableAutoSave(out))
 		require.NoError(t, buildErr)
 		db, openErr := validated.Open(t.Context())
 		require.NoError(t, openErr)

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -70,9 +70,11 @@ func BenchmarkOpenJSONL(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		validated, err := NewBuilder().
-			AddReader(bytes.NewReader(lines), "events", FileTypeJSONL).
-			Build(context.Background())
+		validated, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddReader(bytes.NewReader(lines), "events", FileTypeJSONL))
+
 		if err != nil {
 			b.Fatalf("Build failed: %v", err)
 		}
@@ -107,9 +109,11 @@ func BenchmarkOpenJSON(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		validated, err := NewBuilder().
-			AddReader(bytes.NewReader(document), "events", FileTypeJSON).
-			Build(context.Background())
+		validated, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddReader(bytes.NewReader(document), "events", FileTypeJSON))
+
 		if err != nil {
 			b.Fatalf("Build failed: %v", err)
 		}
@@ -137,9 +141,11 @@ func BenchmarkOpenReader(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		validated, err := NewBuilder().
-			AddReader(bytes.NewReader(body), "customers", FileTypeCSV).
-			Build(context.Background())
+		validated, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddReader(bytes.NewReader(body), "customers", FileTypeCSV))
+
 		if err != nil {
 			b.Fatalf("Build failed: %v", err)
 		}
@@ -166,7 +172,7 @@ func BenchmarkOpenWithAutoSave(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		validated, err := NewBuilder().AddPath(csvPath).EnableAutoSave(outputDir).Build(context.Background())
+		validated, err := buildForTest(context.Background(), NewBuilder().AddPath(csvPath).EnableAutoSave(outputDir))
 		if err != nil {
 			b.Fatalf("Build failed: %v", err)
 		}
@@ -224,7 +230,7 @@ func BenchmarkOverwriteWorkbookOfNumbers(b *testing.B) {
 		write()
 		b.StartTimer()
 
-		validated, err := NewBuilder().AddPath(path).EnableAutoSave("").Build(context.Background())
+		validated, err := buildForTest(context.Background(), NewBuilder().AddPath(path).EnableAutoSave(""))
 		if err != nil {
 			b.Fatalf("Build failed: %v", err)
 		}
@@ -282,7 +288,7 @@ func BenchmarkOverwriteWorkbook(b *testing.B) {
 		write()
 		b.StartTimer()
 
-		validated, err := NewBuilder().AddPath(path).EnableAutoSave("").Build(context.Background())
+		validated, err := buildForTest(context.Background(), NewBuilder().AddPath(path).EnableAutoSave(""))
 		if err != nil {
 			b.Fatalf("Build failed: %v", err)
 		}

--- a/builder.go
+++ b/builder.go
@@ -434,20 +434,6 @@ func (b *DBBuilder) usesDialectTranslation() bool {
 	return b.sqlDialect != "" && b.sqlDialect != dialect.SQLite
 }
 
-// Build validates all configured inputs and prepares the builder for opening a
-// database.
-//
-// Deprecated: Open, OpenReadOnly, LoadInto and LoadIntoTx validate the inputs
-// themselves, so call one of those directly. Build is kept so existing
-// two-step callers keep working, and validating twice costs nothing but the
-// validation.
-func (b *DBBuilder) Build(ctx context.Context) (*DBBuilder, error) {
-	if err := b.build(ctx); err != nil {
-		return nil, err
-	}
-	return b, nil
-}
-
 // build validates all configured inputs and prepares the builder for opening a
 // database. It performs the following operations:
 //

--- a/builder_test.go
+++ b/builder_test.go
@@ -26,6 +26,17 @@ import (
 //go:embed testdata/embed_test/*.csv testdata/embed_test/*.tsv
 var testFS embed.FS
 
+// buildForTest runs the validation that Open, OpenReadOnly, LoadInto and
+// LoadIntoTx run before they load anything, and hands the builder back. The
+// tests below check that validation on its own, which the terminal methods no
+// longer let a caller do separately.
+func buildForTest(ctx context.Context, b *DBBuilder) (*DBBuilder, error) {
+	if err := b.build(ctx); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
 func TestNewBuilder(t *testing.T) {
 	t.Parallel()
 
@@ -126,8 +137,8 @@ func TestDBBuilder_AddFS_Compressed(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			validated, err := NewBuilder().AddFS(mockFS).Build(ctx)
-			require.NoError(t, err, "Build() failed for %s", codec.compression)
+			validated, err := buildForTest(ctx, NewBuilder().AddFS(mockFS))
+			require.NoError(t, err, "build() failed for %s", codec.compression)
 
 			db, err := validated.Open(ctx)
 			require.NoError(t, err, "Open() failed for %s", codec.compression)
@@ -166,8 +177,8 @@ func TestDBBuilder_AddFS_CompressedHeaderOnly(t *testing.T) {
 			}
 
 			ctx := context.Background()
-			validated, err := NewBuilder().AddFS(mockFS).Build(ctx)
-			require.NoError(t, err, "Build() failed for %s", codec)
+			validated, err := buildForTest(ctx, NewBuilder().AddFS(mockFS))
+			require.NoError(t, err, "build() failed for %s", codec)
 
 			db, err := validated.Open(ctx)
 			require.NoError(t, err, "Open() failed for %s", codec)
@@ -277,11 +288,13 @@ func TestDBBuilder_SetDefaultChunkSize(t *testing.T) {
 			want := (rows + size - 1) / size
 
 			counter := &chunkCountingHandler{}
-			validated, err := NewBuilder().
-				AddPath(path).
-				SetDefaultChunkSize(size).
-				WithLogger(slog.New(counter)).
-				Build(ctx)
+			validated, err := buildForTest(
+
+				ctx, NewBuilder().
+					AddPath(path).
+					SetDefaultChunkSize(size).
+					WithLogger(slog.New(counter)))
+
 			require.NoError(t, err)
 			db, err := validated.Open(ctx)
 			require.NoError(t, err)
@@ -291,11 +304,13 @@ func TestDBBuilder_SetDefaultChunkSize(t *testing.T) {
 			// A reader is loaded by the same processor, so it has to chunk the
 			// same way a path does.
 			counter = &chunkCountingHandler{}
-			validated, err = NewBuilder().
-				AddReader(strings.NewReader(body), "counted", FileTypeCSV).
-				SetDefaultChunkSize(size).
-				WithLogger(slog.New(counter)).
-				Build(ctx)
+			validated, err = buildForTest(
+
+				ctx, NewBuilder().
+					AddReader(strings.NewReader(body), "counted", FileTypeCSV).
+					SetDefaultChunkSize(size).
+					WithLogger(slog.New(counter)))
+
 			require.NoError(t, err)
 			db, err = validated.Open(ctx)
 			require.NoError(t, err)
@@ -312,10 +327,12 @@ func TestDBBuilder_SetDefaultChunkSize(t *testing.T) {
 
 		var want string
 		for _, size := range []int{1, 2, 7, 20, defaultChunkSizeRows} {
-			validated, err := NewBuilder().
-				AddReader(strings.NewReader(body), "counted", FileTypeCSV).
-				SetDefaultChunkSize(size).
-				Build(ctx)
+			validated, err := buildForTest(
+
+				ctx, NewBuilder().
+					AddReader(strings.NewReader(body), "counted", FileTypeCSV).
+					SetDefaultChunkSize(size))
+
 			require.NoError(t, err)
 			db, err := validated.Open(ctx)
 			require.NoError(t, err)
@@ -415,7 +432,7 @@ func describeTableForChunkTest(t *testing.T, db *sql.DB, tableName string) strin
 	return out.String()
 }
 
-func TestDBBuilder_Build(t *testing.T) {
+func TestDBBuilder_build(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -423,8 +440,8 @@ func TestDBBuilder_Build(t *testing.T) {
 	t.Run("no inputs error", func(t *testing.T) {
 		t.Parallel()
 		builder := NewBuilder()
-		_, err := builder.Build(ctx)
-		assert.Error(t, err, "Build() should return error for no inputs")
+		_, err := buildForTest(ctx, builder)
+		assert.Error(t, err, "build() should return error for no inputs")
 	})
 
 	t.Run("reader with nil reader error", func(t *testing.T) {
@@ -436,8 +453,8 @@ func TestDBBuilder_Build(t *testing.T) {
 			fileType:  FileTypeCSV,
 		})
 
-		_, err := builder.Build(ctx)
-		assert.Error(t, err, "Build() should return error for nil reader")
+		_, err := buildForTest(ctx, builder)
+		assert.Error(t, err, "build() should return error for nil reader")
 		assert.Contains(t, err.Error(), "reader cannot be nil", "error message should mention nil reader")
 	})
 
@@ -451,8 +468,8 @@ func TestDBBuilder_Build(t *testing.T) {
 			fileType:  FileTypeCSV,
 		})
 
-		_, err := builder.Build(ctx)
-		assert.Error(t, err, "Build() should return error for empty table name")
+		_, err := buildForTest(ctx, builder)
+		assert.Error(t, err, "build() should return error for empty table name")
 		assert.Contains(t, err.Error(), "table name must be specified", "error message should mention table name requirement")
 	})
 
@@ -466,8 +483,8 @@ func TestDBBuilder_Build(t *testing.T) {
 			fileType:  FileTypeUnsupported,
 		})
 
-		_, err := builder.Build(ctx)
-		assert.Error(t, err, "Build() should return error for unsupported file type")
+		_, err := buildForTest(ctx, builder)
+		assert.Error(t, err, "build() should return error for unsupported file type")
 		assert.Contains(t, err.Error(), "file type must be specified", "error message should mention file type requirement")
 	})
 
@@ -477,11 +494,11 @@ func TestDBBuilder_Build(t *testing.T) {
 		reader := bytes.NewReader([]byte(data))
 		builder := NewBuilder().AddReader(reader, "users", FileTypeCSV)
 
-		validatedBuilder, err := builder.Build(ctx)
-		assert.NoError(t, err, "Build() should succeed with valid CSV data")
-		require.NotNil(t, validatedBuilder, "Build() should not return nil builder")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		assert.NoError(t, err, "build() should succeed with valid CSV data")
+		require.NotNil(t, validatedBuilder, "build() should not return nil builder")
 		// Readers don't create temp files anymore - they use direct streaming
-		assert.Len(t, validatedBuilder.readers, 1, "Build() should have 1 reader input")
+		assert.Len(t, validatedBuilder.readers, 1, "build() should have 1 reader input")
 
 		// Clean up temp files
 	})
@@ -493,9 +510,9 @@ func TestDBBuilder_Build(t *testing.T) {
 		reader := bytes.NewReader(data)
 		builder := NewBuilder().AddReader(reader, "logs", FileTypeCSV)
 
-		validatedBuilder, err := builder.Build(ctx)
-		assert.NoError(t, err, "Build() should succeed with compressed type")
-		assert.NotNil(t, validatedBuilder, "Build() should not return nil builder")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		assert.NoError(t, err, "build() should succeed with compressed type")
+		assert.NotNil(t, validatedBuilder, "build() should not return nil builder")
 
 		// Clean up temp files
 	})
@@ -509,11 +526,11 @@ func TestDBBuilder_Build(t *testing.T) {
 			AddReader(reader1, "table1", FileTypeCSV).
 			AddReader(reader2, "table2", FileTypeTSV)
 
-		validatedBuilder, err := builder.Build(ctx)
-		assert.NoError(t, err, "Build() should succeed with multiple readers")
-		require.NotNil(t, validatedBuilder, "Build() should not return nil builder")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		assert.NoError(t, err, "build() should succeed with multiple readers")
+		require.NotNil(t, validatedBuilder, "build() should not return nil builder")
 		// Readers don't create temp files anymore - they use direct streaming
-		assert.Len(t, validatedBuilder.readers, 2, "Build() should have 2 reader inputs")
+		assert.Len(t, validatedBuilder.readers, 2, "build() should have 2 reader inputs")
 
 		// Clean up temp files
 	})
@@ -521,8 +538,8 @@ func TestDBBuilder_Build(t *testing.T) {
 	t.Run("invalid path error", func(t *testing.T) {
 		t.Parallel()
 		builder := NewBuilder().AddPath(filepath.Join("nonexistent", "file.csv"))
-		_, err := builder.Build(ctx)
-		assert.Error(t, err, "Build() should return error for nonexistent path")
+		_, err := buildForTest(ctx, builder)
+		assert.Error(t, err, "build() should return error for nonexistent path")
 	})
 
 	t.Run("unsupported file type error", func(t *testing.T) {
@@ -534,8 +551,8 @@ func TestDBBuilder_Build(t *testing.T) {
 		require.NoError(t, err, "should create test file")
 
 		builder := NewBuilder().AddPath(unsupportedFile)
-		_, err = builder.Build(ctx)
-		assert.Error(t, err, "Build() should return error for unsupported file type")
+		_, err = buildForTest(ctx, builder)
+		assert.Error(t, err, "build() should return error for unsupported file type")
 	})
 
 	t.Run("valid CSV file", func(t *testing.T) {
@@ -548,9 +565,9 @@ func TestDBBuilder_Build(t *testing.T) {
 		require.NoError(t, err, "should create CSV file")
 
 		builder := NewBuilder().AddPath(csvFile)
-		validatedBuilder, err := builder.Build(ctx)
-		assert.NoError(t, err, "Build() should succeed with valid CSV file")
-		assert.NotNil(t, validatedBuilder, "Build() should not return nil builder")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		assert.NoError(t, err, "build() should succeed with valid CSV file")
+		assert.NotNil(t, validatedBuilder, "build() should not return nil builder")
 	})
 
 	t.Run("valid directory", func(t *testing.T) {
@@ -564,9 +581,9 @@ func TestDBBuilder_Build(t *testing.T) {
 		require.NoError(t, err, "Failed to create test CSV file")
 
 		builder := NewBuilder().AddPath(tempDir)
-		validatedBuilder, err := builder.Build(ctx)
-		assert.NoError(t, err, "Build() should succeed with valid directory")
-		assert.NotNil(t, validatedBuilder, "Build() should not return nil builder")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		assert.NoError(t, err, "build() should succeed with valid directory")
+		assert.NotNil(t, validatedBuilder, "build() should not return nil builder")
 	})
 
 	t.Run("FS with valid files", func(t *testing.T) {
@@ -579,12 +596,12 @@ func TestDBBuilder_Build(t *testing.T) {
 		}
 
 		builder := NewBuilder().AddFS(mockFS)
-		validatedBuilder, err := builder.Build(ctx)
-		assert.NoError(t, err, "Build() should succeed with FS containing valid files")
-		require.NotNil(t, validatedBuilder, "Build() should not return nil builder")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		assert.NoError(t, err, "build() should succeed with FS containing valid files")
+		require.NotNil(t, validatedBuilder, "build() should not return nil builder")
 		// Should have found 3 files (csv, tsv, ltsv) and ignored txt
 		// fs.FS files are now stored as readers instead of collectedPaths
-		assert.Len(t, validatedBuilder.readers, 3, "Build() should have 3 readers from fs.FS")
+		assert.Len(t, validatedBuilder.readers, 3, "build() should have 3 readers from fs.FS")
 	})
 
 	t.Run("FS with nil filesystem error", func(t *testing.T) {
@@ -592,8 +609,8 @@ func TestDBBuilder_Build(t *testing.T) {
 		builder := NewBuilder()
 		builder.filesystems = append(builder.filesystems, nil)
 
-		_, err := builder.Build(ctx)
-		assert.Error(t, err, "Build() should return error for nil FS")
+		_, err := buildForTest(ctx, builder)
+		assert.Error(t, err, "build() should return error for nil FS")
 	})
 
 	t.Run("FS with no supported files error", func(t *testing.T) {
@@ -604,8 +621,8 @@ func TestDBBuilder_Build(t *testing.T) {
 		}
 
 		builder := NewBuilder().AddFS(mockFS)
-		_, err := builder.Build(ctx)
-		assert.Error(t, err, "Build() should return error for FS with no supported files")
+		_, err := buildForTest(ctx, builder)
+		assert.Error(t, err, "build() should return error for FS with no supported files")
 	})
 }
 
@@ -634,8 +651,8 @@ func TestDBBuilder_ChunkedReading(t *testing.T) {
 			AddReader(reader, "large_table", FileTypeCSV)
 
 		ctx := context.Background()
-		validatedBuilder, err := builder.Build(ctx)
-		require.NoError(t, err, "Build() should succeed")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		require.NoError(t, err, "build() should succeed")
 
 		db, err := validatedBuilder.Open(ctx)
 		assert.NoError(t, err, "Open() should succeed")
@@ -659,8 +676,8 @@ func TestDBBuilder_Open_WithReader(t *testing.T) {
 		reader := bytes.NewReader([]byte(data))
 		builder := NewBuilder().AddReader(reader, "users", FileTypeCSV)
 
-		validatedBuilder, err := builder.Build(ctx)
-		require.NoError(t, err, "Build() should succeed")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		require.NoError(t, err, "build() should succeed")
 
 		db, err := validatedBuilder.Open(ctx)
 		assert.NoError(t, err, "Open() should succeed")
@@ -691,8 +708,8 @@ func TestDBBuilder_Open_WithReader(t *testing.T) {
 			AddPath(csvFile).
 			AddReader(reader, "products", FileTypeCSV)
 
-		validatedBuilder, err := builder.Build(ctx)
-		require.NoError(t, err, "Build() should succeed with mixed inputs")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		require.NoError(t, err, "build() should succeed with mixed inputs")
 
 		db, err := validatedBuilder.Open(ctx)
 		assert.NoError(t, err, "Open() should succeed")
@@ -735,23 +752,23 @@ func TestDBBuilder_Open(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrNoFiles), "error should be ErrNoFiles, got %v", err)
 	})
 
-	t.Run("build then open loads an added filesystem once", func(t *testing.T) {
-		// build appends the readers it derives from a filesystem, so running
-		// it twice would register every file of that filesystem twice.
+	t.Run("validating then opening loads an added filesystem once", func(t *testing.T) {
+		// The validation derives a reader per file of the filesystem, so
+		// running it twice would register every one of them twice.
 		fsys := fstest.MapFS{
 			"users.csv": &fstest.MapFile{Data: []byte("id,name\n1,Alice\n")},
 		}
 
-		validated, err := NewBuilder().AddFS(fsys).Build(ctx)
-		require.NoError(t, err, "Build() should succeed")
+		validated, err := buildForTest(ctx, NewBuilder().AddFS(fsys))
+		require.NoError(t, err, "build() should succeed")
 
 		db, err := validated.Open(ctx)
-		require.NoError(t, err, "Open() after Build() should succeed")
+		require.NoError(t, err, "Open() after the validation should succeed")
 		defer func() { _ = db.Close() }()
 
 		var rows int
 		require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM users").Scan(&rows))
-		assert.Equal(t, 1, rows, "the file must be loaded once, not once per build")
+		assert.Equal(t, 1, rows, "the file must be loaded once, not once per validation")
 	})
 
 	t.Run("open after a failed open loads an added filesystem once", func(t *testing.T) {
@@ -794,8 +811,8 @@ func TestDBBuilder_Open(t *testing.T) {
 		require.NoError(t, err, "should create CSV file")
 
 		builder := NewBuilder().AddPath(csvFile)
-		validatedBuilder, err := builder.Build(ctx)
-		require.NoError(t, err, "Build() should succeed")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		require.NoError(t, err, "build() should succeed")
 
 		db, err := validatedBuilder.Open(ctx)
 		assert.NoError(t, err, "Open() should succeed")
@@ -811,8 +828,8 @@ func TestDBBuilder_Open(t *testing.T) {
 		}
 
 		builder := NewBuilder().AddFS(mockFS)
-		validatedBuilder, err := builder.Build(ctx)
-		require.NoError(t, err, "Build() should succeed")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		require.NoError(t, err, "build() should succeed")
 
 		db, err := validatedBuilder.Open(ctx)
 		assert.NoError(t, err, "Open() should succeed")
@@ -830,8 +847,8 @@ func TestDBBuilder_Open(t *testing.T) {
 		}
 
 		builder := NewBuilder().AddFS(mockFS)
-		validatedBuilder, err := builder.Build(ctx)
-		require.NoError(t, err, "Build() should succeed")
+		validatedBuilder, err := buildForTest(ctx, builder)
+		require.NoError(t, err, "build() should succeed")
 
 		db, err := validatedBuilder.Open(ctx)
 		assert.NoError(t, err, "Open() should succeed")
@@ -903,8 +920,8 @@ func TestIntegrationWithEmbedFS(t *testing.T) {
 	// Test loading all supported files from embedded FS
 	builder := NewBuilder().AddFS(subFS)
 
-	validatedBuilder, err := builder.Build(ctx)
-	require.NoError(t, err, "Build() should succeed with embedded FS")
+	validatedBuilder, err := buildForTest(ctx, builder)
+	require.NoError(t, err, "build() should succeed with embedded FS")
 
 	db, err := validatedBuilder.Open(ctx)
 	assert.NoError(t, err, "Open() with embed.FS should succeed")
@@ -942,7 +959,7 @@ func TestAutoSave_OnClose(t *testing.T) {
 		AddPath(csvPath).
 		EnableAutoSave(outputDir)
 
-	validatedBuilder, err := builder.Build(ctx)
+	validatedBuilder, err := buildForTest(ctx, builder)
 	require.NoError(t, err, "Build should succeed")
 
 	db, err := validatedBuilder.Open(ctx)
@@ -991,7 +1008,7 @@ func TestAutoSave_OnCommit(t *testing.T) {
 		AddPath(csvPath).
 		EnableAutoSaveOnCommit(outputDir)
 
-	validatedBuilder, err := builder.Build(ctx)
+	validatedBuilder, err := buildForTest(ctx, builder)
 	if err != nil {
 		require.NoError(t, err, "Build should succeed")
 	}
@@ -1056,7 +1073,7 @@ func TestAutoSave_OffByDefault(t *testing.T) {
 		AddPath(csvPath)
 	// Note: No EnableAutoSave() call
 
-	validatedBuilder, err := builder.Build(ctx)
+	validatedBuilder, err := buildForTest(ctx, builder)
 	if err != nil {
 		require.NoError(t, err, "Build should succeed")
 	}
@@ -1109,7 +1126,7 @@ func TestAutoSave_MultipleCommitsOverwrite(t *testing.T) {
 		AddPath(csvPath).
 		EnableAutoSaveOnCommit(outputDir)
 
-	validatedBuilder, err := builder.Build(ctx)
+	validatedBuilder, err := buildForTest(ctx, builder)
 	if err != nil {
 		require.NoError(t, err, "Build should succeed")
 	}
@@ -1225,27 +1242,27 @@ func TestBuilder_ErrorCases(t *testing.T) {
 	t.Run("build with no inputs", func(t *testing.T) {
 		t.Parallel()
 		builder := NewBuilder()
-		_, err := builder.Build(ctx)
+		_, err := buildForTest(ctx, builder)
 		if err == nil {
-			assert.Error(t, err, "Build() with no inputs should return error")
+			assert.Error(t, err, "build() with no inputs should return error")
 		}
 	})
 
 	t.Run("build with empty path", func(t *testing.T) {
 		t.Parallel()
 		builder := NewBuilder().AddPath("")
-		_, err := builder.Build(ctx)
+		_, err := buildForTest(ctx, builder)
 		if err == nil {
-			assert.Error(t, err, "Build() with empty path should return error")
+			assert.Error(t, err, "build() with empty path should return error")
 		}
 	})
 
 	t.Run("build with non-existent path", func(t *testing.T) {
 		t.Parallel()
 		builder := NewBuilder().AddPath(filepath.Join("non", "existent", "file.csv"))
-		_, err := builder.Build(ctx)
+		_, err := buildForTest(ctx, builder)
 		if err == nil {
-			assert.Error(t, err, "Build() with non-existent path should return error")
+			assert.Error(t, err, "build() with non-existent path should return error")
 		}
 	})
 
@@ -1262,9 +1279,9 @@ func TestBuilder_ErrorCases(t *testing.T) {
 			AddPath(csvPath).
 			EnableAutoSave("") // Empty string should work for overwrite mode
 
-		_, err := builder.Build(ctx)
+		_, err := buildForTest(ctx, builder)
 		if err != nil {
-			t.Errorf("Build() with empty output directory should not error, got: %v", err)
+			t.Errorf("build() with empty output directory should not error, got: %v", err)
 		}
 	})
 
@@ -1281,9 +1298,9 @@ func TestBuilder_ErrorCases(t *testing.T) {
 			AddPath(csvPath).
 			EnableAutoSaveOnCommit("") // Empty string should work for overwrite mode
 
-		_, err := builder.Build(ctx)
+		_, err := buildForTest(ctx, builder)
 		if err != nil {
-			t.Errorf("Build() with empty output directory for auto-save on commit should not error, got: %v", err)
+			t.Errorf("build() with empty output directory for auto-save on commit should not error, got: %v", err)
 		}
 	})
 
@@ -1295,7 +1312,7 @@ func TestBuilder_ErrorCases(t *testing.T) {
 		reader := strings.NewReader(invalidCSV)
 
 		builder := NewBuilder().AddReader(reader, "invalid", FileTypeCSV)
-		_, err := builder.Build(ctx)
+		_, err := buildForTest(ctx, builder)
 
 		// Should handle malformed CSV gracefully or return meaningful error
 		if err == nil {
@@ -1308,7 +1325,7 @@ func TestBuilder_ErrorCases(t *testing.T) {
 
 		reader := strings.NewReader("")
 		builder := NewBuilder().AddReader(reader, "empty", FileTypeCSV)
-		_, err := builder.Build(ctx)
+		_, err := buildForTest(ctx, builder)
 
 		// Build should fail with empty CSV data
 		if err == nil {
@@ -1327,7 +1344,7 @@ func TestBuilder_ErrorCases(t *testing.T) {
 			AddReader(reader, "test", FileTypeCSV).
 			SetDefaultChunkSize(1) // Very small chunk size
 
-		_, err := builder.Build(ctx)
+		_, err := buildForTest(ctx, builder)
 		if err != nil {
 			assert.NoError(t, err, "Build should handle small chunk size")
 		}
@@ -1510,10 +1527,12 @@ func TestTransactionMethods(t *testing.T) {
 			require.NoError(t, err, "operation should succeed")
 		}
 
-		validatedBuilder, err := NewBuilder().
-			AddPath(testCsvFile).
-			EnableAutoSaveOnCommit(testTempDir).
-			Build(context.Background())
+		validatedBuilder, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddPath(testCsvFile).
+				EnableAutoSaveOnCommit(testTempDir))
+
 		if err != nil {
 			require.NoError(t, err, "operation should succeed")
 		}
@@ -1552,10 +1571,12 @@ func TestTransactionMethods(t *testing.T) {
 			require.NoError(t, err, "operation should succeed")
 		}
 
-		validatedBuilder, err := NewBuilder().
-			AddPath(testCsvFile).
-			EnableAutoSaveOnCommit(testTempDir).
-			Build(context.Background())
+		validatedBuilder, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddPath(testCsvFile).
+				EnableAutoSaveOnCommit(testTempDir))
+
 		if err != nil {
 			require.NoError(t, err, "operation should succeed")
 		}
@@ -1586,10 +1607,12 @@ func TestTransactionMethods(t *testing.T) {
 			require.NoError(t, err, "operation should succeed")
 		}
 
-		validatedBuilder, err := NewBuilder().
-			AddPath(testCsvFile).
-			EnableAutoSaveOnCommit(""). // Empty string triggers overwrite
-			Build(context.Background())
+		validatedBuilder, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddPath(testCsvFile).
+				EnableAutoSaveOnCommit(""))
+
 		if err != nil {
 			require.NoError(t, err, "operation should succeed")
 		}
@@ -1635,10 +1658,12 @@ func TestAutoSavePaths(t *testing.T) {
 			require.NoError(t, err, "operation should succeed")
 		}
 
-		validatedBuilder, err := NewBuilder().
-			AddPath(testCsvFile).
-			EnableAutoSave(testTempDir).
-			Build(context.Background())
+		validatedBuilder, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddPath(testCsvFile).
+				EnableAutoSave(testTempDir))
+
 		if err != nil {
 			require.NoError(t, err, "operation should succeed")
 		}
@@ -1665,9 +1690,11 @@ func TestAutoSavePaths(t *testing.T) {
 		t.Parallel()
 
 		// Test with header-only reader to trigger createEmptyTable path
-		validatedBuilder, err := NewBuilder().
-			AddReader(strings.NewReader("col1,col2\n"), "empty_test", FileTypeCSV).
-			Build(context.Background())
+		validatedBuilder, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddReader(strings.NewReader("col1,col2\n"), "empty_test", FileTypeCSV))
+
 		if err != nil {
 			require.NoError(t, err, "operation should succeed")
 		}
@@ -1699,10 +1726,12 @@ func TestAutoSavePaths(t *testing.T) {
 
 		// Create a custom reader input that forces empty table creation
 		// We'll simulate this by creating a very small chunk size that reads only headers
-		validatedBuilder, err := NewBuilder().
-			AddReader(reader, "parsed_empty", FileTypeCSV).
-			SetDefaultChunkSize(1). // Very small chunk to simulate header-only parsing
-			Build(context.Background())
+		validatedBuilder, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddReader(reader, "parsed_empty", FileTypeCSV).
+				SetDefaultChunkSize(1))
+
 		if err != nil {
 			require.NoError(t, err, "operation should succeed")
 		}
@@ -1738,9 +1767,11 @@ func TestAutoSavePaths(t *testing.T) {
 
 		// Test with duplicate column names
 		duplicateCSV := "id,name,id\n"
-		validatedBuilder, err := NewBuilder().
-			AddReader(strings.NewReader(duplicateCSV), "duplicate_cols", FileTypeCSV).
-			Build(context.Background())
+		validatedBuilder, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddReader(strings.NewReader(duplicateCSV), "duplicate_cols", FileTypeCSV))
+
 		if err != nil {
 			require.NoError(t, err, "operation should succeed")
 		}
@@ -1760,9 +1791,11 @@ func TestAutoSavePaths(t *testing.T) {
 		// Test the fallback path when parseFromReader fails
 		// Use a reader that would cause parsing to fail but still have readable content
 		brokenCSV := "id,name,email\n" // Header only, no data, should trigger fallback
-		validatedBuilder, err := NewBuilder().
-			AddReader(strings.NewReader(brokenCSV), "fallback_test", FileTypeCSV).
-			Build(context.Background())
+		validatedBuilder, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddReader(strings.NewReader(brokenCSV), "fallback_test", FileTypeCSV))
+
 		if err != nil {
 			require.NoError(t, err, "operation should succeed")
 		}
@@ -1818,7 +1851,7 @@ func canceledContext(t *testing.T) context.Context {
 func builtBuilder(t *testing.T, path string) *DBBuilder {
 	t.Helper()
 
-	builder, err := NewBuilder().AddPath(path).Build(context.Background())
+	builder, err := buildForTest(context.Background(), NewBuilder().AddPath(path))
 	require.NoError(t, err)
 	return builder
 }

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -159,7 +159,7 @@ func TestLoadIntoTxStagingFailureRollsBackEverything(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	goodBuilder, err := NewBuilder().AddPath(good).Build(t.Context())
+	goodBuilder, err := buildForTest(t.Context(), NewBuilder().AddPath(good))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +167,7 @@ func TestLoadIntoTxStagingFailureRollsBackEverything(t *testing.T) {
 		t.Fatalf("staging the good input: %v", err)
 	}
 
-	brokenBuilder, err := NewBuilder().AddPath(broken).Build(t.Context())
+	brokenBuilder, err := buildForTest(t.Context(), NewBuilder().AddPath(broken))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func TestLoadIntoTxACHMetadataStaysInTheTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	builder, err := NewBuilder().AddPath(achPath).Build(t.Context())
+	builder, err := buildForTest(t.Context(), NewBuilder().AddPath(achPath))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -121,7 +121,7 @@ func TestAutoSaveConcurrentQueries(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "users.csv")
 	require.NoError(t, os.WriteFile(path, []byte("id,name\n1,alice\n"), 0o600))
 
-	validated, err := NewBuilder().AddPath(path).EnableAutoSave("").Build(ctx)
+	validated, err := buildForTest(ctx, NewBuilder().AddPath(path).EnableAutoSave(""))
 	require.NoError(t, err)
 	db, err := validated.Open(ctx)
 	require.NoError(t, err)
@@ -171,7 +171,7 @@ func TestAutoSaveOnCommitConcurrentCommits(t *testing.T) {
 	require.NoError(t, os.WriteFile(path, []byte("id,name\n1,alice\n"), 0o600))
 
 	outputDir := t.TempDir()
-	validated, err := NewBuilder().AddPath(path).EnableAutoSaveOnCommit(outputDir).Build(ctx)
+	validated, err := buildForTest(ctx, NewBuilder().AddPath(path).EnableAutoSaveOnCommit(outputDir))
 	require.NoError(t, err)
 	db, err := validated.Open(ctx)
 	require.NoError(t, err)
@@ -227,7 +227,7 @@ func TestAutoSaveOnCommitConcurrentQueriesAndCommits(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "users.csv")
 	require.NoError(t, os.WriteFile(path, []byte("id,name\n1,alice\n"), 0o600))
 
-	validated, err := NewBuilder().AddPath(path).EnableAutoSaveOnCommit(t.TempDir()).Build(ctx)
+	validated, err := buildForTest(ctx, NewBuilder().AddPath(path).EnableAutoSaveOnCommit(t.TempDir()))
 	require.NoError(t, err)
 	db, err := validated.Open(ctx)
 	require.NoError(t, err)
@@ -330,7 +330,7 @@ func TestAutoSaveSavesOnceUnderConcurrentClose(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "users.csv")
 	require.NoError(t, os.WriteFile(path, []byte("id,name\n1,alice\n"), 0o600))
 
-	validated, err := NewBuilder().AddPath(path).EnableAutoSave("").Build(ctx)
+	validated, err := buildForTest(ctx, NewBuilder().AddPath(path).EnableAutoSave(""))
 	require.NoError(t, err)
 	db, err := validated.Open(ctx)
 	require.NoError(t, err)
@@ -468,9 +468,11 @@ func TestConcurrentLoadIntoFromReaders(t *testing.T) {
 	errs := make([]error, goroutines)
 	for i := range goroutines {
 		wg.Go(func() {
-			builder, buildErr := NewBuilder().
-				AddReader(strings.NewReader("id,name\n1,alice\n"), fmt.Sprintf("r%d", i), FileTypeCSV).
-				Build(t.Context())
+			builder, buildErr := buildForTest(
+
+				t.Context(), NewBuilder().
+					AddReader(strings.NewReader("id,name\n1,alice\n"), fmt.Sprintf("r%d", i), FileTypeCSV))
+
 			if buildErr != nil {
 				errs[i] = buildErr
 				return

--- a/dialect_bridge_test.go
+++ b/dialect_bridge_test.go
@@ -22,7 +22,7 @@ import (
 func TestOpenWithDialectMySQL(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.MySQL).Build(ctx)
+	builder, err := buildForTest(ctx, NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.MySQL))
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestOpenWithDialectMySQL(t *testing.T) {
 func TestOpenWithDialectPostgreSQL(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.PostgreSQL).Build(ctx)
+	builder, err := buildForTest(ctx, NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.PostgreSQL))
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestOpenWithDialectPostgreSQL(t *testing.T) {
 func TestOpenWithDialectGoogleSQL(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.GoogleSQL).Build(ctx)
+	builder, err := buildForTest(ctx, NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.GoogleSQL))
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -144,7 +144,7 @@ func TestStringAggDistinctExecutes(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(tt.dialect).Build(ctx)
+			builder, err := buildForTest(ctx, NewBuilder().AddPath("testdata/sample.csv").WithDialect(tt.dialect))
 			if err != nil {
 				t.Fatalf("Build: %v", err)
 			}
@@ -172,7 +172,7 @@ func TestOpenWithDialectDefaultIsSQLite(t *testing.T) {
 	ctx := context.Background()
 	// Without WithDialect, the database is plain SQLite: a MySQL-only construct
 	// like backtick strings is not translated, but standard SQL still works.
-	builder, err := NewBuilder().AddPath("testdata/sample.csv").Build(ctx)
+	builder, err := buildForTest(ctx, NewBuilder().AddPath("testdata/sample.csv"))
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestOpenWithDialectDefaultIsSQLite(t *testing.T) {
 func TestWithDialectLoadIsSQLite(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.MySQL).Build(ctx)
+	builder, err := buildForTest(ctx, NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.MySQL))
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestWithDialectLoadIsSQLite(t *testing.T) {
 func TestOpenReadOnlyWithDialect(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.PostgreSQL).Build(ctx)
+	builder, err := buildForTest(ctx, NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.PostgreSQL))
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -247,11 +247,13 @@ func TestOpenReadOnlyWithDialect(t *testing.T) {
 func TestWithDialectAutoSaveConflict(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	_, err := NewBuilder().
-		AddPath("testdata/sample.csv").
-		WithDialect(dialect.MySQL).
-		EnableAutoSave(t.TempDir()).
-		Build(ctx)
+	_, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddPath("testdata/sample.csv").
+			WithDialect(dialect.MySQL).
+			EnableAutoSave(t.TempDir()))
+
 	if err == nil {
 		t.Fatal("Build should reject WithDialect + auto-save")
 	}
@@ -263,10 +265,12 @@ func TestWithDialectAutoSaveConflict(t *testing.T) {
 func TestWithDialectUnknown(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	_, err := NewBuilder().
-		AddPath("testdata/sample.csv").
-		WithDialect(dialect.Dialect("oracle")).
-		Build(ctx)
+	_, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddPath("testdata/sample.csv").
+			WithDialect(dialect.Dialect("oracle")))
+
 	if err == nil {
 		t.Fatal("Build should reject an unknown dialect")
 	}
@@ -280,7 +284,7 @@ func TestWithDialectUnknown(t *testing.T) {
 func TestWithDialectTranslationError(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.PostgreSQL).Build(ctx)
+	builder, err := buildForTest(ctx, NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.PostgreSQL))
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -302,7 +306,7 @@ func TestWithDialectTranslationError(t *testing.T) {
 func TestWithDialectTransaction(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.MySQL).Build(ctx)
+	builder, err := buildForTest(ctx, NewBuilder().AddPath("testdata/sample.csv").WithDialect(dialect.MySQL))
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -447,7 +451,7 @@ func TestDialectQueryKeepsResultColumnNames(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
-			builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(tt.dialect).Build(ctx)
+			builder, err := buildForTest(ctx, NewBuilder().AddPath("testdata/sample.csv").WithDialect(tt.dialect))
 			if err != nil {
 				t.Fatalf("Build: %v", err)
 			}
@@ -551,7 +555,7 @@ func TestDialectLiteralsMeanWhatTheySay(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
 
-			builder, err := NewBuilder().AddPath("testdata/sample.csv").WithDialect(tt.dialect).Build(ctx)
+			builder, err := buildForTest(ctx, NewBuilder().AddPath("testdata/sample.csv").WithDialect(tt.dialect))
 			if err != nil {
 				t.Fatalf("Build: %v", err)
 			}
@@ -725,7 +729,7 @@ func TestLikeEscapesWildcard(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			validated, err := NewBuilder().AddPath(path).WithDialect(d).Build(ctx)
+			validated, err := buildForTest(ctx, NewBuilder().AddPath(path).WithDialect(d))
 			if err != nil {
 				t.Fatalf("Build: %v", err)
 			}

--- a/dump_test.go
+++ b/dump_test.go
@@ -1311,7 +1311,7 @@ func TestDumpDatabaseFollowsASymlink(t *testing.T) {
 		t.Skipf("this platform does not allow a symlink to be created: %v", err)
 	}
 
-	validated, err := NewBuilder().AddPath(src).Build(t.Context())
+	validated, err := buildForTest(t.Context(), NewBuilder().AddPath(src))
 	require.NoError(t, err)
 	db, err := validated.Open(t.Context())
 	require.NoError(t, err)
@@ -1473,9 +1473,11 @@ func TestUsableAsFileNameRejectsWhatTheDumpCannotReach(t *testing.T) {
 func loadOneTable(t *testing.T, table string) (*sql.DB, string) {
 	t.Helper()
 
-	validated, err := NewBuilder().
-		AddReader(strings.NewReader("v\n1\n"), table, FileTypeCSV).
-		Build(t.Context())
+	validated, err := buildForTest(
+
+		t.Context(), NewBuilder().
+			AddReader(strings.NewReader("v\n1\n"), table, FileTypeCSV))
+
 	require.NoError(t, err)
 	db, err := validated.Open(t.Context())
 	require.NoError(t, err)

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -705,9 +705,11 @@ func TestUTF16RoundTripKeepsAstralCharacters(t *testing.T) {
 		t.Run(enc.String(), func(t *testing.T) {
 			t.Parallel()
 
-			built, err := NewBuilder().
-				AddReader(strings.NewReader("v\n"+want+"\n"), "t", FileTypeCSV).
-				Build(ctx)
+			built, err := buildForTest(
+
+				ctx, NewBuilder().
+					AddReader(strings.NewReader("v\n"+want+"\n"), "t", FileTypeCSV))
+
 			require.NoError(t, err)
 			db, err := built.Open(ctx)
 			require.NoError(t, err)

--- a/errors_test.go
+++ b/errors_test.go
@@ -214,7 +214,7 @@ func TestErrorSentinelsAreReachable(t *testing.T) {
 				dir := t.TempDir()
 				src := filepath.Join(dir, "users.csv")
 				require.NoError(t, os.WriteFile(src, []byte("id,name\n1,alice\n"), 0o600))
-				validated, err := NewBuilder().AddPath(src).Build(t.Context())
+				validated, err := buildForTest(t.Context(), NewBuilder().AddPath(src))
 				require.NoError(t, err)
 				db, err := validated.Open(t.Context())
 				require.NoError(t, err)

--- a/example_api_test.go
+++ b/example_api_test.go
@@ -102,12 +102,7 @@ func ExampleDBBuilder_SetDefaultChunkSize() {
 		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n3,Cora\n"), "users", filesql.FileTypeCSV).
 		SetDefaultChunkSize(2)
 
-	validated, err := builder.Build(context.Background())
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	db, err := validated.Open(context.Background())
+	db, err := builder.Open(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -127,15 +122,11 @@ func ExampleDBBuilder_SetDefaultChunkSize() {
 func ExampleDBBuilder_WithMalformedRowPolicy() {
 	csvData := "id,name\n1,Alice\n2\n3,Cora,extra\n4,Dave\n"
 
-	validated, err := filesql.NewBuilder().
+	builder := filesql.NewBuilder().
 		AddReader(strings.NewReader(csvData), "users", filesql.FileTypeCSV).
-		WithMalformedRowPolicy(filesql.MalformedRowSkip).
-		Build(context.Background())
-	if err != nil {
-		log.Fatal(err)
-	}
+		WithMalformedRowPolicy(filesql.MalformedRowSkip)
 
-	db, err := validated.Open(context.Background())
+	db, err := builder.Open(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -153,15 +144,11 @@ func ExampleDBBuilder_WithMalformedRowPolicy() {
 }
 
 func ExampleDBBuilder_WithDialect() {
-	validated, err := filesql.NewBuilder().
+	builder := filesql.NewBuilder().
 		AddReader(strings.NewReader("id,shipped_at\n1,2024-12-31 09:07:00\n"), "orders", filesql.FileTypeCSV).
-		WithDialect(dialect.MySQL).
-		Build(context.Background())
-	if err != nil {
-		log.Fatal(err)
-	}
+		WithDialect(dialect.MySQL)
 
-	db, err := validated.Open(context.Background())
+	db, err := builder.Open(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -197,15 +184,11 @@ func ExampleDBBuilder_WithLogger() {
 		},
 	}))
 
-	validated, err := filesql.NewBuilder().
+	builder := filesql.NewBuilder().
 		WithLogger(logger).
-		AddReader(strings.NewReader("id,name\n1,Alice\n"), "users", filesql.FileTypeCSV).
-		Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+		AddReader(strings.NewReader("id,name\n1,Alice\n"), "users", filesql.FileTypeCSV)
 
-	db, err := validated.Open(ctx)
+	db, err := builder.Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -222,17 +205,13 @@ func ExampleDBBuilder_WithLogger() {
 func ExampleDBBuilder_OpenReadOnly() {
 	ctx := context.Background()
 
-	validated, err := filesql.NewBuilder().
-		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", filesql.FileTypeCSV).
-		Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+	builder := filesql.NewBuilder().
+		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", filesql.FileTypeCSV)
 
 	// The result is an ordinary *sql.DB whose connections carry SQLite's
 	// query_only pragma, so a write is refused by the engine rather than by
 	// this package.
-	db, err := validated.OpenReadOnly(ctx)
+	db, err := builder.OpenReadOnly(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -262,14 +241,10 @@ func ExampleDBBuilder_LoadInto() {
 		log.Fatal(err)
 	}
 
-	validated, err := filesql.NewBuilder().
-		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", filesql.FileTypeCSV).
-		Build(context.Background())
-	if err != nil {
-		log.Fatal(err)
-	}
+	builder := filesql.NewBuilder().
+		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", filesql.FileTypeCSV)
 
-	if err := validated.LoadInto(ctx, db); err != nil {
+	if err := builder.LoadInto(ctx, db); err != nil {
 		log.Fatal(err)
 	}
 
@@ -292,12 +267,8 @@ func ExampleDBBuilder_LoadIntoTx() {
 
 	ctx := context.Background()
 
-	validated, err := filesql.NewBuilder().
-		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", filesql.FileTypeCSV).
-		Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+	builder := filesql.NewBuilder().
+		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", filesql.FileTypeCSV)
 
 	// The caller owns the transaction: the load lands only on Commit, and a
 	// Rollback discards it.
@@ -305,7 +276,7 @@ func ExampleDBBuilder_LoadIntoTx() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if err := validated.LoadIntoTx(ctx, tx); err != nil {
+	if err := builder.LoadIntoTx(ctx, tx); err != nil {
 		log.Fatal(err)
 	}
 	if err := tx.Commit(); err != nil {
@@ -491,15 +462,11 @@ func ExampleDBBuilder_WithExcelSheetPolicy() {
 
 	path := exampleWorkbook(dir)
 
-	validated, err := filesql.NewBuilder().
+	builder := filesql.NewBuilder().
 		AddPath(path).
-		WithExcelSheetPolicy(filesql.ExcelSheetPolicyVisibleOnly).
-		Build(context.Background())
-	if err != nil {
-		log.Fatal(err)
-	}
+		WithExcelSheetPolicy(filesql.ExcelSheetPolicyVisibleOnly)
 
-	db, err := validated.Open(context.Background())
+	db, err := builder.Open(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -638,21 +605,17 @@ func ExampleExcelSheetTableNames() {
 func ExampleDBBuilder_SkippedRows() {
 	csvData := "id,name\n1,Alice\n2\n3,Cora,extra\n4,Dave\n"
 
-	validated, err := filesql.NewBuilder().
+	builder := filesql.NewBuilder().
 		AddReader(strings.NewReader(csvData), "users", filesql.FileTypeCSV).
-		WithMalformedRowPolicy(filesql.MalformedRowSkip).
-		Build(context.Background())
-	if err != nil {
-		log.Fatal(err)
-	}
+		WithMalformedRowPolicy(filesql.MalformedRowSkip)
 
-	db, err := validated.Open(context.Background())
+	db, err := builder.Open(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
 
-	for _, skipped := range validated.SkippedRows() {
+	for _, skipped := range builder.SkippedRows() {
 		fmt.Printf("%s: %d of %d rows skipped\n", skipped.Table, skipped.Count, skipped.Total)
 	}
 	// Output:
@@ -783,13 +746,10 @@ func ExampleDumpACHWithTableSet() {
 	}
 
 	ctx := context.Background()
-	validated, err := filesql.NewBuilder().
-		AddReader(bytes.NewReader(body), "payment", filesql.FileTypeACH).
-		Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-	db, err := validated.Open(ctx)
+	builder := filesql.NewBuilder().
+		AddReader(bytes.NewReader(body), "payment", filesql.FileTypeACH)
+
+	db, err := builder.Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -841,13 +801,10 @@ func ExampleDumpFedWireWithTableSet() {
 	}
 
 	ctx := context.Background()
-	validated, err := filesql.NewBuilder().
-		AddReader(bytes.NewReader(body), "transfer", filesql.FileTypeFedWire).
-		Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-	db, err := validated.Open(ctx)
+	builder := filesql.NewBuilder().
+		AddReader(bytes.NewReader(body), "transfer", filesql.FileTypeFedWire)
+
+	db, err := builder.Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -1721,9 +1721,7 @@ func ExampleNewBuilder() {
 
 	// In real usage, you would continue with:
 	// ctx := context.Background()
-	// validatedBuilder, err := builder.Build(ctx)
-	// if err != nil { return err }
-	// db, err := validatedBuilder.Open(ctx)
+	// db, err := builder.Open(ctx)
 	// if err != nil { return err }
 	// defer db.Close()
 
@@ -1757,9 +1755,7 @@ func ExampleDBBuilder_EnableAutoSave() {
 		AddPath(csvPath).
 		EnableAutoSave(outputDir, filesql.NewDumpOptions()) // Save to backup directory on close
 
-	validatedBuilder, _ := builder.Build(ctx)
-
-	db, _ := validatedBuilder.Open(ctx)
+	db, _ := builder.Open(ctx)
 
 	// Modify data - this will be automatically saved when db.Close() is called
 	_, _ = db.ExecContext(ctx, "INSERT INTO employees (name, department, salary) VALUES ('Charlie', 'Sales', 70000)")
@@ -1800,9 +1796,7 @@ func ExampleDBBuilder_EnableAutoSaveOnCommit() {
 		AddPath(csvPath).
 		EnableAutoSaveOnCommit(tempDir, filesql.NewDumpOptions()) // Save to temp directory on each commit
 
-	validatedBuilder, _ := builder.Build(ctx)
-
-	db, _ := validatedBuilder.Open(ctx)
+	db, _ := builder.Open(ctx)
 	defer func() { _ = db.Close() }()
 
 	// Start transaction
@@ -1835,12 +1829,8 @@ func ExampleDBBuilder_AddPath() {
 
 	// Build and open database
 	ctx := context.Background()
-	validatedBuilder, err := builder.Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	db, err := validatedBuilder.Open(ctx)
+	db, err := builder.Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1884,12 +1874,8 @@ func ExampleDBBuilder_AddPaths() {
 	builder := filesql.NewBuilder().AddPaths(usersFile, productsFile)
 
 	ctx := context.Background()
-	validatedBuilder, err := builder.Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	db, err := validatedBuilder.Open(ctx)
+	db, err := builder.Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1932,12 +1918,8 @@ func ExampleDBBuilder_AddFS() {
 	builder := filesql.NewBuilder().AddFS(mockFS)
 
 	ctx := context.Background()
-	validatedBuilder, err := builder.Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	db, err := validatedBuilder.Open(ctx)
+	db, err := builder.Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1978,12 +1960,8 @@ func ExampleDBBuilder_AddFS_embedFS() {
 	builder := filesql.NewBuilder().AddFS(subFS)
 
 	ctx := context.Background()
-	validatedBuilder, err := builder.Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	db, err := validatedBuilder.Open(ctx)
+	db, err := builder.Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -2011,29 +1989,6 @@ func ExampleDBBuilder_AddFS_embedFS() {
 }
 
 //nolint:errcheck // Examples don't need full error handling
-func ExampleDBBuilder_Build() {
-	// Create temporary CSV file
-	tempDir, _ := os.MkdirTemp("", "filesql-example")
-	defer os.RemoveAll(tempDir)
-
-	csvFile := filepath.Join(tempDir, "data.csv")
-	content := "name,value\ntest,123\n"
-	os.WriteFile(csvFile, []byte(content), 0644)
-
-	// Build validates inputs and prepares for opening
-	builder := filesql.NewBuilder().AddPath(csvFile)
-
-	ctx := context.Background()
-	validatedBuilder, err := builder.Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Printf("Builder validated successfully: %t\n", validatedBuilder != nil)
-	// Output: Builder validated successfully: true
-}
-
-//nolint:errcheck // Examples don't need full error handling
 func ExampleDBBuilder_Open() {
 	// Create temporary CSV file
 	tempDir, _ := os.MkdirTemp("", "filesql-example")
@@ -2047,12 +2002,8 @@ func ExampleDBBuilder_Open() {
 	builder := filesql.NewBuilder().AddPath(csvFile)
 
 	ctx := context.Background()
-	validatedBuilder, err := builder.Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
 
-	db, err := validatedBuilder.Open(ctx)
+	db, err := builder.Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -2104,14 +2055,10 @@ func ExampleDBBuilder_chaining() {
 
 	// Demonstrate method chaining
 	ctx := context.Background()
-	db, err := filesql.NewBuilder().
+	db := filesql.NewBuilder().
 		AddPath(csvFile).
 		AddPaths(tsvFile).
-		AddFS(mockFS).
-		Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
+		AddFS(mockFS)
 
 	connection, err := db.Open(ctx)
 	if err != nil {
@@ -2142,25 +2089,24 @@ func ExampleDBBuilder_chaining() {
 
 //nolint:errcheck // Examples don't need full error handling
 func ExampleDBBuilder_errorHandling() {
-	// Example 1: Build without inputs should fail
-	builder := filesql.NewBuilder()
 	ctx := context.Background()
 
-	_, err := builder.Build(ctx)
+	// Example 1: a builder with no input at all
+	_, err := filesql.NewBuilder().Open(ctx)
 	if err != nil {
 		fmt.Printf("Expected error for no inputs: %v\n", err)
 	}
 
-	// Example 2: Open without Build should fail
-	builder2 := filesql.NewBuilder().AddPath("nonexistent.csv")
-	_, err = builder2.Open(ctx)
+	// Example 2: a file that does not exist
+	_, err = filesql.NewBuilder().AddPath("nonexistent.csv").Open(ctx)
 	if err != nil {
-		fmt.Println("Expected error for Open without Build")
+		fmt.Println("Expected error for a file that does not exist")
 	}
 
-	// Example 3: Non-existent file should fail during Build
-	builder3 := filesql.NewBuilder().AddPath(filepath.Join("nonexistent", "file.csv"))
-	_, err = builder3.Build(ctx)
+	// Example 3: a directory that does not exist
+	_, err = filesql.NewBuilder().
+		AddPath(filepath.Join("nonexistent", "file.csv")).
+		Open(ctx)
 	if err != nil {
 		fmt.Println("Expected error for non-existent file")
 	}
@@ -2172,13 +2118,7 @@ func ExampleDBBuilder_errorHandling() {
 	csvFile := filepath.Join(tempDir, "valid.csv")
 	os.WriteFile(csvFile, []byte("id,name\n1,test\n"), 0644)
 
-	builder4 := filesql.NewBuilder().AddPath(csvFile)
-	validatedBuilder, err := builder4.Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	db, err := validatedBuilder.Open(ctx)
+	db, err := filesql.NewBuilder().AddPath(csvFile).Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -2187,7 +2127,7 @@ func ExampleDBBuilder_errorHandling() {
 	fmt.Println("Success: Valid file loaded correctly")
 
 	// Output: Expected error for no inputs: filesql: no supported files found: at least one path must be provided
-	// Expected error for Open without Build
+	// Expected error for a file that does not exist
 	// Expected error for non-existent file
 	// Success: Valid file loaded correctly
 }
@@ -2211,13 +2151,9 @@ func ExampleDBBuilder_AddReader() {
 		SetDefaultChunkSize(5000)                            // Set 5000 rows per chunk for large data
 
 	// Build validates the input
-	validatedBuilder, err := builder.Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
 
 	// Open creates the database connection
-	db, err := validatedBuilder.Open(ctx)
+	db, err := builder.Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -2280,12 +2216,7 @@ func ExampleDBBuilder_AddReader_compressed() {
 	builder := filesql.NewBuilder().
 		AddReader(reader, "products", filesql.FileTypeTSV, filesql.WithCompression(filesql.CompressionGZ))
 
-	validatedBuilder, err := builder.Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	db, err := validatedBuilder.Open(ctx)
+	db, err := builder.Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -2322,12 +2253,7 @@ func ExampleDBBuilder_AddReader_multiple() {
 		AddReader(strings.NewReader(ordersCSV), "orders", filesql.FileTypeCSV).
 		SetDefaultChunkSize(2500) // 2500 rows per chunk
 
-	validatedBuilder, err := builder.Build(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	db, err := validatedBuilder.Open(ctx)
+	db, err := builder.Open(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/excel_sheet_test.go
+++ b/excel_sheet_test.go
@@ -342,10 +342,12 @@ func TestBuilderSheetPolicyFromReader(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			builder, err := NewBuilder().
-				AddReader(bytes.NewReader(data), "book", FileTypeXLSX).
-				WithExcelSheetPolicy(tt.policy).
-				Build(context.Background())
+			builder, err := buildForTest(
+
+				context.Background(), NewBuilder().
+					AddReader(bytes.NewReader(data), "book", FileTypeXLSX).
+					WithExcelSheetPolicy(tt.policy))
+
 			if err != nil {
 				t.Fatalf("Build: %v", err)
 			}
@@ -370,10 +372,12 @@ func TestBuilderSheetPolicyFromFS(t *testing.T) {
 		sheetSpec{"Shown", sheetVisible},
 	)
 
-	builder, err := NewBuilder().
-		AddFS(os.DirFS(dir)).
-		WithExcelSheetPolicy(ExcelSheetPolicyVisibleOnly).
-		Build(context.Background())
+	builder, err := buildForTest(
+
+		context.Background(), NewBuilder().
+			AddFS(os.DirFS(dir)).
+			WithExcelSheetPolicy(ExcelSheetPolicyVisibleOnly))
+
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -612,10 +616,12 @@ func openWithSheetPolicy(t *testing.T, policy ExcelSheetPolicy, paths ...string)
 
 func openWithSheetPolicyErr(policy ExcelSheetPolicy, paths ...string) (*sql.DB, error) {
 	ctx := context.Background()
-	builder, err := NewBuilder().
-		AddPaths(paths...).
-		WithExcelSheetPolicy(policy).
-		Build(ctx)
+	builder, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddPaths(paths...).
+			WithExcelSheetPolicy(policy))
+
 	if err != nil {
 		return nil, err
 	}
@@ -659,10 +665,12 @@ func TestLoadIntoAppliesSheetPolicy(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
-	builder, err := NewBuilder().
-		AddPath(path).
-		WithExcelSheetPolicy(ExcelSheetPolicyVisibleOnly).
-		Build(ctx)
+	builder, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddPath(path).
+			WithExcelSheetPolicy(ExcelSheetPolicyVisibleOnly))
+
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
@@ -702,9 +710,12 @@ func TestSaveKeepsTheSheetsThePolicyDidNotLoad(t *testing.T) {
 				sheetSpec{name: "Secret", visibility: hidden},
 			)
 
-			validated, err := NewBuilder().AddPath(path).
-				WithExcelSheetPolicy(ExcelSheetPolicyVisibleOnly).
-				EnableAutoSave("").Build(ctx)
+			validated, err := buildForTest(
+
+				ctx, NewBuilder().AddPath(path).
+					WithExcelSheetPolicy(ExcelSheetPolicyVisibleOnly).
+					EnableAutoSave(""))
+
 			require.NoError(t, err)
 			db, err := validated.Open(ctx)
 			require.NoError(t, err)
@@ -748,7 +759,7 @@ func TestSaveKeepsWhatItDidNotWrite(t *testing.T) {
 	require.NoError(t, book.SaveAs(path))
 	require.NoError(t, book.Close())
 
-	validated, err := NewBuilder().AddPath(path).EnableAutoSave("").Build(ctx)
+	validated, err := buildForTest(ctx, NewBuilder().AddPath(path).EnableAutoSave(""))
 	require.NoError(t, err)
 	db, err := validated.Open(ctx)
 	require.NoError(t, err)
@@ -843,7 +854,7 @@ func TestSaveAndAFormulaCell(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "calc.xlsx")
 			writeWorkbook(t, path)
 
-			validated, err := NewBuilder().AddPath(path).EnableAutoSave("").Build(ctx)
+			validated, err := buildForTest(ctx, NewBuilder().AddPath(path).EnableAutoSave(""))
 			require.NoError(t, err)
 			db, err := validated.Open(ctx)
 			require.NoError(t, err)
@@ -899,7 +910,7 @@ func TestSaveKeepsADateCellADate(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, before.Close())
 
-	validated, err := NewBuilder().AddPath(path).EnableAutoSave("").Build(ctx)
+	validated, err := buildForTest(ctx, NewBuilder().AddPath(path).EnableAutoSave(""))
 	require.NoError(t, err)
 	db, err := validated.Open(ctx)
 	require.NoError(t, err)
@@ -941,7 +952,7 @@ func TestSaveShrinksASheetTheTableNoLongerFills(t *testing.T) {
 	require.NoError(t, book.SaveAs(path))
 	require.NoError(t, book.Close())
 
-	validated, err := NewBuilder().AddPath(path).EnableAutoSave("").Build(ctx)
+	validated, err := buildForTest(ctx, NewBuilder().AddPath(path).EnableAutoSave(""))
 	require.NoError(t, err)
 	db, err := validated.Open(ctx)
 	require.NoError(t, err)
@@ -1436,9 +1447,11 @@ func TestXLSXDateCellsImportAsISOThroughAddReader(t *testing.T) {
 	var book bytes.Buffer
 	require.NoError(t, f.Write(&book))
 
-	db, err := NewBuilder().
-		AddReader(bytes.NewReader(book.Bytes()), "book", FileTypeXLSX).
-		Build(ctx)
+	db, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddReader(bytes.NewReader(book.Bytes()), "book", FileTypeXLSX))
+
 	require.NoError(t, err)
 	sqlDB, err := db.Open(ctx)
 	require.NoError(t, err)
@@ -1928,8 +1941,10 @@ func TestEverySheetIsLoadedByEveryRoute(t *testing.T) {
 	t.Run("a reader", func(t *testing.T) {
 		t.Parallel()
 
-		validated, err := NewBuilder().
-			AddReader(bytes.NewReader(data), "book", FileTypeXLSX).Build(ctx)
+		validated, err := buildForTest(
+			ctx, NewBuilder().
+				AddReader(bytes.NewReader(data), "book", FileTypeXLSX))
+
 		require.NoError(t, err)
 		db, err := validated.Open(ctx)
 		require.NoError(t, err)
@@ -1940,8 +1955,10 @@ func TestEverySheetIsLoadedByEveryRoute(t *testing.T) {
 	t.Run("an embedded filesystem", func(t *testing.T) {
 		t.Parallel()
 
-		validated, err := NewBuilder().
-			AddFS(fstest.MapFS{"book.xlsx": &fstest.MapFile{Data: data}}).Build(ctx)
+		validated, err := buildForTest(
+			ctx, NewBuilder().
+				AddFS(fstest.MapFS{"book.xlsx": &fstest.MapFile{Data: data}}))
+
 		require.NoError(t, err)
 		db, err := validated.Open(ctx)
 		require.NoError(t, err)
@@ -1960,9 +1977,11 @@ func TestEverySheetIsLoadedByEveryRoute(t *testing.T) {
 
 		// A reader carries no path, so the codec is named through the option
 		// rather than guessed from bytes.
-		compressed, err := NewBuilder().
-			AddReader(bytes.NewReader(squeezed.Bytes()), "book", FileTypeXLSX, WithCompression(CompressionGZ)).
-			Build(ctx)
+		compressed, err := buildForTest(
+
+			ctx, NewBuilder().
+				AddReader(bytes.NewReader(squeezed.Bytes()), "book", FileTypeXLSX, WithCompression(CompressionGZ)))
+
 		require.NoError(t, err)
 		db, err := compressed.Open(ctx)
 		require.NoError(t, err)
@@ -1974,8 +1993,10 @@ func TestEverySheetIsLoadedByEveryRoute(t *testing.T) {
 		t.Parallel()
 
 		colliding := multiSheetWorkbook(t, "Q1 sales", "Q1.sales")
-		validated, err := NewBuilder().
-			AddReader(bytes.NewReader(colliding), "book", FileTypeXLSX).Build(ctx)
+		validated, err := buildForTest(
+			ctx, NewBuilder().
+				AddReader(bytes.NewReader(colliding), "book", FileTypeXLSX))
+
 		require.NoError(t, err)
 		_, err = validated.Open(ctx)
 		require.Error(t, err)

--- a/file_processor_test.go
+++ b/file_processor_test.go
@@ -548,7 +548,7 @@ func TestLoadIntoTxKeepsInputOrder(t *testing.T) {
 			db := newMemoryDB(t)
 			ctx := context.Background()
 
-			builder, err := NewBuilder().AddPaths(tt.paths...).Build(ctx)
+			builder, err := buildForTest(ctx, NewBuilder().AddPaths(tt.paths...))
 			if err != nil {
 				t.Fatalf("Build: %v", err)
 			}
@@ -707,10 +707,12 @@ func TestBuilderRefusesTwoReadersWhoseNamesDifferOnlyInCase(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 
-	validated, err := NewBuilder().
-		AddReader(strings.NewReader("a,b\n1,2\n"), "Users", FileTypeCSV).
-		AddReader(strings.NewReader("c,d\n3,4\n"), "users", FileTypeCSV).
-		Build(ctx)
+	validated, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddReader(strings.NewReader("a,b\n1,2\n"), "Users", FileTypeCSV).
+			AddReader(strings.NewReader("c,d\n3,4\n"), "users", FileTypeCSV))
+
 	if err != nil {
 		if !errors.Is(err, ErrDuplicateTable) {
 			t.Errorf("Build error = %v, want ErrDuplicateTable", err)

--- a/filesql_integration_test.go
+++ b/filesql_integration_test.go
@@ -1189,7 +1189,7 @@ func TestEveryRouteBuildsTheSameTable(t *testing.T) {
 			require.NoError(t, err)
 			// ":memory:" is private per connection, so the pool has to be one.
 			db.SetMaxOpenConns(1)
-			builder, err := NewBuilder().AddPath(src).Build(ctx)
+			builder, err := buildForTest(ctx, NewBuilder().AddPath(src))
 			require.NoError(t, err)
 			require.NoError(t, builder.LoadInto(ctx, db))
 			return db, func() { _ = db.Close() }
@@ -1202,7 +1202,7 @@ func TestEveryRouteBuildsTheSameTable(t *testing.T) {
 func openBuilt(ctx context.Context, t *testing.T, b *DBBuilder) *sql.DB {
 	t.Helper()
 
-	built, err := b.Build(ctx)
+	built, err := buildForTest(ctx, b)
 	require.NoError(t, err)
 	db, err := built.Open(ctx)
 	require.NoError(t, err)

--- a/filesql_test.go
+++ b/filesql_test.go
@@ -331,7 +331,7 @@ id:3	product:Keyboard	price:75`
 			AddReader(strings.NewReader(tsvData), "departments", FileTypeTSV).
 			AddReader(strings.NewReader(ltsvData), "products", FileTypeLTSV)
 
-		validatedBuilder, err := builder.Build(context.Background())
+		validatedBuilder, err := buildForTest(context.Background(), builder)
 		require.NoError(t, err, "Build failed")
 
 		db, err := validatedBuilder.Open(context.Background())
@@ -382,7 +382,7 @@ id:3	product:Keyboard	price:75`
 		testFS := os.DirFS(filepath.Join("testdata", "embed_test"))
 
 		builder := NewBuilder().AddFS(testFS)
-		validatedBuilder, err := builder.Build(context.Background())
+		validatedBuilder, err := buildForTest(context.Background(), builder)
 		require.NoError(t, err, "Build with FS failed")
 
 		db, err := validatedBuilder.Open(context.Background())
@@ -445,7 +445,7 @@ id:3	product:Keyboard	price:75`
 			AddPath(filepath.Join("testdata", "benchmark", "customers100000.csv")).
 			SetDefaultChunkSize(500) // 500 rows per chunk for testing
 
-		validatedBuilder, err := builder.Build(context.Background())
+		validatedBuilder, err := buildForTest(context.Background(), builder)
 		require.NoError(t, err, "Build with large file failed")
 
 		db, err := validatedBuilder.Open(context.Background())
@@ -523,7 +523,7 @@ id:3	product:Keyboard	price:75`
 		}
 
 		builder := NewBuilder().AddPaths(compressedFiles...)
-		validatedBuilder, err := builder.Build(context.Background())
+		validatedBuilder, err := buildForTest(context.Background(), builder)
 		require.NoError(t, err, "Build with compressed files failed")
 
 		db, err := validatedBuilder.Open(context.Background())
@@ -595,7 +595,7 @@ id:3	product:Keyboard	price:75`
 			AddPath(filepath.Join("testdata", "users.csv")).
 			EnableAutoSave(tempDir, NewDumpOptions().WithFormat(OutputFormatCSV))
 
-		validatedBuilder, err := builder.Build(context.Background())
+		validatedBuilder, err := buildForTest(context.Background(), builder)
 		require.NoError(t, err, "Build with auto-save failed")
 
 		db, err := validatedBuilder.Open(context.Background())
@@ -655,7 +655,7 @@ id:3	product:Keyboard	price:75`
 			AddFS(testFS).                                                       // embed.FS
 			AddPath(filepath.Join("testdata", "sample2.csv"))                    // Different file to avoid table name conflict
 
-		validatedBuilder, err := builder.Build(context.Background())
+		validatedBuilder, err := buildForTest(context.Background(), builder)
 		require.NoError(t, err, "Build with mixed sources failed")
 
 		db, err := validatedBuilder.Open(context.Background())
@@ -3670,7 +3670,7 @@ func TestEdgeCasesReaderInput(t *testing.T) {
 			builder := NewBuilder().AddReader(reader, "test_table", tt.fileType)
 
 			ctx := context.Background()
-			validatedBuilder, err := builder.Build(ctx)
+			validatedBuilder, err := buildForTest(ctx, builder)
 
 			if tt.expectedErr {
 				if err == nil {
@@ -4223,9 +4223,11 @@ func TestTableNameHoldingAQuotingCharacter(t *testing.T) {
 			t.Parallel()
 
 			ctx := t.Context()
-			validated, err := NewBuilder().
-				AddReader(strings.NewReader("v\n1\n2\n"), tt.table, FileTypeCSV).
-				Build(ctx)
+			validated, err := buildForTest(
+
+				ctx, NewBuilder().
+					AddReader(strings.NewReader("v\n1\n2\n"), tt.table, FileTypeCSV))
+
 			require.NoError(t, err)
 			db, err := validated.Open(ctx)
 			require.NoError(t, err, "a name SQLite accepts must load")

--- a/load_into_test.go
+++ b/load_into_test.go
@@ -78,7 +78,7 @@ func TestDBBuilder_LoadIntoTxUsesCallerTransaction(t *testing.T) {
 	tx, err := db.BeginTx(context.Background(), nil)
 	require.NoError(t, err)
 
-	builder, err := NewBuilder().AddPath(path).Build(context.Background())
+	builder, err := buildForTest(context.Background(), NewBuilder().AddPath(path))
 	require.NoError(t, err)
 	require.NoError(t, builder.LoadIntoTx(context.Background(), tx))
 
@@ -93,7 +93,7 @@ func TestDBBuilder_LoadIntoTxUsesCallerTransaction(t *testing.T) {
 
 func TestDBBuilder_LoadIntoTxACHIsDumpableOnlyAfterCommit(t *testing.T) {
 	db := newCallerDB(t)
-	builder, err := NewBuilder().AddPath(filepath.Join("testdata", "ppd-debit.ach")).Build(context.Background())
+	builder, err := buildForTest(context.Background(), NewBuilder().AddPath(filepath.Join("testdata", "ppd-debit.ach")))
 	require.NoError(t, err)
 	tx, err := db.BeginTx(context.Background(), nil)
 	require.NoError(t, err)
@@ -109,10 +109,12 @@ func TestDBBuilder_LoadIntoTxDiscardsACHMetadataOnFailure(t *testing.T) {
 	dir := t.TempDir()
 	bad := writeTempCSV(t, dir, "broken.json", "[")
 	db := newCallerDB(t)
-	builder, err := NewBuilder().
-		AddPath(filepath.Join("testdata", "ppd-debit.ach")).
-		AddPath(bad).
-		Build(context.Background())
+	builder, err := buildForTest(
+
+		context.Background(), NewBuilder().
+			AddPath(filepath.Join("testdata", "ppd-debit.ach")).
+			AddPath(bad))
+
 	require.NoError(t, err)
 	tx, err := db.BeginTx(context.Background(), nil)
 	require.NoError(t, err)
@@ -125,10 +127,12 @@ func TestDBBuilder_LoadIntoTxDiscardsFedwireMetadataOnFailure(t *testing.T) {
 	dir := t.TempDir()
 	bad := writeTempCSV(t, dir, "broken.json", "[")
 	db := newCallerDB(t)
-	builder, err := NewBuilder().
-		AddPath(filepath.Join("testdata", "customer-transfer.fed")).
-		AddPath(bad).
-		Build(context.Background())
+	builder, err := buildForTest(
+
+		context.Background(), NewBuilder().
+			AddPath(filepath.Join("testdata", "customer-transfer.fed")).
+			AddPath(bad))
+
 	require.NoError(t, err)
 	tx, err := db.BeginTx(context.Background(), nil)
 	require.NoError(t, err)
@@ -287,9 +291,11 @@ func TestLoadInto_PreservesTypeInference(t *testing.T) {
 
 func TestLoadInto_BuilderReaders(t *testing.T) {
 	db := newCallerDB(t)
-	builder, err := NewBuilder().
-		AddReader(strings.NewReader("id,v\n1,x\n2,y\n"), "from_reader", FileTypeCSV).
-		Build(context.Background())
+	builder, err := buildForTest(
+
+		context.Background(), NewBuilder().
+			AddReader(strings.NewReader("id,v\n1,x\n2,y\n"), "from_reader", FileTypeCSV))
+
 	require.NoError(t, err)
 	require.NoError(t, builder.LoadInto(context.Background(), db))
 
@@ -328,10 +334,12 @@ func TestLoadInto_Errors(t *testing.T) {
 
 	t.Run("auto-save configured is rejected", func(t *testing.T) {
 		db := newCallerDB(t)
-		builder, err := NewBuilder().
-			AddPath(filepath.Join("testdata", "sample.csv")).
-			EnableAutoSave(t.TempDir()).
-			Build(context.Background())
+		builder, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddPath(filepath.Join("testdata", "sample.csv")).
+				EnableAutoSave(t.TempDir()))
+
 		require.NoError(t, err)
 		err = builder.LoadInto(context.Background(), db)
 		require.Error(t, err)
@@ -340,9 +348,11 @@ func TestLoadInto_Errors(t *testing.T) {
 
 func TestLoadInto_DoesNotLeakReplaceModeToBuilder(t *testing.T) {
 	db := newCallerDB(t)
-	builder, err := NewBuilder().
-		AddPath(filepath.Join("testdata", "sample.csv")).
-		Build(context.Background())
+	builder, err := buildForTest(
+
+		context.Background(), NewBuilder().
+			AddPath(filepath.Join("testdata", "sample.csv")))
+
 	require.NoError(t, err)
 	require.NoError(t, builder.LoadInto(context.Background(), db))
 
@@ -495,7 +505,7 @@ func TestLoadInto_FailedXLSXLeavesTheDatabaseAsItWas(t *testing.T) {
 	t.Run("no prior table", func(t *testing.T) {
 		t.Parallel()
 		db := newCallerDB(t)
-		builder, err := NewBuilder().AddPath(path).Build(context.Background())
+		builder, err := buildForTest(context.Background(), NewBuilder().AddPath(path))
 		require.NoError(t, err)
 		require.Error(t, builder.LoadInto(context.Background(), db))
 		assert.Empty(t, listTables(t, db), "a workbook that failed partway left a sheet's table behind")
@@ -508,7 +518,7 @@ func TestLoadInto_FailedXLSXLeavesTheDatabaseAsItWas(t *testing.T) {
 		require.NoError(t, err)
 		_, err = db.ExecContext(context.Background(), `INSERT INTO book_good VALUES ('precious')`)
 		require.NoError(t, err)
-		builder, err := NewBuilder().AddPath(path).Build(context.Background())
+		builder, err := buildForTest(context.Background(), NewBuilder().AddPath(path))
 		require.NoError(t, err)
 		require.Error(t, builder.LoadInto(context.Background(), db))
 		var kept string
@@ -524,7 +534,7 @@ func TestLoadInto_FailedXLSXLeavesTheDatabaseAsItWas(t *testing.T) {
 		require.NoError(t, err)
 		_, err = db.ExecContext(context.Background(), `INSERT INTO book_good VALUES ('precious')`)
 		require.NoError(t, err)
-		builder, err := NewBuilder().AddPath(path).Build(context.Background())
+		builder, err := buildForTest(context.Background(), NewBuilder().AddPath(path))
 		require.NoError(t, err)
 		tx, err := db.BeginTx(context.Background(), nil)
 		require.NoError(t, err)
@@ -578,7 +588,7 @@ func TestLoadIntoTx_FailedInputLeavesCallersTable(t *testing.T) {
 			} else {
 				builder = builder.AddPath(writeTempCSV(t, t.TempDir(), "tbl.csv", content))
 			}
-			built, err := builder.Build(context.Background())
+			built, err := buildForTest(context.Background(), builder)
 			require.NoError(t, err)
 
 			tx, err := db.BeginTx(context.Background(), nil)
@@ -621,7 +631,7 @@ func TestLoadIntoTx_CanceledLoadLeavesCallersTable(t *testing.T) {
 	_, err = db.ExecContext(context.Background(), `INSERT INTO tbl VALUES ('keep-me')`)
 	require.NoError(t, err)
 
-	builder, err := NewBuilder().AddPath(path).SetDefaultChunkSize(100).Build(context.Background())
+	builder, err := buildForTest(context.Background(), NewBuilder().AddPath(path).SetDefaultChunkSize(100))
 	require.NoError(t, err)
 
 	tx, err := db.BeginTx(context.Background(), nil)
@@ -661,7 +671,7 @@ func TestLoadIntoTx_CanceledContextTheTransactionWasBuiltOn(t *testing.T) {
 	path := writeTempCSV(t, t.TempDir(), "tbl.csv", body.String())
 
 	db := newCallerDB(t)
-	builder, err := NewBuilder().AddPath(path).SetDefaultChunkSize(100).Build(context.Background())
+	builder, err := buildForTest(context.Background(), NewBuilder().AddPath(path).SetDefaultChunkSize(100))
 	require.NoError(t, err)
 
 	// The context is cancelled after the transaction has begun rather than by a

--- a/logger_test.go
+++ b/logger_test.go
@@ -72,10 +72,12 @@ func TestDBBuilderWithLogger(t *testing.T) {
 		require.NoError(t, os.WriteFile(csvFile, []byte("a,b\n1,2\n3,4"), 0o600))
 
 		ctx := context.Background()
-		validated, err := NewBuilder().
-			WithLogger(debugLogger(buf)).
-			AddPath(csvFile).
-			Build(ctx)
+		validated, err := buildForTest(
+
+			ctx, NewBuilder().
+				WithLogger(debugLogger(buf)).
+				AddPath(csvFile))
+
 		require.NoError(t, err)
 
 		db, err := validated.Open(ctx)
@@ -94,10 +96,12 @@ func TestDBBuilderWithLogger(t *testing.T) {
 
 		buf := &bytes.Buffer{}
 		ctx := context.Background()
-		validated, err := NewBuilder().
-			WithLogger(debugLogger(buf)).
-			AddReader(strings.NewReader("a,b\n1,2"), "test_table", FileTypeCSV).
-			Build(ctx)
+		validated, err := buildForTest(
+
+			ctx, NewBuilder().
+				WithLogger(debugLogger(buf)).
+				AddReader(strings.NewReader("a,b\n1,2"), "test_table", FileTypeCSV))
+
 		require.NoError(t, err)
 
 		db, err := validated.Open(ctx)
@@ -119,10 +123,12 @@ func TestDBBuilderWithLogger(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
 		ctx := context.Background()
-		validated, err := NewBuilder().
-			WithLogger(logger).
-			AddReader(strings.NewReader("a,b\n1,2"), "quiet", FileTypeCSV).
-			Build(ctx)
+		validated, err := buildForTest(
+
+			ctx, NewBuilder().
+				WithLogger(logger).
+				AddReader(strings.NewReader("a,b\n1,2"), "quiet", FileTypeCSV))
+
 		require.NoError(t, err)
 
 		db, err := validated.Open(ctx)

--- a/ltsv_test.go
+++ b/ltsv_test.go
@@ -102,7 +102,7 @@ func TestLTSVColumnOrderSurvivesChunking(t *testing.T) {
 		src := filepath.Join(t.TempDir(), "logs.ltsv")
 		require.NoError(t, os.WriteFile(src, []byte(content), 0o600))
 
-		validated, err := NewBuilder().AddPath(src).SetDefaultChunkSize(10).Build(ctx)
+		validated, err := buildForTest(ctx, NewBuilder().AddPath(src).SetDefaultChunkSize(10))
 		require.NoError(t, err)
 		db, err := validated.Open(ctx)
 		require.NoError(t, err)
@@ -527,7 +527,7 @@ func loadLTSVWithPolicy(t *testing.T, content string, policy MalformedRowPolicy)
 	}
 
 	ctx := context.Background()
-	builder, err := NewBuilder().AddPath(path).WithMalformedRowPolicy(policy).Build(ctx)
+	builder, err := buildForTest(ctx, NewBuilder().AddPath(path).WithMalformedRowPolicy(policy))
 	if err != nil {
 		return 0, 0, err
 	}

--- a/malformed_row_test.go
+++ b/malformed_row_test.go
@@ -39,10 +39,12 @@ func queryColumn(t *testing.T, db *sql.DB, query string) []string {
 
 func openWithPolicy(t *testing.T, content string, ft FileType, policy MalformedRowPolicy) (*sql.DB, error) {
 	t.Helper()
-	b, err := NewBuilder().
-		AddReader(strings.NewReader(content), "t", ft).
-		WithMalformedRowPolicy(policy).
-		Build(context.Background())
+	b, err := buildForTest(
+
+		context.Background(), NewBuilder().
+			AddReader(strings.NewReader(content), "t", ft).
+			WithMalformedRowPolicy(policy))
+
 	if err != nil {
 		return nil, err
 	}
@@ -60,10 +62,12 @@ func TestSkippedRowsReportsWhatWasDropped(t *testing.T) {
 	t.Run("a skipping import counts the rows it dropped", func(t *testing.T) {
 		t.Parallel()
 
-		b, err := NewBuilder().
-			AddReader(strings.NewReader("a,b\n1,2\n3\n5,6\n7\n"), "t", FileTypeCSV).
-			WithMalformedRowPolicy(MalformedRowSkip).
-			Build(context.Background())
+		b, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddReader(strings.NewReader("a,b\n1,2\n3\n5,6\n7\n"), "t", FileTypeCSV).
+				WithMalformedRowPolicy(MalformedRowSkip))
+
 		if err != nil {
 			t.Fatalf("build failed: %v", err)
 		}
@@ -91,10 +95,12 @@ func TestSkippedRowsReportsWhatWasDropped(t *testing.T) {
 	t.Run("an import that dropped nothing reports nothing", func(t *testing.T) {
 		t.Parallel()
 
-		b, err := NewBuilder().
-			AddReader(strings.NewReader("a,b\n1,2\n3,4\n"), "t", FileTypeCSV).
-			WithMalformedRowPolicy(MalformedRowSkip).
-			Build(context.Background())
+		b, err := buildForTest(
+
+			context.Background(), NewBuilder().
+				AddReader(strings.NewReader("a,b\n1,2\n3,4\n"), "t", FileTypeCSV).
+				WithMalformedRowPolicy(MalformedRowSkip))
+
 		if err != nil {
 			t.Fatalf("build failed: %v", err)
 		}
@@ -146,7 +152,7 @@ func TestMalformedRowPolicy_Stop(t *testing.T) {
 		t.Parallel()
 		const csv = "id,name,zip\n1,alice,01234\n3,caro\n"
 		// No WithMalformedRowPolicy call: the zero value must behave as stop.
-		b, err := NewBuilder().AddReader(strings.NewReader(csv), "t", FileTypeCSV).Build(context.Background())
+		b, err := buildForTest(context.Background(), NewBuilder().AddReader(strings.NewReader(csv), "t", FileTypeCSV))
 		if err != nil {
 			t.Fatalf("build failed: %v", err)
 		}
@@ -301,7 +307,7 @@ func TestXLSXIgnoresTheMalformedRowPolicy(t *testing.T) {
 		t.Run(policy.String(), func(t *testing.T) {
 			t.Parallel()
 
-			built, err := NewBuilder().AddPath(path).WithMalformedRowPolicy(policy).Build(ctx)
+			built, err := buildForTest(ctx, NewBuilder().AddPath(path).WithMalformedRowPolicy(policy))
 			require.NoError(t, err)
 			db, err := built.Open(ctx)
 			if db != nil {
@@ -321,9 +327,12 @@ func TestMalformedRowFillRefusesALongRecord(t *testing.T) {
 
 	ctx := context.Background()
 
-	built, err := NewBuilder().
-		AddReader(strings.NewReader("a,b,c\n1,2\n"), "short", FileTypeCSV).
-		WithMalformedRowPolicy(MalformedRowFill).Build(ctx)
+	built, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddReader(strings.NewReader("a,b,c\n1,2\n"), "short", FileTypeCSV).
+			WithMalformedRowPolicy(MalformedRowFill))
+
 	require.NoError(t, err)
 	db, err := built.Open(ctx)
 	require.NoError(t, err, "a short record is padded")
@@ -332,9 +341,12 @@ func TestMalformedRowFillRefusesALongRecord(t *testing.T) {
 	assert.Equal(t, "", c, "the missing cell is the empty string")
 	require.NoError(t, db.Close())
 
-	built, err = NewBuilder().
-		AddReader(strings.NewReader("a\n1,2\n"), "long", FileTypeCSV).
-		WithMalformedRowPolicy(MalformedRowFill).Build(ctx)
+	built, err = buildForTest(
+
+		ctx, NewBuilder().
+			AddReader(strings.NewReader("a\n1,2\n"), "long", FileTypeCSV).
+			WithMalformedRowPolicy(MalformedRowFill))
+
 	require.NoError(t, err)
 	db, err = built.Open(ctx)
 	if db != nil {

--- a/parquet_test.go
+++ b/parquet_test.go
@@ -708,8 +708,10 @@ func TestDamagedParquetIsAnErrorNotAPanic(t *testing.T) {
 		t.Parallel()
 
 		require.NotPanics(t, func() {
-			built, err := NewBuilder().
-				AddReader(bytes.NewReader(data), "t", FileTypeParquet).Build(ctx)
+			built, err := buildForTest(
+				ctx, NewBuilder().
+					AddReader(bytes.NewReader(data), "t", FileTypeParquet))
+
 			if err != nil {
 				return
 			}

--- a/readme_examples_test.go
+++ b/readme_examples_test.go
@@ -52,14 +52,9 @@ Bob,bob@example.com,user
 	}
 
 	ctx := context.Background()
-	validatedBuilder, err := filesql.NewBuilder().
+	db, err := filesql.NewBuilder().
 		AddReader(strings.NewReader(string(cleaned)), "users", filesql.FileTypeCSV).
-		Build(ctx)
-	if err != nil {
-		t.Fatalf("Build() error = %v", err)
-	}
-
-	db, err := validatedBuilder.Open(ctx)
+		Open(ctx)
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}

--- a/readonly_test.go
+++ b/readonly_test.go
@@ -16,9 +16,11 @@ import (
 func openReadOnlyUsers(t *testing.T) *sql.DB {
 	t.Helper()
 
-	validated, err := NewBuilder().
-		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", FileTypeCSV).
-		Build(context.Background())
+	validated, err := buildForTest(
+
+		context.Background(), NewBuilder().
+			AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", FileTypeCSV))
+
 	require.NoError(t, err)
 
 	db, err := validated.OpenReadOnly(context.Background())
@@ -166,9 +168,11 @@ func TestOpenReadOnly_LeavesOpenWritable(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	validated, err := NewBuilder().
-		AddReader(strings.NewReader("id,name\n1,Alice\n"), "users", FileTypeCSV).
-		Build(ctx)
+	validated, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddReader(strings.NewReader("id,name\n1,Alice\n"), "users", FileTypeCSV))
+
 	require.NoError(t, err)
 
 	db, err := validated.Open(ctx)
@@ -192,9 +196,11 @@ func TestOpenReadOnly_ClosingOrder(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	validated, err := NewBuilder().
-		AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", FileTypeCSV).
-		Build(ctx)
+	validated, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddReader(strings.NewReader("id,name\n1,Alice\n2,Bob\n"), "users", FileTypeCSV))
+
 	require.NoError(t, err)
 
 	db, err := validated.OpenReadOnly(ctx)
@@ -216,10 +222,12 @@ func TestOpenReadOnly_WithAutoSave(t *testing.T) {
 	ctx := context.Background()
 	outDir := t.TempDir()
 
-	validated, err := NewBuilder().
-		AddPath("testdata/sample.csv").
-		EnableAutoSave(outDir).
-		Build(ctx)
+	validated, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddPath("testdata/sample.csv").
+			EnableAutoSave(outDir))
+
 	require.NoError(t, err)
 
 	db, err := validated.OpenReadOnly(ctx)

--- a/save_encoding_test.go
+++ b/save_encoding_test.go
@@ -417,7 +417,7 @@ func TestAutoSaveExportIgnoresSourceEncoding(t *testing.T) {
 	require.NoError(t, os.WriteFile(source, utf16Bytes(t, "id,v\n1,a\n", unicode.LittleEndian), 0o600))
 
 	outputDir := t.TempDir()
-	validated, err := NewBuilder().AddPath(source).EnableAutoSave(outputDir).Build(t.Context())
+	validated, err := buildForTest(t.Context(), NewBuilder().AddPath(source).EnableAutoSave(outputDir))
 	require.NoError(t, err)
 	db, err := validated.Open(t.Context())
 	require.NoError(t, err)

--- a/save_test.go
+++ b/save_test.go
@@ -512,7 +512,7 @@ func TestAutoSaveConnection_Begin(t *testing.T) {
 
 	// Use Builder to create a database with auto-save config
 	builder := NewBuilder().AddPath(filepath.Join("testdata", "test.csv"))
-	validatedBuilder, err := builder.Build(ctx)
+	validatedBuilder, err := buildForTest(ctx, builder)
 	require.NoError(t, err)
 
 	db, err := validatedBuilder.Open(ctx)
@@ -914,7 +914,7 @@ func TestDumpDatabase_RefusesACodecItCannotWrite(t *testing.T) {
 	src := filepath.Join(dir, "users.csv")
 	require.NoError(t, os.WriteFile(src, []byte("id,name\n1,alice\n"), 0o600))
 
-	validated, err := NewBuilder().AddPath(src).Build(t.Context())
+	validated, err := buildForTest(t.Context(), NewBuilder().AddPath(src))
 	require.NoError(t, err)
 	db, err := validated.Open(t.Context())
 	require.NoError(t, err)

--- a/source_registry_test.go
+++ b/source_registry_test.go
@@ -75,9 +75,11 @@ func TestReservedTableNameIsRefused(t *testing.T) {
 	assert.Contains(t, err.Error(), "_filesql_")
 
 	// A reader names its own table, so it can reach the namespace too.
-	builder, err := NewBuilder().
-		AddReader(strings.NewReader("id\n1\n"), "_filesql_sources", FileTypeCSV).
-		Build(ctx)
+	builder, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddReader(strings.NewReader("id\n1\n"), "_filesql_sources", FileTypeCSV))
+
 	require.NoError(t, err)
 	_, err = builder.Open(ctx)
 	require.Error(t, err)
@@ -129,9 +131,11 @@ func TestSQLitePrefixIsRefusedTheSameWay(t *testing.T) {
 	}
 
 	// A reader names its own table, so it can reach that namespace too.
-	builder, err := NewBuilder().
-		AddReader(strings.NewReader("id\n1\n"), "sqlite_x", FileTypeCSV).
-		Build(ctx)
+	builder, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddReader(strings.NewReader("id\n1\n"), "sqlite_x", FileTypeCSV))
+
 	require.NoError(t, err)
 	db, err := builder.Open(ctx)
 	if db != nil {
@@ -164,7 +168,7 @@ func TestSourceMetadataRolledBackWithTransaction(t *testing.T) {
 	defer db.Close()
 	db.SetMaxOpenConns(1)
 
-	builder, err := NewBuilder().AddPath(copyACHFixture(t, "ppd-debit.ach")).Build(ctx)
+	builder, err := buildForTest(ctx, NewBuilder().AddPath(copyACHFixture(t, "ppd-debit.ach")))
 	require.NoError(t, err)
 
 	tx, err := db.BeginTx(ctx, nil)
@@ -189,7 +193,7 @@ func TestSourceMetadataSurvivesCommit(t *testing.T) {
 	defer db.Close()
 	db.SetMaxOpenConns(1)
 
-	builder, err := NewBuilder().AddPath(copyACHFixture(t, "ppd-debit.ach")).Build(ctx)
+	builder, err := buildForTest(ctx, NewBuilder().AddPath(copyACHFixture(t, "ppd-debit.ach")))
 	require.NoError(t, err)
 
 	tx, err := db.BeginTx(ctx, nil)
@@ -209,10 +213,12 @@ func TestAutoSaveWritesACHFromSourceMetadata(t *testing.T) {
 	ctx := context.Background()
 
 	outputDir := t.TempDir()
-	builder, err := NewBuilder().
-		AddPath(copyACHFixture(t, "ppd-debit.ach")).
-		EnableAutoSave(outputDir, NewDumpOptions().WithFormat(OutputFormatACH)).
-		Build(ctx)
+	builder, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddPath(copyACHFixture(t, "ppd-debit.ach")).
+			EnableAutoSave(outputDir, NewDumpOptions().WithFormat(OutputFormatACH)))
+
 	require.NoError(t, err)
 
 	db, err := builder.Open(ctx)
@@ -236,9 +242,11 @@ func TestReaderLoadedACHCannotBeDumped(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join("testdata", "ppd-debit.ach"))
 	require.NoError(t, err)
 
-	builder, err := NewBuilder().
-		AddReader(strings.NewReader(string(content)), "payment", FileTypeACH).
-		Build(ctx)
+	builder, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddReader(strings.NewReader(string(content)), "payment", FileTypeACH))
+
 	require.NoError(t, err)
 
 	db, err := builder.Open(ctx)

--- a/stream_processor_test.go
+++ b/stream_processor_test.go
@@ -460,7 +460,7 @@ func TestAddFS_ReadsAFileAgainWhenAColumnWidens(t *testing.T) {
 
 	ctx := context.Background()
 	mockFS := fstest.MapFS{"t.csv": &fstest.MapFile{Data: []byte("v\n1\n2.50\nabc\n")}}
-	built, err := NewBuilder().AddFS(mockFS).SetDefaultChunkSize(1).Build(ctx)
+	built, err := buildForTest(ctx, NewBuilder().AddFS(mockFS).SetDefaultChunkSize(1))
 	require.NoError(t, err)
 	db, err := built.Open(ctx)
 	require.NoError(t, err)

--- a/stream_test.go
+++ b/stream_test.go
@@ -1800,7 +1800,7 @@ func TestChunkSizeDoesNotChangeTheColumnType(t *testing.T) {
 				if chunkSize > 0 {
 					builder = builder.SetDefaultChunkSize(chunkSize)
 				}
-				built, err := builder.Build(context.Background())
+				built, err := buildForTest(context.Background(), builder)
 				if err != nil {
 					t.Fatalf("chunk size %d: build: %v", chunkSize, err)
 				}
@@ -1867,7 +1867,7 @@ func TestChunkSizeDoesNotChangeStoredValues(t *testing.T) {
 			t.Parallel()
 			for _, chunk := range []int{1, 2, 3, 4, 5, defaultChunkSizeRows} {
 				b := NewBuilder().AddReader(strings.NewReader(tt.body), "t", FileTypeCSV).SetDefaultChunkSize(chunk)
-				built, err := b.Build(context.Background())
+				built, err := buildForTest(context.Background(), b)
 				require.NoError(t, err)
 				db, err := built.Open(context.Background())
 				require.NoError(t, err)
@@ -1901,7 +1901,7 @@ func TestChunkSizeDoesNotChangeStoredValues_File(t *testing.T) {
 	want := []string{"1/text", "2.50/text", "abc/text"}
 
 	for _, chunk := range []int{1, 2, 3, 4, defaultChunkSizeRows} {
-		built, err := NewBuilder().AddPath(path).SetDefaultChunkSize(chunk).Build(context.Background())
+		built, err := buildForTest(context.Background(), NewBuilder().AddPath(path).SetDefaultChunkSize(chunk))
 		require.NoError(t, err)
 		db, err := built.Open(context.Background())
 		require.NoError(t, err)
@@ -2239,7 +2239,7 @@ func TestACanceledLoadStopsReadingItsSource(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			src := &dripReader{body: body(2000, format.name), cancelAt: deliverBeforeCancel, cancel: cancel}
-			builder, err := NewBuilder().AddReader(src, "slow", format.typ).Build(context.Background())
+			builder, err := buildForTest(context.Background(), NewBuilder().AddReader(src, "slow", format.typ))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2266,7 +2266,7 @@ func TestACanceledLoadStopsReadingItsSource(t *testing.T) {
 			t.Parallel()
 
 			src := &dripReader{body: body(50, format.name)}
-			builder, err := NewBuilder().AddReader(src, "slow", format.typ).Build(context.Background())
+			builder, err := buildForTest(context.Background(), NewBuilder().AddReader(src, "slow", format.typ))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/types_test.go
+++ b/types_test.go
@@ -1078,10 +1078,12 @@ func loadColumnForTypeTest(t *testing.T, values []string, chunkSize int) (string
 
 	body := "v\n" + strings.Join(values, "\n") + "\n"
 	ctx := context.Background()
-	validated, err := NewBuilder().
-		AddReader(strings.NewReader(body), "t", FileTypeCSV).
-		SetDefaultChunkSize(chunkSize).
-		Build(ctx)
+	validated, err := buildForTest(
+
+		ctx, NewBuilder().
+			AddReader(strings.NewReader(body), "t", FileTypeCSV).
+			SetDefaultChunkSize(chunkSize))
+
 	require.NoError(t, err)
 	db, err := validated.Open(ctx)
 	require.NoError(t, err)
@@ -1248,9 +1250,11 @@ func TestColumnType_ADecimalMakesTheColumnReal(t *testing.T) {
 
 		ctx := context.Background()
 		body := "v\n" + strings.Join(append(append([]string{}, integers...), "4.0"), "\n") + "\n"
-		validated, err := NewBuilder().
-			AddReader(strings.NewReader(body), "t", FileTypeCSV).
-			Build(ctx)
+		validated, err := buildForTest(
+
+			ctx, NewBuilder().
+				AddReader(strings.NewReader(body), "t", FileTypeCSV))
+
 		require.NoError(t, err)
 		db, err := validated.Open(ctx)
 		require.NoError(t, err)
@@ -1281,9 +1285,11 @@ func TestColumnType_DeclaredTypeAgreesWithStoredType(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			validated, err := NewBuilder().
-				AddReader(strings.NewReader(body), "t", FileTypeCSV).
-				Build(ctx)
+			validated, err := buildForTest(
+
+				ctx, NewBuilder().
+					AddReader(strings.NewReader(body), "t", FileTypeCSV))
+
 			require.NoError(t, err)
 			db, err := validated.Open(ctx)
 			require.NoError(t, err)
@@ -1830,7 +1836,7 @@ func TestBlankCellInNumericColumnAtEveryChunkSize(t *testing.T) {
 			src := filepath.Join(t.TempDir(), "rows.csv")
 			require.NoError(t, os.WriteFile(src, []byte(body), 0o600))
 
-			validated, err := NewBuilder().AddPath(src).SetDefaultChunkSize(chunk).Build(ctx)
+			validated, err := buildForTest(ctx, NewBuilder().AddPath(src).SetDefaultChunkSize(chunk))
 			require.NoError(t, err)
 			db, err := validated.Open(ctx)
 			require.NoError(t, err)
@@ -1912,9 +1918,11 @@ func TestBlankCellInNumericColumnOnEveryLoadRoute(t *testing.T) {
 			name: "AddFS",
 			open: func(t *testing.T) *sql.DB {
 				t.Helper()
-				validated, err := NewBuilder().
-					AddFS(fstest.MapFS{"rows.csv": &fstest.MapFile{Data: []byte(blankCellSource)}}).
-					Build(ctx)
+				validated, err := buildForTest(
+
+					ctx, NewBuilder().
+						AddFS(fstest.MapFS{"rows.csv": &fstest.MapFile{Data: []byte(blankCellSource)}}))
+
 				require.NoError(t, err)
 				db, err := validated.Open(ctx)
 				require.NoError(t, err)
@@ -1936,9 +1944,11 @@ func TestBlankCellInNumericColumnOnEveryLoadRoute(t *testing.T) {
 				t.Helper()
 				db, err := sql.Open("sqlite", ":memory:")
 				require.NoError(t, err)
-				validated, err := NewBuilder().
-					AddReader(strings.NewReader(blankCellSource), "rows", FileTypeCSV).
-					Build(ctx)
+				validated, err := buildForTest(
+
+					ctx, NewBuilder().
+						AddReader(strings.NewReader(blankCellSource), "rows", FileTypeCSV))
+
 				require.NoError(t, err)
 				require.NoError(t, validated.LoadInto(ctx, db))
 				return db
@@ -2015,7 +2025,7 @@ func TestBlankCellInNumericColumnFromAReaderInEveryFormat(t *testing.T) {
 // openReaderTable loads body as one table named "rows" through AddReader, which
 // is the route an input that cannot be read twice takes.
 func openReaderTable(ctx context.Context, body string, kind FileType) (*sql.DB, error) {
-	validated, err := NewBuilder().AddReader(strings.NewReader(body), "rows", kind).Build(ctx)
+	validated, err := buildForTest(ctx, NewBuilder().AddReader(strings.NewReader(body), "rows", kind))
 	if err != nil {
 		return nil, err
 	}

--- a/wire_test.go
+++ b/wire_test.go
@@ -164,7 +164,7 @@ func TestBuilderAddPathFedWire(t *testing.T) {
 	ctx := context.Background()
 
 	builder := NewBuilder().AddPath(testFile)
-	builder, err := builder.Build(ctx)
+	builder, err := buildForTest(ctx, builder)
 	require.NoError(t, err)
 
 	db, err := builder.Open(ctx)
@@ -281,7 +281,7 @@ func TestAddFS_FedWireFile(t *testing.T) {
 
 	fsys := os.DirFS(tmpDir)
 	builder := NewBuilder().AddFS(fsys)
-	builder, err = builder.Build(ctx)
+	builder, err = buildForTest(ctx, builder)
 	require.NoError(t, err, "Build should succeed with .fed file in AddFS")
 
 	db, err := builder.Open(ctx)


### PR DESCRIPTION
Removes `DBBuilder.Build`, which v0.49.0 deprecated. That release is the one callers migrate from: `Open`, `OpenReadOnly`, `LoadInto` and `LoadIntoTx` validate the builder themselves, so the two-step protocol bought nothing, and sqly has already moved to the one-step call (nao1215/sqly#925, released as v1.2.1).

The examples change shape rather than losing anything: a chain that ended in `Build(ctx)` followed by an intermediate builder and its error check now ends in the terminal method. `ExampleDBBuilder_Build` is gone with the method, and `ExampleDBBuilder_errorHandling` asks the same four questions through `Open`.

The tests in this package still check the validation on its own, because that is a step the public API no longer exposes: they go through a `buildForTest` helper over the unexported `build`, which is what the terminal methods call. Nothing about what is validated or which error is reported changed.

Verified with `make test` (93.8% coverage), `make lint`, `make examples`, a windows/amd64 cross-build, and sqly's build and test suite against this checkout through a local replace.

Closes #694
