### PR TITLE
refactor(dialect): name the rule that tells a call from an operator

### DIFF
--- a/dialect/internal/parser/expr.go
+++ b/dialect/internal/parser/expr.go
@@ -110,8 +110,7 @@ func (p *Parser) parsePrefix(minPrec int) (ast.Expr, error) {
 			Span: span,
 		}, nil
 
-	case t.IsWord("INTERVAL") && p.dialect != dialects.PostgreSQL &&
-		!(p.peek(1).IsOp("(") && p.adjacent(1)):
+	case t.IsWord("INTERVAL") && p.dialect != dialects.PostgreSQL && !p.callParenFollows():
 		return p.parseUnitInterval()
 
 	case t.IsWord("EXISTS") && p.peek(1).IsOp("("):

--- a/dialect/internal/parser/parser.go
+++ b/dialect/internal/parser/parser.go
@@ -191,6 +191,14 @@ func (p *Parser) adjacent(n int) bool {
 	return p.peek(n).Offset == cur.Offset+len(cur.Text)
 }
 
+// callParenFollows reports whether an opening parenthesis stands against the
+// word at the cursor with nothing between them, which is how MySQL tells the
+// function "MOD(a, b)" from the operator in "a MOD (b + 1)", and "INTERVAL(...)"
+// from the "INTERVAL 1 DAY" unit.
+func (p *Parser) callParenFollows() bool {
+	return p.peek(1).IsOp("(") && p.adjacent(1)
+}
+
 // atOp reports whether the cursor is on the operator op.
 func (p *Parser) atOp(op string) bool { return p.cur().IsOp(op) }
 

--- a/dialect/internal/parser/precedence.go
+++ b/dialect/internal/parser/precedence.go
@@ -72,7 +72,7 @@ func (p *Parser) binaryOpFor() (op ast.BinaryOp, prec int, tokens int, ok bool) 
 		// MOD is the operator unless a parenthesis follows the word with
 		// nothing between them, which is how MySQL itself tells "MOD(a, b)"
 		// from "a MOD (b + 1)".
-		if p.dialect == dialects.MySQL && !(p.peek(1).IsOp("(") && p.adjacent(1)) {
+		if p.dialect == dialects.MySQL && !p.callParenFollows() {
 			return ast.Mod, precMulDiv, 1, true
 		}
 	case "LIKE":


### PR DESCRIPTION
main has been failing staticcheck since the parser landed, with two QF1001 reports for a negated conjunction. The staticcheck workflow does not run on a pull request, only on main, so the failure was invisible until after the merge.

The condition is the same one at both sites: MySQL tells the function `MOD(a, b)` from the operator in `a MOD (b + 1)` by whether an opening parenthesis stands against the word with nothing between them, and `INTERVAL(...)` from the `INTERVAL 1 DAY` unit the same way. It is one named method now, asked positively at both, which answers the report and removes the duplication rather than rewriting the same expression twice.

Verified with `make test`, `make lint` (0 issues) and `make lint-staticcheck` (0 issues), which is the check that was failing.