### PR TITLE
fix: refuse an LTSV dump of a table with no rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- An LTSV dump of a table with no rows is refused rather than writing an empty file ([#716](https://github.com/nao1215/filesql/issues/716)). LTSV carries its labels on every record rather than in a header, so a table with no rows has nothing to write; the empty file that came of it did not only lose its own columns, it blocked the load of every file beside it, since an empty file is not a table. A database of two tables, one of them empty, dumped to LTSV wrote `empty.ltsv` at zero bytes beside a `full.ltsv` that held its rows, and `OpenContext` on that directory failed naming the empty file, so neither table could be read. The refusal carries `ErrUnsupportedFormat` and says to dump the table as CSV, which is the shape the other LTSV refusals have. CSV and TSV keep the header, Parquet keeps its schema and XLSX keeps the header row, so a table with no rows round-trips in every other format. Migration: dump such a table as CSV, or drop it before dumping. This overturns a decision recorded in a test -- that an empty file was a correct empty LTSV -- which was made without the directory load in view.
+
 ### Fixed
 
 - `LoadInto` and `LoadIntoTx` refuse a dialect rather than dropping it ([#714](https://github.com/nao1215/filesql/issues/714)). `WithDialect` was accepted by both and then did nothing, because a dialect is a connector wrapping the database `Open` returns and cannot reach one the caller opened -- so a caller who configured PostgreSQL and loaded into their own database met SQLite's tokenizer error on their first `::` cast, about a token they had not written, with no sentinel of this package's to match and no mention of the option that had been dropped. Auto-save cannot reach that database either and has always been refused by name; the dialect is now refused the same way, carrying `ErrDatabaseOperation` and naming the dialect and the method. A builder configured with `dialect.SQLite`, or with no dialect at all, asks for no translation and is unaffected.

--- a/dump_test.go
+++ b/dump_test.go
@@ -30,6 +30,9 @@ import (
 func TestDumpEmptyTable(t *testing.T) {
 	t.Parallel()
 
+	// LTSV is not here: it has no header to carry the columns, so a table with
+	// no rows has nothing to write, and TestDumpLTSVRefusesATableWithNoRows
+	// holds what happens instead.
 	tests := []struct {
 		name        string
 		format      OutputFormat
@@ -38,7 +41,6 @@ func TestDumpEmptyTable(t *testing.T) {
 		{name: "csv", format: OutputFormatCSV, compression: CompressionNone},
 		{name: "csv gz", format: OutputFormatCSV, compression: CompressionGZ},
 		{name: "tsv", format: OutputFormatTSV, compression: CompressionNone},
-		{name: "ltsv", format: OutputFormatLTSV, compression: CompressionNone},
 		{name: "parquet", format: OutputFormatParquet, compression: CompressionNone},
 		{name: "xlsx", format: OutputFormatXLSX, compression: CompressionNone},
 	}
@@ -74,8 +76,9 @@ func TestDumpEmptyTable(t *testing.T) {
 // as the same table with no rows.
 //
 // LTSV is the exception and is covered separately: it carries a label on every
-// row and so has no header, which leaves an emptied table nothing to write and
-// nothing to read back.
+// row and so has no header, which leaves an emptied table nothing to write --
+// and the empty file that came of it blocked the load of every file beside it,
+// so the dump refuses the table.
 func TestDumpEmptyTableRoundTrip(t *testing.T) {
 	t.Parallel()
 
@@ -126,7 +129,11 @@ func TestDumpEmptyTableRoundTrip(t *testing.T) {
 		})
 	}
 
-	t.Run("ltsv has no header, so an emptied table cannot be read back", func(t *testing.T) {
+	// LTSV has no header to carry the columns, so an emptied table has nothing
+	// to write. The empty file that came out did not only lose its own columns:
+	// an empty file is not a table, so loading the directory failed on it and
+	// took every file beside it down. The dump refuses instead.
+	t.Run("ltsv has no header, so an emptied table is refused", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := t.Context()
@@ -141,20 +148,18 @@ func TestDumpEmptyTableRoundTrip(t *testing.T) {
 		require.NoError(t, err)
 
 		outDir := t.TempDir()
-		require.NoError(t, DumpDatabase(db, outDir, NewDumpOptions().WithFormat(OutputFormatLTSV)))
+		err = DumpDatabase(db, outDir, NewDumpOptions().WithFormat(OutputFormatLTSV))
 
-		// The empty file is a correct empty LTSV; there is simply no column list in
-		// it to rebuild the table from.
-		_, err = OpenContext(ctx, filepath.Join(outDir, "people.ltsv"))
 		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrEmptyData)
+		assert.ErrorIs(t, err, ErrUnsupportedFormat)
+		assert.Contains(t, err.Error(), "CSV")
 	})
 }
 
 // TestDumpEmptyTableColumnsSurvive pins that a dump of an emptied table still
 // carries its columns, for the formats that have somewhere to put them. LTSV
-// writes one label per row and so has nowhere; an empty LTSV file is all it can
-// be.
+// writes one label per row and so has nowhere, which is why it refuses the
+// table rather than writing a file nothing can read.
 func TestDumpEmptyTableColumnsSurvive(t *testing.T) {
 	t.Parallel()
 
@@ -162,10 +167,12 @@ func TestDumpEmptyTableColumnsSurvive(t *testing.T) {
 		name   string
 		format OutputFormat
 		want   string
+		// refused is set for a format that cannot say what an empty table is.
+		refused bool
 	}{
 		{name: "csv keeps its header", format: OutputFormatCSV, want: "id,name\n"},
 		{name: "tsv keeps its header", format: OutputFormatTSV, want: "id\tname\n"},
-		{name: "ltsv has nowhere to put one", format: OutputFormatLTSV, want: ""},
+		{name: "ltsv has nowhere to put one", format: OutputFormatLTSV, refused: true},
 	}
 
 	for _, tt := range tests {
@@ -185,7 +192,14 @@ func TestDumpEmptyTableColumnsSurvive(t *testing.T) {
 
 			opts := NewDumpOptions().WithFormat(tt.format)
 			outDir := t.TempDir()
-			require.NoError(t, DumpDatabase(db, outDir, opts))
+			err = DumpDatabase(db, outDir, opts)
+			if tt.refused {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrUnsupportedFormat)
+				assert.Empty(t, dirEntriesOrNone(t, outDir), "nothing may be written for a refused table")
+				return
+			}
+			require.NoError(t, err)
 
 			got, err := os.ReadFile(filepath.Join(outDir, "people"+opts.FileExtension())) //nolint:gosec // Test path from t.TempDir()
 			require.NoError(t, err)
@@ -1887,5 +1901,78 @@ func TestDumpXLSXRefusesAnUnnamedLastColumn(t *testing.T) {
 		var last string
 		require.NoError(t, back.QueryRowContext(ctx, `SELECT " " FROM t`).Scan(&last))
 		assert.Equal(t, "q", last)
+	})
+}
+
+// TestDumpLTSVRefusesATableWithNoRows holds the rule that a dump is a file this
+// package can read again, on the one format that cannot say what a table with
+// no rows is. LTSV carries its labels on every record rather than in a header,
+// so an empty table wrote an empty file, and the load of an empty file is
+// refused -- a dump nobody can read back. Every other format keeps the columns.
+func TestDumpLTSVRefusesATableWithNoRows(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("LTSV is refused", func(t *testing.T) {
+		t.Parallel()
+
+		db := openWithTable(t, "CREATE TABLE t (id INTEGER, name TEXT)", "")
+
+		outDir := filepath.Join(t.TempDir(), "out")
+		err := DumpDatabase(db, outDir, NewDumpOptions().WithFormat(OutputFormatLTSV))
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnsupportedFormat)
+		assert.Contains(t, err.Error(), "CSV", "the error must say what to dump instead")
+		assert.Empty(t, dirEntriesOrNone(t, outDir), "nothing may be written for a refused table")
+	})
+
+	t.Run("every other format keeps the columns", func(t *testing.T) {
+		t.Parallel()
+
+		for _, tc := range []struct {
+			format OutputFormat
+			ext    string
+		}{
+			{format: OutputFormatCSV, ext: ".csv"},
+			{format: OutputFormatTSV, ext: ".tsv"},
+			{format: OutputFormatParquet, ext: ".parquet"},
+			{format: OutputFormatXLSX, ext: ".xlsx"},
+		} {
+			db := openWithTable(t, "CREATE TABLE t (id INTEGER, name TEXT)", "")
+
+			outDir := filepath.Join(t.TempDir(), "out")
+			require.NoError(t, DumpDatabase(db, outDir, NewDumpOptions().WithFormat(tc.format)))
+			require.NoError(t, db.Close())
+
+			back, err := OpenContext(ctx, filepath.Join(outDir, "t"+tc.ext))
+			require.NoError(t, err, "a dump of an empty table must load")
+
+			var columns, rows int
+			require.NoError(t, back.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('t')").Scan(&columns))
+			require.NoError(t, back.QueryRowContext(ctx, "SELECT COUNT(*) FROM t").Scan(&rows))
+			assert.Equal(t, 2, columns, "%s must keep the columns", tc.ext)
+			assert.Equal(t, 0, rows)
+			require.NoError(t, back.Close())
+		}
+	})
+
+	t.Run("LTSV with a row is unaffected", func(t *testing.T) {
+		t.Parallel()
+
+		db := openWithTable(t, "CREATE TABLE t (id INTEGER, name TEXT)", "INSERT INTO t VALUES (1, 'Alice')")
+
+		outDir := filepath.Join(t.TempDir(), "out")
+		require.NoError(t, DumpDatabase(db, outDir, NewDumpOptions().WithFormat(OutputFormatLTSV)))
+		require.NoError(t, db.Close())
+
+		back, err := OpenContext(ctx, filepath.Join(outDir, "t.ltsv"))
+		require.NoError(t, err)
+		defer func() { _ = back.Close() }()
+
+		var name string
+		require.NoError(t, back.QueryRowContext(ctx, "SELECT name FROM t").Scan(&name))
+		assert.Equal(t, "Alice", name)
 	})
 }

--- a/filesql.go
+++ b/filesql.go
@@ -123,7 +123,10 @@ func LoadInto(ctx context.Context, db *sql.DB, paths ...string) error {
 // break in TSV, those and a colon in an LTSV label, and in XLSX a control
 // character other than tab, line feed and carriage return, which is what an XML
 // 1.0 document has no way to spell, or a last column with no name, which a
-// worksheet does not store.
+// worksheet does not store. A table with no rows is refused for LTSV alone,
+// which has no header to carry the columns and would leave an empty file --
+// and an empty file is not a table, so it blocks the load of every file beside
+// it. The other formats keep the columns of an empty table.
 //
 // A table whose column names a load would refuse is refused too, with
 // ErrDuplicateColumn: this package reads " a", "a" and "a " as one name, and
@@ -591,6 +594,7 @@ func writeTextData(w io.Writer, columns []string, rows *sql.Rows, text textDumpF
 	// Record returns, so it keeps no reference to the strings in it.
 	record := make([]string, len(columns))
 
+	written := 0
 	for rows.Next() {
 		if err := rows.Scan(scanArgs...); err != nil {
 			return err
@@ -601,10 +605,24 @@ func writeTextData(w io.Writer, columns []string, rows *sql.Rows, text textDumpF
 		if err := out.Record(record); err != nil {
 			return dumpFormatError(err, text)
 		}
+		written++
 	}
 
 	if err := rows.Err(); err != nil {
 		return err
+	}
+
+	// LTSV carries its labels on every record rather than in a header, so a
+	// table with no rows has nothing to write and the columns go with it: the
+	// file came out empty, and an empty file is not a table, so the dump wrote
+	// something this package refuses to read. The other formats keep the
+	// columns -- a header line, a Parquet schema, a header row -- so this is
+	// the one place a table with no rows cannot be said. Writing a line of bare
+	// labels instead would load as one row of empty values, which is a row the
+	// table did not have.
+	if written == 0 && text.format == writer.FormatLTSV {
+		return fmt.Errorf("%w: LTSV cannot hold a table with no rows, since it has no header to carry the columns; dump this table as CSV instead",
+			ErrUnsupportedFormat)
 	}
 	// The writer buffers, so this is where a destination that could not take the
 	// bytes — an encoder refusing a value it cannot write, for instance —


### PR DESCRIPTION
Found by generating random tables, dumping each one and dumping the result again: the property is that a dump must be loadable and the second dump must equal the first. Two thousand rounds over CSV, TSV, LTSV, Parquet and XLSX turned up one failure, always the same one -- an LTSV dump of a table with no rows.

LTSV carries its labels on every record rather than in a header, so a table with no rows has nothing to write, and the file came out empty. That empty file did not only lose its own columns: an empty file is not a table, so it blocked the load of every file beside it. A database of two tables, one of them empty, dumped to LTSV wrote `empty.ltsv` at zero bytes beside a `full.ltsv` that held its rows, and `OpenContext` on that directory failed naming the empty file -- neither table could be read.

The dump now refuses the table, with `ErrUnsupportedFormat` and the advice to dump it as CSV, which is the shape the other LTSV refusals have. The check sits where the format and the row count are both known, so nothing is written and no staged file is left behind. CSV and TSV keep the header, Parquet keeps its schema and XLSX keeps the header row, so a table with no rows still round-trips in every other format -- that is a test.

Two existing tests recorded the opposite decision, that an empty file is a correct empty LTSV and simply cannot be read back. They are rewritten rather than deleted, and their comments now say why the decision changed: the file does not fail alone, it takes the directory with it, which was not in view when they were written.

Verified with `make test` (93.7% coverage), `make lint`, a windows/amd64 cross-build, and sqly's build, unit tests and full atago suite against this checkout (1011 passed, 2 skipped).

Closes #716
