### PR TITLE
chore(release): v0.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.56.0] - 2026-09-02
 
 ### Fixed
 
@@ -2307,6 +2307,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
+[0.56.0]: https://github.com/nao1215/filesql/compare/v0.55.0...v0.56.0
 [0.55.0]: https://github.com/nao1215/filesql/compare/v0.54.0...v0.55.0
 [0.54.0]: https://github.com/nao1215/filesql/compare/v0.53.0...v0.54.0
 [0.53.0]: https://github.com/nao1215/filesql/compare/v0.52.0...v0.53.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,8 @@ Security fixes are provided for the latest published release series only.
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| `0.55.x` | Yes | Current published release series as of September 2, 2026 |
-| `0.54.x` and earlier | No | Upgrade to the latest `0.55.x` release |
+| `0.56.x` | Yes | Current published release series as of September 2, 2026 |
+| `0.55.x` and earlier | No | Upgrade to the latest `0.56.x` release |
 
 Security fixes are not backported to unsupported release series. When the next
 series is published, support moves to it.


### PR DESCRIPTION
## Summary

Releases eleven entries, of which one is the reason not to wait: **a bare `CURRENT_TIMESTAMP` answered the string `"CURRENT_TIMESTAMP"`** under every dialect but `sqlite`, and `CURRENT_DATE` and `CURRENT_TIME` answered theirs, with nothing to report it. A query stamping rows with the current time wrote the same eleven characters into every row (#1044).

With it: MySQL's `UTC_TIMESTAMP`, `UTC_DATE`, `UTC_TIME` and `SYSDATE` now answer the clock rather than reaching a SQLite that has no function by those names; `BINARY(x)` casts as `BINARY x` already did; a clock keyword given a fractional-seconds precision, and `POSITION` or `CONVERT` given the wrong number of arguments, are refused with what they take; and 150 MySQL names and 571 PostgreSQL names are refused by name with the reason their family gives instead of failing as names SQLite does not have.

The refusal tables are no longer swept by hand: `dialect/testdata` holds what MySQL's help tables and PostgreSQL's `pg_proc` say each engine defines, and a test requires that every one of those names is translated or refused here.

No breaking changes. Minor because that is what this repository's 0.x releases use.

## Downstream

sqly follows in its own release; nothing in its code has to change.