### PR TITLE
chore(release): v0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.54.0] - 2026-09-01
 
 ### Fixed
 
@@ -2132,6 +2132,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
+[0.54.0]: https://github.com/nao1215/filesql/compare/v0.53.0...v0.54.0
 [0.53.0]: https://github.com/nao1215/filesql/compare/v0.52.0...v0.53.0
 [0.52.0]: https://github.com/nao1215/filesql/compare/v0.51.0...v0.52.0
 [0.51.0]: https://github.com/nao1215/filesql/compare/v0.50.0...v0.51.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,8 @@ Security fixes are provided for the latest published release series only.
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| `0.53.x` | Yes | Current published release series as of August 31, 2026 |
-| `0.52.x` and earlier | No | Upgrade to the latest `0.53.x` release |
+| `0.54.x` | Yes | Current published release series as of September 1, 2026 |
+| `0.53.x` and earlier | No | Upgrade to the latest `0.54.x` release |
 
 Security fixes are not backported to unsupported release series. When the next
 series is published, support moves to it.


### PR DESCRIPTION
Cuts v0.54.0 out of what has accumulated in Unreleased since v0.53.0: thirty-one fixes, most of them in the dialect translation and in what the loaders and the dump make of a file's own shape.

The dialect work is the bulk of it. Calls and clauses that a source dialect defines were reaching SQLite untranslated, so a caller read an error naming a function or a keyword they had not written: GoogleSQL's SUBSTRING and POSITION, its bitwise aggregates, PostgreSQL's ANY_VALUE, an UPDATE or a DELETE carrying ORDER BY or LIMIT, a row-locking clause in the spellings that were missed, an ALTER TABLE asking for what SQLite cannot make, a PostgreSQL ONLY, an IS JSON predicate, a DEFAULT standing where a value goes, and the clauses that stand around a statement. A RETURNING clause and a table reference's column list now name their columns after what the caller wrote.

The loaders and the dump take the rest. A file beginning with a blank line loads the same whether it is written with commas, with tabs or in a workbook. A numeric XLSX cell loads the number the file stores rather than the number its format draws, and a REAL column stays REAL through an XLSX dump. A dump that an encoding cannot write names the column and the character, and an ISO-2022-JP dump refuses an escape. A builder given a path or a reader after a build passes it to the next one, and SkippedRows describes the load that just ran.

No public symbol changes. sqly builds and its tests pass against this tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQL dialect translation for string, date, interval, numeric, JSON, aggregate, and bitwise operations.
  - Added clearer handling for unsupported row-locking, table alteration, and ordered or limited data modification statements.
  - Improved file loading, including blank lines, encoding validation, spreadsheet numeric values, and numeric column types.
  - Resolved builder and auto-save reliability issues.

- **Documentation**
  - Published version 0.54.0 release notes.
  - Updated supported-version guidance to identify 0.54.x as the current supported release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->