### PR TITLE
docs: say what an XLSX load costs and what the number follows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+
+- The Memory and Streaming section says what an XLSX load costs and what the number depends on ([#712](https://github.com/nao1215/filesql/issues/712)). It read "Budget from the file size" and gave XLSX as "about 24 times the file", which is one workbook measured at one size: a workbook is read whole, so what it costs follows the cells it holds rather than the size of the file, which is a zip and shrinks with how well the sheet compressed. The same 200,000 rows cost about 26 times the file as a wide workbook and about 37 times as a workbook of one column, and against the file alone the ratio reaches 135 times for a small one-column workbook -- so a caller sizing a server for uploads from the old figure was wrong by more than a factor of four on a shape that is not unusual. The section now says to budget an XLSX load from the cells, and to bound the decompressed size before loading a workbook that came from somewhere else, since nothing here does. `TestLoadMemoryFootprintByFormat` grew a one-column workbook beside the wide one, so both shapes are printed by the command the section names and neither can drift alone.
+
 ## [0.50.0] - 2026-08-27
 
 ### Breaking Changes

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -650,6 +650,14 @@ func TestLoadMemoryFootprintByFormat(t *testing.T) {
 			return convertCSV(t, csvPath, OutputFormatParquet, ".parquet")
 		}},
 		{name: "xlsx", write: func(t *testing.T, csvPath string) string { return convertCSV(t, csvPath, OutputFormatXLSX, ".xlsx") }},
+		// The same rows in one column. A workbook is read whole, so what it
+		// costs follows the cells it holds rather than the size of the file --
+		// which is a zip, and shrinks when every row is short. Without this
+		// shape beside the one above, the table reads as if the format had one
+		// multiplier.
+		{name: "xlsx/1col", write: func(t *testing.T, csvPath string) string {
+			return convertCSV(t, oneColumnCSV(t, csvPath), OutputFormatXLSX, ".xlsx")
+		}},
 	} {
 		var prevFileMB, prevPeakMB float64
 		for _, rows := range []int{50000, 100000, 200000} {
@@ -677,6 +685,47 @@ func TestLoadMemoryFootprintByFormat(t *testing.T) {
 			prevFileMB, prevPeakMB = fileMB, peakMB
 		}
 	}
+}
+
+// oneColumnCSV rewrites a CSV as its first column alone, keeping the row count.
+// It is what puts a second shape of workbook in the footprint table.
+func oneColumnCSV(t *testing.T, csvPath string) string {
+	t.Helper()
+
+	in, err := os.Open(csvPath) //nolint:gosec // path is under t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = in.Close() }()
+
+	// Named the way convertCSV expects, which takes the dumped file by name.
+	path := filepath.Join(t.TempDir(), "data.csv")
+	out, err := os.Create(path) //nolint:gosec // path is under t.TempDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := bufio.NewWriter(out)
+	sc := bufio.NewScanner(in)
+	sc.Buffer(make([]byte, 1<<20), 1<<20)
+	for sc.Scan() {
+		line := sc.Text()
+		if i := strings.IndexByte(line, ','); i >= 0 {
+			line = line[:i]
+		}
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 // footprintPathEnv names the file the child process loads. Its presence is also

--- a/doc.go
+++ b/doc.go
@@ -126,11 +126,18 @@
 //
 // The rows end up in SQLite rather than on the Go heap, so the heap is not where
 // the cost is: loading CSVs of 16 MB through 131 MB kept the Go heap flat at
-// about 24 MB while resident memory grew by about twice the file's size. Budget
-// from the file size. The multiplier belongs to the format rather than to this
-// package: over the same 200,000 rows, CSV and Parquet each cost about 2.1 times
-// the file and XLSX about 24 times, because a workbook's rows arrive as one
-// slice covering the sheet's used range. Both figures are printed by
+// about 24 MB while resident memory grew by about twice the file's size. For a
+// chunked format, budget from the file size: over 200,000 rows, CSV and Parquet
+// each cost about 2.1 times the file.
+//
+// A workbook is read whole, so what it costs follows the cells it holds rather
+// than the size of the file, which is a zip and shrinks with how well the sheet
+// compressed. The same 200,000 rows cost about 26 times the file as a wide
+// workbook and about 37 times as a workbook of one column, and against the file
+// alone the ratio reaches 135 times for a small one-column workbook. Budget an
+// XLSX load from the cells rather than from the file, and bound the decompressed
+// size before loading a workbook that came from somewhere else, since nothing
+// here does. Every figure is printed by
 // "go test -tags benchmark -run TestLoadMemoryFootprint -v ." and
 // "go test -tags benchmark -run TestLoadMemoryFootprintByFormat -v .", which
 // print the tables they are drawn from so they can be re-derived rather than


### PR DESCRIPTION
The Memory and Streaming section told a caller to "Budget from the file size" and gave XLSX as costing "about 24 times the file". That is one workbook measured at one size, and the number moves by more than a factor of four with the workbook's shape, which is the wrong way to be wrong for the reader this section is for: someone sizing a server for workbooks that came from somewhere else.

A workbook is read whole, so what it costs follows the cells it holds rather than the size of the file -- the file is a zip, and it shrinks with how well the sheet compressed. Measured through the package's own footprint benchmark, the same 200,000 rows cost about 26 times the file as the wide benchmark workbook and about 37 times as a workbook of one column, and against the file alone the ratio reaches 135 times for a small one-column workbook.

`TestLoadMemoryFootprintByFormat` now writes a one-column workbook beside the wide one, so both shapes are printed by the command the section names and neither figure can drift without the other. Its new table:

```
     rows format      file MB  peak RSS MB    ratio   marginal
    50000 xlsx            6.1        287.2    47.4x          -
   100000 xlsx           12.0        241.8    20.1x      -7.6x
   200000 xlsx           17.6        387.8    22.0x      25.9x
    50000 xlsx/1col       0.5         67.2   135.4x          -
   100000 xlsx/1col       1.0        104.5   106.1x      76.3x
   200000 xlsx/1col       1.7        131.7    76.8x      37.3x
```

The section also now says to bound the decompressed size before loading a workbook that came from elsewhere, since nothing in this package does.

Closes #712


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated memory-footprint guidance for CSV, Parquet, and XLSX files.
  * Clarified that XLSX memory usage depends on workbook shape and cell count, not only compressed file size.
  * Added recommendations to set decompressed-size limits before loading workbooks from untrusted sources.

* **Tests**
  * Expanded memory-footprint coverage to include both wide and single-column XLSX workbooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->