### PR TITLE
chore: release v0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.51.0] - 2026-08-27
 
 ### Breaking Changes
 
@@ -1927,6 +1927,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
+[0.51.0]: https://github.com/nao1215/filesql/compare/v0.50.0...v0.51.0
 [0.50.0]: https://github.com/nao1215/filesql/compare/v0.49.0...v0.50.0
 [0.49.0]: https://github.com/nao1215/filesql/compare/v0.48.0...v0.49.0
 [0.48.0]: https://github.com/nao1215/filesql/compare/v0.47.0...v0.48.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,8 @@ Security fixes are provided for the latest published release series only.
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| `0.50.x` | Yes | Current published release series as of August 27, 2026 |
-| `0.49.x` and earlier | No | Upgrade to the latest `0.50.x` release |
+| `0.51.x` | Yes | Current published release series as of August 27, 2026 |
+| `0.50.x` and earlier | No | Upgrade to the latest `0.51.x` release |
 
 Security fixes are not backported to unsupported release series. When the next
 series is published, support moves to it.


### PR DESCRIPTION
Dates the Unreleased section as v0.51.0, adds the compare link, and names 0.51.x as the supported series.

One breaking change, and it is the same rule the last release was about: an LTSV dump of a table with no rows is refused rather than writing an empty file (#716). LTSV has no header to carry the columns, so such a table had nothing to write, and the empty file did not fail alone -- it blocked the load of every file beside it, so a dump of a database with one empty table could not be read at all. Every other format keeps the columns of an empty table.

Two fixes beside it. `LoadInto` and `LoadIntoTx` refuse a dialect rather than dropping it (#714): the dialect is a connector wrapping the database `Open` returns, so it cannot reach one the caller opened, and a caller who configured PostgreSQL met SQLite's tokenizer error on their first cast. And the Memory and Streaming section now says what an XLSX load costs and what the number follows (#712), since the multiplier is the workbook's rather than the format's and moves by more than a factor of four with its shape.
