### PR TITLE
docs: release v0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.53.0] - 2026-08-31
 
 ### Breaking Changes
 
@@ -2066,6 +2066,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
+[0.53.0]: https://github.com/nao1215/filesql/compare/v0.52.0...v0.53.0
 [0.52.0]: https://github.com/nao1215/filesql/compare/v0.51.0...v0.52.0
 [0.51.0]: https://github.com/nao1215/filesql/compare/v0.50.0...v0.51.0
 [0.50.0]: https://github.com/nao1215/filesql/compare/v0.49.0...v0.50.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,8 @@ Security fixes are provided for the latest published release series only.
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| `0.52.x` | Yes | Current published release series as of August 29, 2026 |
-| `0.51.x` and earlier | No | Upgrade to the latest `0.52.x` release |
+| `0.53.x` | Yes | Current published release series as of August 31, 2026 |
+| `0.52.x` and earlier | No | Upgrade to the latest `0.53.x` release |
 
 Security fixes are not backported to unsupported release series. When the next
 series is published, support moves to it.


### PR DESCRIPTION
Turns the accumulated [Unreleased] section into 0.53.0 and moves the supported release series to 0.53.x.

The series carries one breaking change -- parser.FileType names a format and no longer fuses in the codec wrapping it, so it has eight constants instead of sixty-four -- which is why this is a minor rather than a patch. The rest is fixes: a path is read through the one open that knows what it may open, an in-place save of a workbook or a Parquet file goes back to what it was read from, the transaction guard reads a whole statement rather than the first word it finds, MySQL's string functions read their arguments the way MySQL reads them, and prep's comparisons decide two integers by the integers.