### PR TITLE
chore(release): v0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.57.0] - 2026-09-03
 
 ### Fixed
 
@@ -2395,6 +2395,7 @@ For users upgrading from v0.3.x:
 - Multi-language documentation (7 languages)
 - Standard database/sql interface implementation
 
+[0.57.0]: https://github.com/nao1215/filesql/compare/v0.56.0...v0.57.0
 [0.56.0]: https://github.com/nao1215/filesql/compare/v0.55.0...v0.56.0
 [0.55.0]: https://github.com/nao1215/filesql/compare/v0.54.0...v0.55.0
 [0.54.0]: https://github.com/nao1215/filesql/compare/v0.53.0...v0.54.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,8 @@ Security fixes are provided for the latest published release series only.
 
 | Version | Supported | Notes |
 |---------|-----------|-------|
-| `0.56.x` | Yes | Current published release series as of September 2, 2026 |
-| `0.55.x` and earlier | No | Upgrade to the latest `0.56.x` release |
+| `0.57.x` | Yes | Current published release series as of September 3, 2026 |
+| `0.56.x` and earlier | No | Upgrade to the latest `0.57.x` release |
 
 Security fixes are not backported to unsupported release series. When the next
 series is published, support moves to it.


### PR DESCRIPTION
v0.57.0 gathers two sessions of fixes: forty-one entries, thirty of them behaviour and eleven documentation. Everything an engine's name appears in was measured against that engine -- MySQL 8.4 and PostgreSQL 17 in containers -- rather than recalled.

The one to read first is the double-quoted name. SQLite reads a quoted name that matches no column as a string literal, and this package quotes names throughout, so `SELECT "namee" FROM t` answered the text `namee` for every row and `SELECT * FROM t WHERE "namee" = 'ada'` compared that text and quietly returned nothing. The database this package opens now carries `_dqs=false`; a database the caller opened themselves and handed to `LoadInto` keeps whatever setting they chose.

Two more that change what a query answers. A column that is neither grouped nor aggregated is refused, as both engines refuse it, where SQLite had answered one row of each group chosen arbitrarily. And a transaction opened by a statement that is not the first in a query is now counted, so `db.Exec("BEGIN; UPDATE ...; COMMIT")` saves at the commit and no longer lets an auto-save discard the work with `Close` reporting success.

The dialect gained a fuzz target that holds every successful translation to SQL SQLite can compile, which found nine spellings that translated into text SQLite could not parse. Beside it: the upsert MySQL callers write (`ON DUPLICATE KEY UPDATE b = VALUES(b)`) now translates, PostgreSQL raises where a mathematical function leaves its domain or a result leaves the range of a double, and each engine's reserved words are refused where a value goes, per dialect and measured from the engine.

On the loading side, a number whose format draws nothing loads as the number wherever it sits, a sheet spelled the way a writer other than Excel spells it holds its rows, a workbook whose main part is not at the usual path is read the same way, and a sheet holding a tag longer than the row scan's buffer no longer panics. `prep` answers malformed input with the sentinels a load answers with.

The documentation entries are the ones a compiler does not read: twelve code snippets in godoc that no longer matched their signatures, a README table linking to sections that had been renamed, and the nightly fuzz workflow, which had been naming a package that moved two releases ago and running two of its targets not at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Started the 0.57.0 release section dated September 3, 2026.
  - Added a comparison link for version 0.57.0.
  - Updated the security policy to identify 0.57.x as the supported release series.
  - Clarified that 0.56.x and earlier versions are unsupported and should be upgraded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->