### PR TITLE
test(prep): hold the two entry points to one answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Two tests over `prep` that had no counterpart: `Process` and `ProcessToWriter` are two ways to ask the same question, so they are now held to one answer -- the same bytes, the same decoded records and the same counts, over eight inputs and each option -- and what one pass writes is read back through a second pass, which is where a format that loses a character to its own output would show. Both pass as they stand; the value is that a rule implemented twice can no longer drift in silence. The JSON cases carry the things there are to lose: a newline, a tab, a nested object, a key outside ASCII.
+
 - Godoc examples for the five exported names that had none: `CompressionType.NewReader`, `WithCompression`, `ParseError`, `ExcelSheetPolicy.String`, and a `CompressionType.NewWriter` that shows what closing the writer does rather than reading the bytes back through the reader's example. The `ParseError` one is the interesting one: it loads two files, one of them broken, and shows that the error names which file failed and that the cause is still reachable with `errors.Is`.
 
 ### Changed

--- a/prep/errors.go
+++ b/prep/errors.go
@@ -7,7 +7,8 @@ import (
 	"github.com/nao1215/filesql/internal/parser"
 )
 
-// Sentinel errors for fileprep
+// Sentinel errors this package returns. Each is matched with errors.Is; the
+// message a caller sees names the input as well.
 var (
 	// ErrStructSlicePointer is returned when the value is not a pointer to a struct slice
 	ErrStructSlicePointer = errors.New("value must be a pointer to a struct slice")

--- a/prep/example_test.go
+++ b/prep/example_test.go
@@ -275,7 +275,7 @@ func Example_jsonProcessing() {
 	// {"name":"Bob","age":25}
 }
 
-// Example_employeePreprocessing demonstrates the full power of fileprep:
+// Example_employeePreprocessing demonstrates what prep does in one pass:
 // combining multiple preprocessors and validators to clean and validate real-world messy data.
 func Example_employeePreprocessing() {
 	// Employee represents employee data with comprehensive preprocessing and validation

--- a/prep/processor_test.go
+++ b/prep/processor_test.go
@@ -3444,35 +3444,73 @@ func TestTheTwoEntryPointsAgree(t *testing.T) {
 				same("OutputFormat", readerResult.OutputFormat, writerResult.OutputFormat)
 				same("HasErrors", readerResult.HasErrors(), writerResult.HasErrors())
 				same("InvalidRowCount", readerResult.InvalidRowCount(), writerResult.InvalidRowCount())
-				same("len(Errors)", len(readerResult.Errors), len(writerResult.Errors))
-				same("len(ValidationErrors)", len(readerResult.ValidationErrors()), len(writerResult.ValidationErrors()))
-				same("len(PrepErrors)", len(readerResult.PrepErrors()), len(writerResult.PrepErrors()))
+				// The errors themselves, in order, rather than how many there
+				// are: two paths that report the same number of different
+				// errors have drifted, and that is what a caller reads.
+				same("Errors", messages(readerResult.Errors), messages(writerResult.Errors))
+				same("ValidationErrors", validationMessages(readerResult.ValidationErrors()), validationMessages(writerResult.ValidationErrors()))
+				same("PrepErrors", prepMessages(readerResult.PrepErrors()), prepMessages(writerResult.PrepErrors()))
 			})
 		}
 	}
+}
+
+// messages renders errors as the caller reads them, so two paths that report
+// the same number of different errors are not mistaken for agreeing.
+func messages(errs []error) []string {
+	out := make([]string, 0, len(errs))
+	for _, err := range errs {
+		out = append(out, err.Error())
+	}
+	return out
+}
+
+func validationMessages(errs []*ValidationError) []string {
+	out := make([]string, 0, len(errs))
+	for _, err := range errs {
+		out = append(out, fmt.Sprintf("row %d %s: %s", err.Row, err.Column, err.Error()))
+	}
+	return out
+}
+
+func prepMessages(errs []*PrepError) []string {
+	out := make([]string, 0, len(errs))
+	for _, err := range errs {
+		out = append(out, err.Error())
+	}
+	return out
 }
 
 type agreeingJSON struct {
 	Data string `name:"data"`
 }
 
-// agreeingJSONRoundTrip is the same round trip for the two formats prep flattens
-// into a single "data" column.
-func TestProbeJSONRoundTrip(t *testing.T) {
+// TestProcessOutputReadsBackThroughProcess is the other half of that: what one
+// pass writes is what a second pass reads. CSV, TSV and LTSV keep their format
+// and JSON becomes JSONL, so each case names the format it expects and that is
+// what the second pass is told -- reading back with the OutputFormat the first
+// pass reported would let a change to both go unnoticed.
+//
+// The JSON cases are the ones with something to lose, since prep carries a JSON
+// row as one raw string in a single column: a newline, a tab, a nested object,
+// a key outside ASCII.
+func TestProcessOutputReadsBackThroughProcess(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		ft   FileType
+		out  FileType
 		in   string
 	}{
-		{name: "csv", ft: FileTypeCSV, in: "data\nplain\n"},
-		{name: "tsv", ft: FileTypeTSV, in: "data\nplain\n"},
-		{name: "ltsv", ft: FileTypeLTSV, in: "data:plain\n"},
-		{name: "json", ft: FileTypeJSON, in: `[{"id":1,"name":"alice"},{"id":2,"name":"bob"}]`},
-		{name: "jsonl", ft: FileTypeJSONL, in: `{"id":1,"name":"alice"}` + "\n" + `{"id":2,"name":"bob"}` + "\n"},
-		{name: "json holding a string with a newline", ft: FileTypeJSON, in: `[{"a":"one\ntwo"}]`},
-		{name: "json holding a nested object", ft: FileTypeJSON, in: `[{"a":{"b":[1,2]}}]`},
-		{name: "json holding non-ascii", ft: FileTypeJSON, in: `[{"名前":"アリス"}]`},
-		{name: "json holding a tab", ft: FileTypeJSON, in: `[{"a":"one\ttwo"}]`},
+		// Two columns, so output that is really CSV cannot read back as TSV.
+		{name: "csv", ft: FileTypeCSV, out: FileTypeCSV, in: "data,other\nplain,second\n"},
+		{name: "tsv", ft: FileTypeTSV, out: FileTypeTSV, in: "data\tother\nplain\tsecond\n"},
+		{name: "ltsv", ft: FileTypeLTSV, out: FileTypeLTSV, in: "data:plain\tother:second\n"},
+		{name: "json", ft: FileTypeJSON, out: FileTypeJSONL, in: `[{"id":1,"name":"alice"},{"id":2,"name":"bob"}]`},
+		{name: "jsonl", ft: FileTypeJSONL, out: FileTypeJSONL, in: `{"id":1,"name":"alice"}` + "\n" + `{"id":2,"name":"bob"}` + "\n"},
+		{name: "json holding a string with a newline", ft: FileTypeJSON, out: FileTypeJSONL, in: `[{"a":"one\ntwo"}]`},
+		{name: "json holding a nested object", ft: FileTypeJSON, out: FileTypeJSONL, in: `[{"a":{"b":[1,2]}}]`},
+		{name: "json holding non-ascii", ft: FileTypeJSON, out: FileTypeJSONL, in: `[{"名前":"アリス"}]`},
+		{name: "json holding a tab", ft: FileTypeJSON, out: FileTypeJSONL, in: `[{"a":"one\ttwo"}]`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var first []agreeingJSON
@@ -3480,15 +3518,18 @@ func TestProbeJSONRoundTrip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("first pass: %v", err)
 			}
+			if result.OutputFormat != tc.out {
+				t.Fatalf("OutputFormat = %v, want %v", result.OutputFormat, tc.out)
+			}
 			body, err := io.ReadAll(reader)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			var second []agreeingJSON
-			_, again, err := NewProcessor(result.OutputFormat).Process(bytes.NewReader(body), &second)
+			_, again, err := NewProcessor(tc.out).Process(bytes.NewReader(body), &second)
 			if err != nil {
-				t.Fatalf("reading prep's own %v output: %v (output was %q)", result.OutputFormat, err, body)
+				t.Fatalf("reading prep's own %v output: %v (output was %q)", tc.out, err, body)
 			}
 			if fmt.Sprint(first) != fmt.Sprint(second) {
 				t.Errorf("first pass decoded %v, second decoded %v (output was %q)", first, second, body)

--- a/prep/processor_test.go
+++ b/prep/processor_test.go
@@ -3362,3 +3362,140 @@ func TestDocDescribesTheFormatsProcessorTakes(t *testing.T) {
 		t.Error("doc.go must state the record bound that is enforced")
 	}
 }
+
+type agreeingUser struct {
+	ID   int    `csv:"id" validate:"required,min=1"`
+	Name string `csv:"name" prep:"trim" validate:"required"`
+	Mail string `csv:"mail" validate:"omitempty,email"`
+}
+
+// TestTheTwoEntryPointsAgree holds Process and ProcessToWriter to one answer.
+// They are two ways to ask the same question -- one hands back a reader over
+// the processed bytes, the other writes them where the caller says -- so a rule
+// implemented twice is a rule that can drift, and what would drift silently is
+// the count a caller reports and the rows a second pass reads.
+func TestTheTwoEntryPointsAgree(t *testing.T) {
+	inputs := []struct {
+		name  string
+		ft    FileType
+		input string
+	}{
+		{name: "csv", ft: FileTypeCSV, input: "id,name,mail\n1, alice ,a@example.com\n2,bob,not-an-email\n0,,c@example.com\n"},
+		{name: "csv with only valid rows", ft: FileTypeCSV, input: "id,name,mail\n1,alice,a@example.com\n"},
+		{name: "csv with only invalid rows", ft: FileTypeCSV, input: "id,name,mail\n0,,x\n"},
+		{name: "csv with no data rows", ft: FileTypeCSV, input: "id,name,mail\n"},
+		{name: "tsv", ft: FileTypeTSV, input: "id\tname\tmail\n1\talice\ta@example.com\n"},
+		{name: "ltsv", ft: FileTypeLTSV, input: "id:1\tname:alice\tmail:a@example.com\n"},
+		{name: "json", ft: FileTypeJSON, input: `[{"id":1,"name":"alice","mail":"a@example.com"}]`},
+		{name: "jsonl", ft: FileTypeJSONL, input: `{"id":1,"name":"alice","mail":"a@example.com"}` + "\n"},
+	}
+
+	for _, in := range inputs {
+		for _, opts := range []struct {
+			name string
+			opts []Option
+		}{
+			{name: "default"},
+			{name: "valid rows only", opts: []Option{WithValidRowsOnly()}},
+			{name: "strict tags", opts: []Option{WithStrictTagParsing()}},
+		} {
+			t.Run(in.name+"/"+opts.name, func(t *testing.T) {
+				var readerRecords, writerRecords []agreeingUser
+
+				reader, readerResult, readerErr := NewProcessor(in.ft, opts.opts...).
+					Process(strings.NewReader(in.input), &readerRecords)
+
+				var buf bytes.Buffer
+				writerResult, writerErr := NewProcessor(in.ft, opts.opts...).
+					ProcessToWriter(strings.NewReader(in.input), &writerRecords, &buf)
+
+				if (readerErr == nil) != (writerErr == nil) {
+					t.Fatalf("Process err = %v, ProcessToWriter err = %v", readerErr, writerErr)
+				}
+				if readerErr != nil {
+					if readerErr.Error() != writerErr.Error() {
+						t.Errorf("Process err = %q, ProcessToWriter err = %q", readerErr, writerErr)
+					}
+					return
+				}
+
+				body, err := io.ReadAll(reader)
+				if err != nil {
+					t.Fatalf("reading what Process returned: %v", err)
+				}
+				if string(body) != buf.String() {
+					t.Errorf("Process wrote %q, ProcessToWriter wrote %q", body, buf.String())
+				}
+
+				if fmt.Sprint(readerRecords) != fmt.Sprint(writerRecords) {
+					t.Errorf("Process decoded %v, ProcessToWriter decoded %v", readerRecords, writerRecords)
+				}
+
+				same := func(name string, a, b any) {
+					t.Helper()
+					if fmt.Sprint(a) != fmt.Sprint(b) {
+						t.Errorf("%s: Process = %v, ProcessToWriter = %v", name, a, b)
+					}
+				}
+				same("RowCount", readerResult.RowCount, writerResult.RowCount)
+				same("ValidRowCount", readerResult.ValidRowCount, writerResult.ValidRowCount)
+				same("Columns", readerResult.Columns, writerResult.Columns)
+				same("OriginalFormat", readerResult.OriginalFormat, writerResult.OriginalFormat)
+				same("OutputFormat", readerResult.OutputFormat, writerResult.OutputFormat)
+				same("HasErrors", readerResult.HasErrors(), writerResult.HasErrors())
+				same("InvalidRowCount", readerResult.InvalidRowCount(), writerResult.InvalidRowCount())
+				same("len(Errors)", len(readerResult.Errors), len(writerResult.Errors))
+				same("len(ValidationErrors)", len(readerResult.ValidationErrors()), len(writerResult.ValidationErrors()))
+				same("len(PrepErrors)", len(readerResult.PrepErrors()), len(writerResult.PrepErrors()))
+			})
+		}
+	}
+}
+
+type agreeingJSON struct {
+	Data string `name:"data"`
+}
+
+// agreeingJSONRoundTrip is the same round trip for the two formats prep flattens
+// into a single "data" column.
+func TestProbeJSONRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ft   FileType
+		in   string
+	}{
+		{name: "csv", ft: FileTypeCSV, in: "data\nplain\n"},
+		{name: "tsv", ft: FileTypeTSV, in: "data\nplain\n"},
+		{name: "ltsv", ft: FileTypeLTSV, in: "data:plain\n"},
+		{name: "json", ft: FileTypeJSON, in: `[{"id":1,"name":"alice"},{"id":2,"name":"bob"}]`},
+		{name: "jsonl", ft: FileTypeJSONL, in: `{"id":1,"name":"alice"}` + "\n" + `{"id":2,"name":"bob"}` + "\n"},
+		{name: "json holding a string with a newline", ft: FileTypeJSON, in: `[{"a":"one\ntwo"}]`},
+		{name: "json holding a nested object", ft: FileTypeJSON, in: `[{"a":{"b":[1,2]}}]`},
+		{name: "json holding non-ascii", ft: FileTypeJSON, in: `[{"名前":"アリス"}]`},
+		{name: "json holding a tab", ft: FileTypeJSON, in: `[{"a":"one\ttwo"}]`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var first []agreeingJSON
+			reader, result, err := NewProcessor(tc.ft).Process(strings.NewReader(tc.in), &first)
+			if err != nil {
+				t.Fatalf("first pass: %v", err)
+			}
+			body, err := io.ReadAll(reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var second []agreeingJSON
+			_, again, err := NewProcessor(result.OutputFormat).Process(bytes.NewReader(body), &second)
+			if err != nil {
+				t.Fatalf("reading prep's own %v output: %v (output was %q)", result.OutputFormat, err, body)
+			}
+			if fmt.Sprint(first) != fmt.Sprint(second) {
+				t.Errorf("first pass decoded %v, second decoded %v (output was %q)", first, second, body)
+			}
+			if again.RowCount != result.RowCount {
+				t.Errorf("RowCount %d then %d", result.RowCount, again.RowCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`Process` and `ProcessToWriter` are two ways to ask `prep` the same question -- one hands back a reader over the processed bytes, the other writes them where the caller says -- and nothing held them equal. What would drift in silence is the count a caller reports and the rows a second pass reads.

The other half of the same invariant: what one pass writes is what a second pass reads. CSV, TSV and LTSV keep their format and JSON becomes JSONL, so the second pass is told the `OutputFormat` the first reported and has to get the same rows back. The JSON cases carry what there is to lose, since prep holds a JSON row as one raw string in a single column: a newline, a tab, a nested object, a key outside ASCII.

Both tests pass as they stand -- this is a negative result made permanent. They are here because a rule with two implementations is the one that drifts, which is where several of this package's past bugs came from.

## Verification

- `make test` green, coverage 92.7%
- `make lint` 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring both processing entry points produce consistent output, decoded records, errors, and metadata across supported formats and options.
  * Added round-trip coverage for reading processor output again, including JSON and JSONL data with special characters, nested values, and non-ASCII text.
* **Documentation**
  * Updated the unreleased changelog with the new test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->