### PR TITLE
chore(release): v0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.52.0] - 2026-08-29
 
 ### Breaking Changes
 
@@ -1989,6 +1989,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
+[0.52.0]: https://github.com/nao1215/filesql/compare/v0.51.0...v0.52.0
 [0.51.0]: https://github.com/nao1215/filesql/compare/v0.50.0...v0.51.0
 [0.50.0]: https://github.com/nao1215/filesql/compare/v0.49.0...v0.50.0
 [0.49.0]: https://github.com/nao1215/filesql/compare/v0.48.0...v0.49.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,8 @@ Security fixes are provided for the latest published release series only.
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| `0.51.x` | Yes | Current published release series as of August 27, 2026 |
-| `0.50.x` and earlier | No | Upgrade to the latest `0.51.x` release |
+| `0.52.x` | Yes | Current published release series as of August 29, 2026 |
+| `0.51.x` and earlier | No | Upgrade to the latest `0.52.x` release |
 
 Security fixes are not backported to unsupported release series. When the next
 series is published, support moves to it.


### PR DESCRIPTION
Cuts v0.52.0 from the 27 entries that have accumulated since v0.51.0.

The release is a minor rather than a major because the version is still below one and breaking changes are still coming; v1.0.0 waits until the shape of the package has stopped moving.

Two breaking changes are in it, both from the dialect rewrite. A query outside the supported subset is refused rather than forwarded to SQLite, with `ErrInvalidSyntax`, `ErrUnsupportedSyntax` or `ErrUnsupportedFeature` naming the construct; a query holding only comments is refused for the same reason, which is what MySQL and PostgreSQL answer for it. And comments are dropped from the translated SQL.

The rest is fixes: the dialect translation rebuilt as lexer, parser, typed AST, lowering and renderer, with the operators, functions, cast targets and template patterns each dialect spells measured against mysql:8.4.11, postgres:17.10 and the BigQuery emulator rather than derived; a text value carrying a zero byte reaching a helper whole; a REAL written into a dump the way SQLite renders it; a decimal a float64 cannot hold keeping its digits; a blank header taking the name of its position; a row of empty values surviving an XLSX dump; a record bound in the formats that are read whole; a file wider than a table refused in this package words; and the prep coercions rewriting how a number is written rather than what it says.

`SECURITY.md` moves its supported series to `0.52.x`.