### PR TITLE
fix(reader): stop a refused JSON element from reading the rest of the stream

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -25,9 +25,13 @@ jobs:
         # GO-2026-5972 (encoding/asn1) are fixed in 1.25.13 and 1.26.6. A
         # floating "1.25" would happily test on a Go the go.mod directive
         # already refuses to vouch for.
+        # 1.27.0 is the newest release. Without it nothing here would notice a
+        # new Go changing behavior this module depends on -- adding it is what
+        # surfaced the JSON read bound this commit's sibling fixes.
         go:
           - "1.25.13"
           - "1.26.6"
+          - "1.27.0"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/internal/reader/json.go
+++ b/internal/reader/json.go
@@ -189,22 +189,56 @@ type elementReader struct {
 	limit int
 	read  int
 	index int
+	// refused is the error this reader has already returned. It is sticky: a
+	// decoder that keeps calling Read after being told the element is too long
+	// must not be able to walk the rest of the stream one byte at a time.
+	refused error
 }
 
 // begin starts counting afresh for the element at index.
 func (e *elementReader) begin(index int) {
 	e.read = 0
 	e.index = index
+	e.refused = nil
 }
 
 // Read implements io.Reader, refusing once one element has asked for more than
 // the limit. The bytes read before the refusal are returned with it, the way
 // bufio does, so nothing already handed over is lost on the way to the error.
+//
+// The buffer handed to the source is capped at what the element is still
+// allowed, plus the one byte that proves the limit was passed. Counting after
+// an uncapped read would bound the record but not the reading: json.Decoder
+// sizes its own read-ahead buffer, and a source that fills whatever it is given
+// -- a file, a bytes.Reader -- would hand over the whole remainder in a single
+// call before the count was even consulted. How much that was depended on the
+// decoder's buffer growth, which is to say on the Go release: through 1.26 it
+// stayed near the bound, and on 1.27 it swallowed a forty-times-oversized body
+// whole. Capping the slice makes the refusal cost the same on any of them.
 func (e *elementReader) Read(p []byte) (int, error) {
+	// Once refused, stay refused without touching the source. json.Decoder does
+	// not stop at the first error it is handed -- it asks again -- so a reader
+	// that keeps serving would let it walk the whole stream a byte at a time,
+	// which is the read this bound exists to prevent.
+	if e.refused != nil {
+		return 0, e.refused
+	}
+	// Cap the slice at what the element is still allowed, plus the one byte
+	// that proves the limit was passed. Counting after an uncapped read bounds
+	// the record but not the reading: json.Decoder sizes its own read-ahead
+	// buffer, and a source that fills whatever it is given hands over the whole
+	// remainder in one call before the count is consulted.
+	if allowed := e.limit - e.read + 1; allowed < len(p) {
+		if allowed < 1 {
+			allowed = 1
+		}
+		p = p[:allowed]
+	}
 	n, err := e.src.Read(p)
 	e.read += n
 	if e.read > e.limit {
-		return n, elementTooLongError(e.index, e.limit)
+		e.refused = elementTooLongError(e.index, e.limit)
+		return n, e.refused
 	}
 	return n, err
 }

--- a/internal/reader/json_test.go
+++ b/internal/reader/json_test.go
@@ -230,6 +230,24 @@ func TestJSONArrayElementIsBounded(t *testing.T) {
 		assert.Less(t, read, limit*8, "the read consumed %d bytes for a %d byte bound", read, limit)
 	})
 
+	t.Run("a refused element stops the reading rather than slowing it", func(t *testing.T) {
+		t.Parallel()
+
+		// The bound has to cost the same however the decoder happens to ask for
+		// bytes. json.Decoder does not stop at the first error it is handed --
+		// it calls Read again -- so a reader that keeps serving after the
+		// refusal lets it walk the rest of the stream, which is exactly the
+		// read the bound exists to prevent. Through Go 1.26 the decoder's
+		// buffer growth hid this; on 1.27 it consumed a forty-times-oversized
+		// body whole. Asserting on the source reads keeps the property pinned
+		// to behavior rather than to a toolchain.
+		body := `[{"a":"` + strings.Repeat("x", limit*40)
+		read, err := readAll(t, body)
+		require.ErrorIs(t, err, ErrRecordTooLong)
+		assert.Less(t, read, len(body)/2,
+			"a %d byte body was read %d bytes deep for a %d byte bound", len(body), read, limit)
+	})
+
 	t.Run("many small elements are unaffected", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary

`internal/reader`'s JSON array bound limited which records it would accept, but not how much it would read to find that out. A single oversized element could be read to the end of the input, which is the read the bound exists to prevent.

The defect predates Go 1.27; what changed is that it became visible. Adding Go 1.27 to the test matrix is what surfaced it.

## Changes

- `internal/reader/json.go`: `elementReader` caps the slice it hands the source at the element's remaining allowance, and its refusal is now sticky.
- `internal/reader/json_test.go`: a new case asserts how deep the source was read after a refusal.
- `.github/workflows/unit_test.yml`: Go 1.27.0 joins the matrix.

## Design Decisions

Two separate things were wrong, and fixing only one moves the cost around instead of removing it.

The first is that the count came after an uncapped read. `elementReader.Read` passed the caller's whole buffer to the source and added the result to a running total afterwards, so the check could only ever run once the bytes were already in hand. `json.Decoder` sizes its own read-ahead buffer, and a source that fills whatever it is given -- a file, a `bytes.Reader`, a `bufio.Reader` with data -- hands over the entire remainder in one call. Capping the slice at `limit - read + 1` bounds that: the `+1` is what lets a read that exactly fills the limit still see the byte that takes it past.

The second only appears once the first is fixed, which is why the cap alone was not enough. `json.Decoder` does not stop at the first error it is handed; it calls `Read` again. With the cap in place and no memory of having refused, each retry was clamped to one byte and served one byte, so the decoder walked the entire forty-kilobyte body one byte at a time and arrived at the same total. Making the refusal sticky is what actually ends the read: once tripped, `Read` returns the error without touching the source, and `begin` clears it for the next element.

The existing test asserted the read landed within `limit*8`, which held through Go 1.26 because the decoder's buffer growth happened to keep it there. That made the assertion a statement about the toolchain rather than about this code. The new case asserts the source was not read past half the body, which is a property of the bound and holds on any Go.

This was verified in both directions on both toolchains: the new case fails against the previous implementation on Go 1.27 (40967 bytes read for a 1024 byte bound) and passes with the fix on 1.25.13, 1.26.6 and 1.27.0, with the rest of the suite green on each.

## Limitations

The bound still permits one buffer's worth of over-read past the limit, which is what `+1` and the source's own buffering allow. Making it exact would mean reading a byte at a time, and the point of the bound is to cap the cost of a refusal, not to make refusal free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of oversized JSON elements to stop reading promptly when record limits are exceeded.
  * Ensured consistent reporting of record-size limit errors without further unnecessary data consumption.
* **Tests**
  * Added regression coverage for JSON array size-limit handling.
  * Expanded automated testing to include Go 1.27.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->