### PR TITLE
test: pin the cancellation contract for every entry point

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -1861,7 +1861,7 @@ func expiredContext(t *testing.T) context.Context {
 
 // endedContext is one way a caller's context can be done, with the error it has
 // to produce. A load that answered the wrong one would tell a caller their
-// deadline passed when they had cancelled, or the reverse.
+// deadline passed when they had canceled, or the reverse.
 type endedContext struct {
 	name string
 	// make builds the context when the case runs, so a parallel subtest gets
@@ -1873,7 +1873,7 @@ type endedContext struct {
 // endedContexts is every way a caller's context can be done.
 func endedContexts() []endedContext {
 	return []endedContext{
-		{"cancelled", canceledContext, context.Canceled},
+		{"canceled", canceledContext, context.Canceled},
 		{"past a deadline", expiredContext, context.DeadlineExceeded},
 	}
 }
@@ -1893,7 +1893,7 @@ func builtBuilder(t *testing.T, path string) *DBBuilder {
 // answers the sentinel that says which way it ended. A load that ignored
 // cancellation would leave half the tables of an abandoned request behind, and
 // one that answered the wrong sentinel would tell a caller their deadline
-// passed when they had cancelled.
+// passed when they had canceled.
 //
 // The godoc names six entry points that take a context. The four that belong to
 // a builder are here; OpenContext is covered in filesql_test.go and

--- a/builder_test.go
+++ b/builder_test.go
@@ -1848,6 +1848,36 @@ func canceledContext(t *testing.T) context.Context {
 	return ctx
 }
 
+// expiredContext returns a context whose deadline has passed, which is the
+// other way a caller's context ends and the one that answers a different
+// sentinel.
+func expiredContext(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Millisecond))
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// endedContext is one way a caller's context can be done, with the error it has
+// to produce. A load that answered the wrong one would tell a caller their
+// deadline passed when they had cancelled, or the reverse.
+type endedContext struct {
+	name string
+	// make builds the context when the case runs, so a parallel subtest gets
+	// one of its own rather than sharing a value built here.
+	make func(*testing.T) context.Context
+	want error
+}
+
+// endedContexts is every way a caller's context can be done.
+func endedContexts() []endedContext {
+	return []endedContext{
+		{"cancelled", canceledContext, context.Canceled},
+		{"past a deadline", expiredContext, context.DeadlineExceeded},
+	}
+}
+
 // builtBuilder returns a builder that has collected path, which is the state a
 // load starts from.
 func builtBuilder(t *testing.T, path string) *DBBuilder {
@@ -1858,39 +1888,64 @@ func builtBuilder(t *testing.T, path string) *DBBuilder {
 	return builder
 }
 
-// TestBuilderEntryPoints_CanceledContext checks that each way of loading stops
-// on a context that is already done, before it opens files or writes tables. A
-// load that ignored cancellation would leave half the tables of an abandoned
-// request behind.
-func TestBuilderEntryPoints_CanceledContext(t *testing.T) {
+// TestBuilderEntryPoints_EndedContext checks that each way of loading stops on a
+// context that is already done, before it opens files or writes tables, and
+// answers the sentinel that says which way it ended. A load that ignored
+// cancellation would leave half the tables of an abandoned request behind, and
+// one that answered the wrong sentinel would tell a caller their deadline
+// passed when they had cancelled.
+//
+// The godoc names six entry points that take a context. The four that belong to
+// a builder are here; OpenContext is covered in filesql_test.go and
+// DumpDatabaseContext in dump_test.go, each beside the code it calls.
+func TestBuilderEntryPoints_EndedContext(t *testing.T) {
 	t.Parallel()
 
 	path := csvFixture(t)
 
-	t.Run("Open", func(t *testing.T) {
-		t.Parallel()
+	for _, tc := range endedContexts() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-		_, err := builtBuilder(t, path).Open(canceledContext(t))
-		assert.ErrorIs(t, err, context.Canceled)
-	})
+			t.Run("Open", func(t *testing.T) {
+				t.Parallel()
 
-	t.Run("LoadInto", func(t *testing.T) {
-		t.Parallel()
+				db, err := builtBuilder(t, path).Open(tc.make(t))
+				if db != nil {
+					_ = db.Close()
+				}
+				assert.ErrorIs(t, err, tc.want)
+			})
 
-		err := builtBuilder(t, path).LoadInto(canceledContext(t), openTestDB(t))
-		assert.ErrorIs(t, err, context.Canceled)
-	})
+			t.Run("OpenReadOnly", func(t *testing.T) {
+				t.Parallel()
 
-	t.Run("LoadIntoTx", func(t *testing.T) {
-		t.Parallel()
+				db, err := builtBuilder(t, path).OpenReadOnly(tc.make(t))
+				if db != nil {
+					_ = db.Close()
+				}
+				assert.ErrorIs(t, err, tc.want)
+			})
 
-		db := openTestDB(t)
-		tx, err := db.BeginTx(context.Background(), nil)
-		require.NoError(t, err)
-		defer func() { _ = tx.Rollback() }()
+			t.Run("LoadInto", func(t *testing.T) {
+				t.Parallel()
 
-		assert.ErrorIs(t, builtBuilder(t, path).LoadIntoTx(canceledContext(t), tx), context.Canceled)
-	})
+				err := builtBuilder(t, path).LoadInto(tc.make(t), openTestDB(t))
+				assert.ErrorIs(t, err, tc.want)
+			})
+
+			t.Run("LoadIntoTx", func(t *testing.T) {
+				t.Parallel()
+
+				db := openTestDB(t)
+				tx, err := db.BeginTx(context.Background(), nil)
+				require.NoError(t, err)
+				defer func() { _ = tx.Rollback() }()
+
+				assert.ErrorIs(t, builtBuilder(t, path).LoadIntoTx(tc.make(t), tx), tc.want)
+			})
+		})
+	}
 }
 
 // TestLoadIntoTx_Refusals covers what LoadIntoTx cannot do. The caller owns the

--- a/dump_test.go
+++ b/dump_test.go
@@ -2726,3 +2726,24 @@ func TestAnIdentifierSurvivesADumpAndLoad(t *testing.T) {
 		})
 	}
 }
+
+// TestDumpDatabaseContext_EndedContext is the dump's share of the contract the
+// godoc states for every entry point that takes a context. DumpDatabase is the
+// same call with a background context, so it has nothing to stop for.
+func TestDumpDatabaseContext_EndedContext(t *testing.T) {
+	t.Parallel()
+
+	db, err := Open(csvFixture(t))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	for _, tc := range endedContexts() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			out := t.TempDir()
+			assert.ErrorIs(t, DumpDatabaseContext(tc.make(t), db, out), tc.want)
+			assert.Empty(t, dirEntries(t, out), "a dump that stopped must leave nothing behind")
+		})
+	}
+}

--- a/filesql_test.go
+++ b/filesql_test.go
@@ -4359,3 +4359,25 @@ func TestAHeaderOfEmptyCellsIsStillAHeader(t *testing.T) {
 		}
 	}
 }
+
+// TestOpenContext_EndedContext is OpenContext's share of the contract the
+// godoc states for every entry point that takes a context: the load stops and
+// the error says which way the context ended. Open is the same call with a
+// background context, so it has nothing to stop for.
+func TestOpenContext_EndedContext(t *testing.T) {
+	t.Parallel()
+
+	path := csvFixture(t)
+
+	for _, tc := range endedContexts() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, err := OpenContext(tc.make(t), path)
+			if db != nil {
+				_ = db.Close()
+			}
+			assert.ErrorIs(t, err, tc.want)
+		})
+	}
+}

--- a/filesql_test.go
+++ b/filesql_test.go
@@ -1187,7 +1187,7 @@ func TestOpenContext(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Context already cancelled",
+			name: "Context already canceled",
 			setupCtx: func() (context.Context, context.CancelFunc) {
 				ctx, cancel := context.WithCancel(t.Context())
 				cancel() // Cancel immediately

--- a/load_into_test.go
+++ b/load_into_test.go
@@ -728,7 +728,7 @@ func TestLoadIntoTx_CanceledContextTheTransactionWasBuiltOn(t *testing.T) {
 	builder, err := buildForTest(context.Background(), NewBuilder().AddPath(path).SetDefaultChunkSize(100))
 	require.NoError(t, err)
 
-	// The context is cancelled after the transaction has begun rather than by a
+	// The context is canceled after the transaction has begun rather than by a
 	// deadline set before it: a deadline short enough to land inside the load
 	// can expire during BeginTx itself on a slow machine, where the driver
 	// reports an interrupted connection and the test fails at its setup.
@@ -745,7 +745,7 @@ func TestLoadIntoTx_CanceledContextTheTransactionWasBuiltOn(t *testing.T) {
 
 	// Ending the transaction here rather than in a defer frees the one pooled
 	// connection the listing below needs. What Rollback reports is the driver's
-	// business: a cancelled context may have ended the transaction already, or
+	// business: a canceled context may have ended the transaction already, or
 	// interrupted the connection it was on.
 	if err := tx.Rollback(); err != nil {
 		t.Logf("rollback after the canceled load: %v", err)


### PR DESCRIPTION
A session that found no defects. Three surfaces were measured against what the godoc says about them and all three held, so the deliverable is the one gap that measuring exposed: the contract that held was only half covered by tests.

## The cancellation contract, pinned for every entry point

doc.go names six calls that take a context -- `OpenContext`, `DBBuilder.Open`, `DBBuilder.OpenReadOnly`, `LoadInto`, `LoadIntoTx` and `DumpDatabaseContext` -- and says a load stops soon after its context ends and that "whatever the database said on the way out, the error it returns matches context.Canceled or context.DeadlineExceeded". Driving all six in both states shows the contract holds in all fourteen cells. The test that guarded it covered three of the six, and only for a cancelled context: `OpenReadOnly`, `OpenContext`, `DumpDatabaseContext` and the whole deadline half were unguarded.

All six are covered now, each beside the code it calls: the four builder methods in `builder_test.go`, `OpenContext` in `filesql_test.go`, `DumpDatabaseContext` in `dump_test.go`. The dump case also asserts the output directory is empty, since a dump that stopped must leave nothing behind. The two ways a context ends live in one table so a seventh entry point cannot be added without an answer for both.

No behavior changed and no source file was touched.

## What was measured and came back clean

The cancellation sentinel, seven entry points by two states, fourteen for fourteen: an already-cancelled context always gives `context.Canceled` and an expired deadline always gives `context.DeadlineExceeded`, including through a reader rather than a path.

How soon "soon" is, per format, at two file sizes. CSV, JSONL and a JSON array return within a millisecond of the deadline at both 400,000 and 1,200,000 rows, which is what a chunked format should do. LTSV and a JSON document that is not an array lag, and the lag grows with the file -- 54ms to 175ms for LTSV, 61ms to 189ms for the document -- which is what the "Memory and Streaming" section already predicts for a format read in full before it is turned into rows. Both still stop well before the load would have finished, so nothing here contradicts the documentation; the classification and the cancellation section agree with each other and with the measurements.

Parquet, whose entry says a file named by path is read where it lies while a reader passed to `AddReader` is buffered whole. Both paths return exactly at the deadline on a 23 MB file, so the buffering does not cost the caller their cancellation.

The retry budget. `LoadInto` against a held write lock gave up after 5.1 seconds with the database's own error, matching the five seconds of waiting the godoc promises, and a caller's two-second deadline won over it and answered `context.DeadlineExceeded`. The "half a minute in all" beside it is the separate wall-clock cap on retrying an expensive input, which a small CSV never reaches; the two numbers are not in conflict.

## Verification

`make test`, `make lint` and `go vet` pass, and the packages cross-compile for windows/amd64 and darwin/arm64. sqly builds and its tests pass against this checkout with a local replace, which was then dropped. No CHANGELOG entry: nothing user-visible changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of canceled or expired operations across database opening, loading, and dumping workflows.
  * Operations now consistently return the underlying context termination error and avoid producing partial output.

* **Tests**
  * Added coverage for canceled and deadline-exceeded contexts across supported entry points and data-loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->