### PR TITLE
fix: refuse a dialect where it cannot reach the database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `LoadInto` and `LoadIntoTx` refuse a dialect rather than dropping it ([#714](https://github.com/nao1215/filesql/issues/714)). `WithDialect` was accepted by both and then did nothing, because a dialect is a connector wrapping the database `Open` returns and cannot reach one the caller opened -- so a caller who configured PostgreSQL and loaded into their own database met SQLite's tokenizer error on their first `::` cast, about a token they had not written, with no sentinel of this package's to match and no mention of the option that had been dropped. Auto-save cannot reach that database either and has always been refused by name; the dialect is now refused the same way, carrying `ErrDatabaseOperation` and naming the dialect and the method. A builder configured with `dialect.SQLite`, or with no dialect at all, asks for no translation and is unaffected.
+
 ### Documentation
 
 - The Memory and Streaming section says what an XLSX load costs and what the number depends on ([#712](https://github.com/nao1215/filesql/issues/712)). It read "Budget from the file size" and gave XLSX as "about 24 times the file", which is one workbook measured at one size: a workbook is read whole, so what it costs follows the cells it holds rather than the size of the file, which is a zip and shrinks with how well the sheet compressed. The same 200,000 rows cost about 26 times the file as a wide workbook and about 37 times as a workbook of one column, and against the file alone the ratio reaches 135 times for a small one-column workbook -- so a caller sizing a server for uploads from the old figure was wrong by more than a factor of four on a shape that is not unusual. The section now says to budget an XLSX load from the cells, and to bound the decompressed size before loading a workbook that came from somewhere else, since nothing here does. `TestLoadMemoryFootprintByFormat` grew a one-column workbook beside the wide one, so both shapes are printed by the command the section names and neither can drift alone.

--- a/builder.go
+++ b/builder.go
@@ -430,7 +430,8 @@ func (b *DBBuilder) WithDialect(d dialect.Dialect) *DBBuilder {
 }
 
 // refuseDialectForCallerDatabase refuses a load into a database this package
-// did not open while a dialect is configured.
+// did not open while a dialect that asks for translation is configured. SQLite,
+// and the zero value that means it, ask for none and are let through.
 //
 // A dialect is a connector wrapping the database Open returns, so it cannot
 // reach one the caller opened -- the same reason auto-save cannot, and auto-save
@@ -721,9 +722,10 @@ func (b *DBBuilder) OpenReadOnly(ctx context.Context) (*sql.DB, error) {
 //     reading is tried again.
 //
 // Auto-save is not supported because the caller owns the database lifecycle;
-// configuring it returns an error. WithDialect is refused for the same reason:
-// the dialect is a connector wrapping the database Open returns, so it cannot
-// reach one the caller opened.
+// configuring it returns an error. WithDialect is refused for the same reason
+// when it asks for a translation -- the dialect is a connector wrapping the
+// database Open returns, so it cannot reach one the caller opened. SQLite asks
+// for no translation and is accepted.
 //
 // Example:
 //
@@ -776,8 +778,9 @@ func (b *DBBuilder) LoadInto(ctx context.Context, db *sql.DB) error {
 // keep it usable after such a failure, since canceling the context it was begun
 // with ends the whole transaction.
 //
-// Auto-save and WithDialect are refused, as they are by LoadInto: both apply to
-// the database Open returns, and the caller owns this one.
+// Auto-save is refused, as it is by LoadInto, and so is a WithDialect that asks
+// for a translation: both apply to the database Open returns, and the caller
+// owns this one. SQLite asks for none and is accepted.
 func (b *DBBuilder) LoadIntoTx(ctx context.Context, tx *sql.Tx) error {
 	if tx == nil {
 		return fmt.Errorf("%w: target transaction is nil", ErrDatabaseOperation)

--- a/builder.go
+++ b/builder.go
@@ -429,6 +429,23 @@ func (b *DBBuilder) WithDialect(d dialect.Dialect) *DBBuilder {
 	return b
 }
 
+// refuseDialectForCallerDatabase refuses a load into a database this package
+// did not open while a dialect is configured.
+//
+// A dialect is a connector wrapping the database Open returns, so it cannot
+// reach one the caller opened -- the same reason auto-save cannot, and auto-save
+// has always been refused here by name. Accepting it and doing nothing left the
+// caller's first dialect query answering SQLite's tokenizer error about a token
+// they had not written, with no sentinel to match and no mention of the option
+// that was dropped.
+func (b *DBBuilder) refuseDialectForCallerDatabase(method string) error {
+	if !b.usesDialectTranslation() {
+		return nil
+	}
+	return fmt.Errorf("%w: WithDialect(%s) is not supported by %s; the dialect applies to the database Open and OpenReadOnly return, and the caller owns this one",
+		ErrDatabaseOperation, b.sqlDialect, method)
+}
+
 // usesDialectTranslation reports whether a non-SQLite dialect is configured.
 func (b *DBBuilder) usesDialectTranslation() bool {
 	return b.sqlDialect != "" && b.sqlDialect != dialect.SQLite
@@ -704,7 +721,9 @@ func (b *DBBuilder) OpenReadOnly(ctx context.Context) (*sql.DB, error) {
 //     reading is tried again.
 //
 // Auto-save is not supported because the caller owns the database lifecycle;
-// configuring it returns an error.
+// configuring it returns an error. WithDialect is refused for the same reason:
+// the dialect is a connector wrapping the database Open returns, so it cannot
+// reach one the caller opened.
 //
 // Example:
 //
@@ -720,6 +739,9 @@ func (b *DBBuilder) LoadInto(ctx context.Context, db *sql.DB) error {
 	}
 	if b.autoSaveConfig != nil && b.autoSaveConfig.enabled {
 		return fmt.Errorf("%w: auto-save is not supported by LoadInto; the caller owns the database lifecycle", ErrDatabaseOperation)
+	}
+	if err := b.refuseDialectForCallerDatabase("LoadInto"); err != nil {
+		return err
 	}
 
 	if err := b.build(ctx); err != nil {
@@ -753,12 +775,18 @@ func (b *DBBuilder) LoadInto(ctx context.Context, db *sql.DB) error {
 // nothing of the failed input remains. Begin tx with a context of its own to
 // keep it usable after such a failure, since canceling the context it was begun
 // with ends the whole transaction.
+//
+// Auto-save and WithDialect are refused, as they are by LoadInto: both apply to
+// the database Open returns, and the caller owns this one.
 func (b *DBBuilder) LoadIntoTx(ctx context.Context, tx *sql.Tx) error {
 	if tx == nil {
 		return fmt.Errorf("%w: target transaction is nil", ErrDatabaseOperation)
 	}
 	if b.autoSaveConfig != nil && b.autoSaveConfig.enabled {
 		return fmt.Errorf("%w: auto-save is not supported by LoadIntoTx", ErrDatabaseOperation)
+	}
+	if err := b.refuseDialectForCallerDatabase("LoadIntoTx"); err != nil {
+		return err
 	}
 	if err := b.build(ctx); err != nil {
 		return err

--- a/load_into_test.go
+++ b/load_into_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nao1215/filesql/dialect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xuri/excelize/v2"
@@ -343,6 +344,59 @@ func TestLoadInto_Errors(t *testing.T) {
 		require.NoError(t, err)
 		err = builder.LoadInto(context.Background(), db)
 		require.Error(t, err)
+	})
+}
+
+// TestLoadIntoRefusesADialect holds the rule that an option which cannot reach
+// the caller's database is refused rather than dropped. The dialect is a
+// connector wrapping the database this package returns, so it cannot wrap one
+// the caller opened -- the same reason auto-save cannot, and auto-save has
+// always been refused by name. The dialect was accepted and then did nothing,
+// and the caller's first dialect query answered SQLite's tokenizer error about a
+// token they had not written.
+func TestLoadIntoRefusesADialect(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	src := filepath.Join("testdata", "sample.csv")
+
+	for _, d := range []dialect.Dialect{dialect.MySQL, dialect.PostgreSQL, dialect.GoogleSQL} {
+		t.Run(string(d), func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("LoadInto", func(t *testing.T) {
+				db := newCallerDB(t)
+				err := NewBuilder().AddPath(src).WithDialect(d).LoadInto(ctx, db)
+
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrDatabaseOperation)
+				assert.Contains(t, err.Error(), string(d), "the error must name the dialect")
+				assert.Empty(t, listTables(t, db), "nothing may be loaded into the caller's database")
+			})
+
+			t.Run("LoadIntoTx", func(t *testing.T) {
+				db := newCallerDB(t)
+				tx, err := db.BeginTx(ctx, nil)
+				require.NoError(t, err)
+				defer func() { _ = tx.Rollback() }()
+
+				err = NewBuilder().AddPath(src).WithDialect(d).LoadIntoTx(ctx, tx)
+
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrDatabaseOperation)
+				assert.Contains(t, err.Error(), string(d))
+			})
+		})
+	}
+
+	t.Run("SQLite asks for no translation and loads", func(t *testing.T) {
+		t.Parallel()
+
+		for _, d := range []dialect.Dialect{"", dialect.SQLite} {
+			db := newCallerDB(t)
+			require.NoError(t, NewBuilder().AddPath(src).WithDialect(d).LoadInto(ctx, db))
+			assert.NotEmpty(t, listTables(t, db))
+		}
 	})
 }
 


### PR DESCRIPTION
Found by building every combination of the builder's options and asking what each one does. Fifty-nine of the sixty behave as documented; this is the one that does not.

`WithDialect` was accepted by `LoadInto` and `LoadIntoTx` and then did nothing. A dialect is a connector wrapping the database `Open` returns, so it cannot reach one the caller opened -- which is the same reason auto-save cannot, and auto-save has always been refused there by name (`auto-save is not supported by LoadInto; the caller owns the database lifecycle`). Two options with one reason, one refused and one dropped in silence.

What the caller got instead was SQLite's tokenizer error on their first dialect query: `SELECT name::text FROM t WHERE name ILIKE 'a%'` answered `SQL logic error: unrecognized token: ":" (1)`, about a token they had not written, with no sentinel of this package's to match and no mention of the option that had been dropped. That is the outcome the package's other checks exist to replace. Through `Open` the same builder answers `Alice`.

Both methods now refuse a non-SQLite dialect, carrying `ErrDatabaseOperation` and naming the dialect and the method, and both godocs say it beside the sentence about auto-save. A builder configured with `dialect.SQLite`, or with no dialect at all, asks for no translation and still loads -- that boundary is a test.

Verified with `make test`, `make lint`, and the option matrix that found it: dialect (none, sqlite, mysql, postgresql, googlesql) by auto-save (none, directory, overwrite) by entry point (Open, OpenReadOnly, LoadInto, LoadIntoTx), all sixty now either working or refused with a message that names the option.

Closes #714


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `LoadInto` and `LoadIntoTx` now reject unsupported non-SQLite dialect configurations instead of silently ignoring them.
  * Errors clearly identify the configured dialect and affected operation.
  * SQLite and unspecified dialect configurations continue to work as before.
  * Prevents database loading failures caused by unintended SQL dialect mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->