### PR TITLE
chore(release): v0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.55.0] - 2026-09-02
 
 ### Changed
 
@@ -2276,6 +2276,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
+[0.55.0]: https://github.com/nao1215/filesql/compare/v0.54.0...v0.55.0
 [0.54.0]: https://github.com/nao1215/filesql/compare/v0.53.0...v0.54.0
 [0.53.0]: https://github.com/nao1215/filesql/compare/v0.52.0...v0.53.0
 [0.52.0]: https://github.com/nao1215/filesql/compare/v0.51.0...v0.52.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,8 @@ Security fixes are provided for the latest published release series only.
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| `0.54.x` | Yes | Current published release series as of September 1, 2026 |
-| `0.53.x` and earlier | No | Upgrade to the latest `0.54.x` release |
+| `0.55.x` | Yes | Current published release series as of September 2, 2026 |
+| `0.54.x` and earlier | No | Upgrade to the latest `0.55.x` release |
 
 Security fixes are not backported to unsupported release series. When the next
 series is published, support moves to it.


### PR DESCRIPTION
## Summary

Releases everything in Unreleased since v0.54.0: the dialect fixes from the boolean, byte-string, hexadecimal, bit-string, JSON, cast and aggregate sweeps, the loader and save fixes, the parser package moving under internal, `Open` and `DumpDatabase` taking a context, the compression surface moving onto `CompressionType`, and the compatibility statement in CONTRIBUTING.md and the dialect package.

It is a minor bump because the version is 0.x and the release carries breaking changes; each of them has a migration note in the Breaking Changes section. `SECURITY.md` moves support to `0.55.x`.

## Downstream

sqly needs a few lines for `Open`, `DumpDatabase`, `NewCompressionHandler` and `NewCompressionFactory`, verified in a scratchpad clone against this branch with a replace directive; its unit tests, smoke tests and atago E2E are green there. The sqly release PR follows the tag.